### PR TITLE
Decouple albums from website (eliminate symlink)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ memory/
 
 # photogen output
 /albums
+
+# per-site static builds (npm run build output)
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@ memory/
 # Python virtualenv
 .venv/
 
-# photogen output (generated; use 'make use-sample' or 'make use-prod' to symlink)
-web/static/albums
-web/albums/
+# photogen output
+albums

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ memory/
 .venv/
 
 # photogen output
-albums
+/albums

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 SITE_ENV ?= config/site.env
 override SITE_ENV := $(abspath $(patsubst ~/%,$(HOME)/%,$(SITE_ENV)))
 
+# Albums directory and site ID — defaults loaded from config/defaults.env.
+# Override on the command line, e.g.: make sample-build DDPHOTOS_SITE_ID=sample-css
+include config/defaults.env
+override DDPHOTOS_ALBUMS_DIR := $(abspath $(patsubst ~/%,$(HOME)/%,$(DDPHOTOS_ALBUMS_DIR)))
+
 # nvm/Node.js initialization:
 # - NVM_INIT always sources nvm.sh (nvm is a shell function, not a binary, so Make's subshell
 #   never has it). NVM_SH is derived from NVM_DIR if set (e.g. Homebrew install), else ~/.nvm.
@@ -67,12 +72,12 @@ web-playwright-install:
 .PHONY: web-npm-run-dev
 ## web-npm-run-dev: run npm dev server in web, opening a browser window to the site
 web-npm-run-dev:
-	$(NODE_INIT) cd web && SITE_ENV=$(abspath $(SITE_ENV)) npm run dev -- --open
+	$(NODE_INIT) cd web && SITE_ENV=$(SITE_ENV) DDPHOTOS_ALBUMS_DIR=$(DDPHOTOS_ALBUMS_DIR) DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) npm run dev -- --open
 
 .PHONY: web-npm-build
 ## web-npm-build: build web app
 web-npm-build:
-	$(NODE_INIT) cd web && SITE_ENV=$(abspath $(SITE_ENV)) npm run build
+	$(NODE_INIT) cd web && SITE_ENV=$(SITE_ENV) DDPHOTOS_ALBUMS_DIR=$(DDPHOTOS_ALBUMS_DIR) DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) npm run build
 
 .PHONY: web-docker-build
 ## web-docker-build: build the photos Apache Docker image
@@ -82,7 +87,11 @@ web-docker-build:
 .PHONY: web-docker-run
 ## web-docker-run: run the photos Apache Docker container on port 8080 (mount web/build as document root)
 web-docker-run:
-	docker run --rm -p 8080:80 -v $(PWD)/web:/usr/local/apache2/htdocs:ro photos-apache
+	mkdir -p web/build/albums
+	docker run --rm -p 8080:80 \
+		-v $(PWD)/web:/usr/local/apache2/htdocs:ro \
+		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/usr/local/apache2/htdocs/build/albums:ro \
+		photos-apache
 
 .PHONY: web-docker-stop
 ## web-docker-stop: stop the running photos Apache Docker container

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
+# Migration check: album data moved from web/albums/ to albums/ in the decouple refactor.
+ifneq ($(wildcard web/albums),)
+$(warning MIGRATION REQUIRED: web/albums/ exists but album data now lives in albums/ )
+$(warning run: 'mv web/albums albums')
+$(error ERROR)
+endif
+
 # Path to site.env - override if your config lives elsewhere, e.g.:
 #   make web-npm-run-dev SITE_ENV=~/work/my-photos/config/site.env
 SITE_ENV ?= config/site.env
 override SITE_ENV := $(abspath $(patsubst ~/%,$(HOME)/%,$(SITE_ENV)))
 
-# Albums directory and site ID — defaults loaded from config/defaults.env.
+# Albums directory and site ID — defaults read from config/defaults.env.
+# ?= means env vars and command-line assignments take precedence over the file defaults.
 # Override on the command line, e.g.: make sample-build DDPHOTOS_SITE_ID=sample-css
-include config/defaults.env
+DDPHOTOS_ALBUMS_DIR ?= $(shell sed -n 's/^DDPHOTOS_ALBUMS_DIR=//p' config/defaults.env)
+DDPHOTOS_SITE_ID    ?= $(shell sed -n 's/^DDPHOTOS_SITE_ID=//p' config/defaults.env)
 override DDPHOTOS_ALBUMS_DIR := $(abspath $(patsubst ~/%,$(HOME)/%,$(DDPHOTOS_ALBUMS_DIR)))
 
 # nvm/Node.js initialization:
@@ -87,10 +96,9 @@ web-docker-build:
 .PHONY: web-docker-run
 ## web-docker-run: run the photos Apache Docker container on port 8080 (mount web/build as document root)
 web-docker-run:
-	mkdir -p web/build/albums
 	docker run --rm -p 8080:80 \
-		-v $(PWD)/web:/usr/local/apache2/htdocs:ro \
-		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/usr/local/apache2/htdocs/build/albums:ro \
+		-v $(PWD)/web:/usr/local/apache2/htdocs \
+		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
 		photos-apache
 
 .PHONY: web-docker-stop
@@ -125,26 +133,6 @@ web-screenshots:
 	$(NODE_INIT) cd web && node scripts/screenshots.mjs --album antarctica --photo 4
 	.venv/bin/python3 bin/generate-screenshot-composite.py
 
-.PHONY: use-sample
-## use-sample: symlink web/static/albums -> ../albums/sample (web/albums/sample/)
-use-sample:
-	ln -sfn ../albums/sample web/static/albums
-
-.PHONY: use-sample-pw-all
-## use-sample-pw-all: symlink web/static/albums -> ../albums/sample-pw-all
-use-sample-pw-all:
-	ln -sfn ../albums/sample-pw-all web/static/albums
-
-.PHONY: use-sample-pw-uganda
-## use-sample-pw-uganda: symlink web/static/albums -> ../albums/sample-pw-uganda
-use-sample-pw-uganda:
-	ln -sfn ../albums/sample-pw-uganda web/static/albums
-
-.PHONY: use-prod
-## use-prod: symlink web/static/albums -> ../albums/prod (web/albums/prod/)
-use-prod:
-	ln -sfn ../albums/prod web/static/albums
-
 .PHONY: sample-photogen
 ## sample-photogen: run photogen using sample images
 sample-photogen:
@@ -165,29 +153,19 @@ sample-photogen-pw-uganda:
 sample-photogen-css:
 	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -css sample/config/custom.css -site-id sample-css -doit
 
-.PHONY: use-sample-css
-## use-sample-css: symlink web/static/albums -> ../albums/sample-css
-use-sample-css:
-	ln -sfn ../albums/sample-css web/static/albums
-
 .PHONY: sample-photogen-demo
 ## sample-photogen-demo: run photogen using sample images with custom CSS and all albums password-protected
 sample-photogen-demo:
 	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -css sample/config/custom.css -passwords sample/config/passwords-all.yaml -site-id sample-demo -doit
 
-.PHONY: use-sample-demo
-## use-sample-demo: symlink web/static/albums -> ../albums/sample-demo
-use-sample-demo:
-	ln -sfn ../albums/sample-demo web/static/albums
-
 .PHONY: sample-demo
 ## sample-demo: one-step demo with custom CSS + password protection — photogens and runs dev server
-sample-demo: sample-photogen-demo use-sample-demo
-	SITE_ENV=sample/config/site.env $(MAKE) web-npm-run-dev
+sample-demo: sample-photogen-demo
+	SITE_ENV=sample/config/site.env DDPHOTOS_SITE_ID=sample-demo $(MAKE) web-npm-run-dev
 
 .PHONY: sample-build
 ## sample-build: build web app using sample config
-sample-build: use-sample
+sample-build:
 	SITE_ENV=sample/config/site.env $(MAKE) web-npm-build
 
 .PHONY: sample-test-apache
@@ -195,7 +173,9 @@ sample-build: use-sample
 sample-test-apache:
 	@test -d web/build || { echo "Error: web/build not found. Run 'make web-npm-build' first."; exit 1; }
 	docker run -d --rm --name sample-test-apache -p 8082:80 \
-		-v $(PWD)/web:/usr/local/apache2/htdocs:ro photos-apache
+		-v $(PWD)/web:/usr/local/apache2/htdocs \
+		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
+		photos-apache
 	@echo "Waiting for Apache to be ready..."; \
 	until curl -s -o /dev/null http://localhost:8082; do sleep 1; done
 	bin/test-photos-apache.sh --config-dir sample/config --local 8082; \
@@ -203,10 +183,10 @@ sample-test-apache:
 
 .PHONY: sample-npm-run-dev
 ## sample-npm-run-dev: run npm dev server using sample config
-sample-npm-run-dev: use-sample
+sample-npm-run-dev:
 	SITE_ENV=sample/config/site.env $(MAKE) web-npm-run-dev
 
 .PHONY: sample-npm-run-dev-css
 ## sample-npm-run-dev-css: run npm dev server using sample config with custom CSS
-sample-npm-run-dev-css: use-sample-css
-	SITE_ENV=sample/config/site.env $(MAKE) web-npm-run-dev
+sample-npm-run-dev-css:
+	SITE_ENV=sample/config/site.env DDPHOTOS_SITE_ID=sample-css $(MAKE) web-npm-run-dev

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,11 @@ web-docker-build:
 	docker build -t photos-apache web/
 
 .PHONY: web-docker-run
-## web-docker-run: run the photos Apache Docker container on port 8080 (mount web/build as document root)
+## web-docker-run: run the photos Apache Docker container on port 8080
 web-docker-run:
 	docker run --rm -p 8080:80 \
-		-v $(PWD)/web:/usr/local/apache2/htdocs \
+		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
+		-v $(PWD)/build:/build:ro \
 		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
 		photos-apache
 
@@ -171,9 +172,10 @@ sample-build:
 .PHONY: sample-test-apache
 ## sample-test-apache: run test-photos-apache.sh tests against local Docker container on port 8082 (starts/stops Docker automatically)
 sample-test-apache:
-	@test -d web/build || { echo "Error: web/build not found. Run 'make web-npm-build' first."; exit 1; }
+	@test -d build/$(DDPHOTOS_SITE_ID) || { echo "Error: build/$(DDPHOTOS_SITE_ID) not found. Run 'make web-npm-build' first."; exit 1; }
 	docker run -d --rm --name sample-test-apache -p 8082:80 \
-		-v $(PWD)/web:/usr/local/apache2/htdocs \
+		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
+		-v $(PWD)/build:/build:ro \
 		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
 		photos-apache
 	@echo "Waiting for Apache to be ready..."; \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help:
 .PHONY: build
 ## build: run `go build`
 build:
-	go build ./...
+	go build -ldflags "-X main.repoRoot=$(PWD)" ./...
 
 .PHONY: test
 ## test: run `go test`

--- a/Makefile
+++ b/Makefile
@@ -88,14 +88,24 @@ web-npm-run-dev:
 web-npm-build:
 	$(NODE_INIT) cd web && SITE_ENV=$(SITE_ENV) DDPHOTOS_ALBUMS_DIR=$(DDPHOTOS_ALBUMS_DIR) DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) npm run build
 
+DOCKER_SCHEMA := 2
+
 .PHONY: web-docker-build
 ## web-docker-build: build the photos Apache Docker image
 web-docker-build:
 	docker build -t photos-apache web/
 
+.PHONY: _check-docker-schema
+_check-docker-schema:
+	@label=$$(docker image inspect photos-apache \
+		--format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null); \
+	[ "$$label" = "$(DOCKER_SCHEMA)" ] || { \
+		echo "ERROR: photos-apache image is stale or missing (expected schema=$(DOCKER_SCHEMA), got '$$label')."; \
+		echo "Run: make web-docker-build"; exit 1; }
+
 .PHONY: web-docker-run
 ## web-docker-run: run the photos Apache Docker container on port 8080
-web-docker-run:
+web-docker-run: _check-docker-schema
 	docker run --rm -p 8080:80 \
 		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
 		-v $(PWD)/build:/build:ro \
@@ -171,7 +181,7 @@ sample-build:
 
 .PHONY: sample-test-apache
 ## sample-test-apache: run test-photos-apache.sh tests against local Docker container on port 8082 (starts/stops Docker automatically)
-sample-test-apache:
+sample-test-apache: _check-docker-schema
 	@test -d build/$(DDPHOTOS_SITE_ID) || { echo "Error: build/$(DDPHOTOS_SITE_ID) not found. Run 'make web-npm-build' first."; exit 1; }
 	docker run -d --rm --name sample-test-apache -p 8082:80 \
 		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -508,6 +508,13 @@ The script parses the album slug and image path from the URL, locates the album'
 `cmd/decode`), and searches for the matching `src` entry to print the `fileName`, `id`,
 and `sourcePath` (for recursive albums).
 
+The search is scoped to `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (defaults from
+`config/defaults.env`). Override to search a different site:
+
+```bash
+DDPHOTOS_SITE_ID=prod bin/search_cover.sh <url>
+```
+
 ## Testing
 
 There are three ways of testing the website:

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -241,7 +241,7 @@ go run cmd/photogen/photogen.go -albums albums-dev.yaml -resize -index -doit
 | `-doit`       | `false`       | Write files; without this, runs in dry-run mode                                                |
 | `-resize`     | `false`       | Generate resized WebP image variants                                                           |
 | `-index`      | `false`       | Generate JSON index files and sitemap.xml                                                      |
-| `-out`        | *(from YAML)* | Output directory override (overrides `settings.output_dir`)                                    |
+| `-out`        | *(from env)*  | Albums directory override (overrides `DDPHOTOS_ALBUMS_DIR`)                                    |
 | `-limit N`    | `0` (all)     | Limit photos per album (useful during development)                                             |
 | `-force`      | `false`       | Regenerate files even if they already exist                                                    |
 | `-workers N`  | `0` (auto)    | Concurrent resize workers (auto = NumCPU/2, min 2)                                             |
@@ -258,10 +258,9 @@ produces `albums/prod`). It must contain only lowercase letters, digits, and hyp
 The `-site-id` flag overrides this, which is useful when generating an encrypted variant
 alongside the standard output from the same config.
 
-Output goes to `{output_dir}/albums/{id}` (configured via `settings.output_dir` and
-`settings.id` in the YAML; git-ignored). Set `output_dir: .` so that output lands in
-`albums/{id}` at the repo root. Do not set it to `web/static` or Vite will double-copy
-the generated files during build.
+Output goes to `{DDPHOTOS_ALBUMS_DIR}/{id}` (git-ignored). `DDPHOTOS_ALBUMS_DIR` defaults
+to `albums` at the repo root (from `config/defaults.env`). Override with the `-out` flag
+or by setting `DDPHOTOS_ALBUMS_DIR` in the environment.
 
 ### Photo Descriptions (`photogen.txt`)
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -478,7 +478,7 @@ The correct password is selected automatically from the filename:
 
 ## Finding a Cover Photo (`search_cover.sh`)
 
-When browsing the site and you want to set a photo as an album cover, you need its
+When browsing the site, and you want to set a photo as an album cover, you need its
 `fileName` value for the `cover:` field in `albums.yaml`. The easiest way to get it is
 to right-click the photo, copy the image URL, and pass it to `bin/search_cover.sh`:
 
@@ -734,24 +734,39 @@ assumes `AWS_APACHE` is in the environment and specifies an accessible IP to you
 
 To deploy, I run `bin/deploy-photos.sh`, which:
 
-1. Runs `photogen` to resize images and generate JSON (skip with `--no-photogen`)
-2. Builds the static site via `npm run build` into `web/build`
+1. Runs `photogen` to resize images and generate JSON
+2. Builds the static site via `npm run build` into `build/<site-id>/`
 3. Starts the Docker/Apache container if not already running, runs
    `bin/test-photos-apache.sh --local` to verify routing locally, then stops the container
-4. Runs Playwright tests against Docker/Apache (skip with `--no-playwright`)
-5. Rsync `web/build` to the `$RSYNC_DEST` directory on the EC2 server (`$AWS_APACHE`).
-   It uses `--checksum` to reduce unnecessary re-copying since Vite resets timestamps.
+4. Runs Playwright tests against Docker/Apache
+5. Rsyncs `build/<site-id>/` to the `$RSYNC_DEST` directory on the EC2 server (`$AWS_APACHE`),
+   using `--checksum` to reduce unnecessary re-copying since Vite resets timestamps.
+   A second rsync pass syncs album data (`albums/<site-id>/`) independently.
 6. Invalidates the CloudFront cache (`$CLOUDFRONT_ID`)
 7. Runs `bin/test-photos-apache.sh` to verify the deployment against production
-8. Runs Playwright tests against production (`$VITE_SITE_URL`) (skip with `--no-playwright`)
+8. Runs Playwright tests against production (`$VITE_SITE_URL`)
 
-The script uses `set -eo pipefail` - any failure (including local tests) aborts before rsync.
+The script uses `set -eo pipefail` — any failure (including local tests) aborts before rsync.
+
+### Flags
+
+| Flag               | Description                                                                                                                                       |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--dry-run`        | Pass `--dry-run` to both rsync calls (shows what would transfer without touching the server); skips CloudFront invalidation and post-deploy tests |
+| `--no-photogen`    | Skip photo generation step                                                                                                                        |
+| `--no-rsync`       | Skip rsync, CloudFront invalidation, and post-deploy tests (build + local test only)                                                              |
+| `--no-apache-test` | Skip both the local and post-deploy Apache routing tests                                                                                          |
+| `--no-playwright`  | Skip Playwright tests (both local and production)                                                                                                 |
+| `--config-dir`     | Directory containing `albums.yaml`, `descriptions.txt`, and (by default) `site.env`                                                               |
+| `--site-env`       | Path to `site.env` — overrides `--config-dir/site.env` when the two live in different locations                                                   |
+
+Examples:
 
 ```bash
 bin/deploy-photos.sh                          # full deploy
+bin/deploy-photos.sh --dry-run                # preview what rsync would transfer, no changes made
 bin/deploy-photos.sh --no-photogen            # skip photo generation
-bin/deploy-photos.sh --no-rsync               # build + local test only, no deploy (safe on a dev machine)
-bin/deploy-photos.sh --no-playwright          # skip Playwright tests (local and production)
+bin/deploy-photos.sh --no-rsync               # build + local test only (safe on a dev machine)
 bin/deploy-photos.sh --no-photogen --no-rsync # build + local test, skip both photogen and rsync
 ```
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -93,8 +93,8 @@ The `site.env` variables are:
 | `TEST_ALBUM_PROD`       | `bin/test-photos-apache.sh` | Album slug used for production tests                                                    |
 | `TEST_ALBUM_HYPHEN`     | `bin/test-photos-apache.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
 
-The last five variables are only needed if using the deployment script. For local development,
-only the `VITE_*` vars are required.
+The last five variables (`CLOUDFRONT_ID`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
+for deployment and Apache routing tests. For local development, only the `VITE_*` vars are required.
 
 In the web app, `vite.config.ts` reads `config/site.env` at startup and injects `VITE_*` keys into `process.env`
 before Vite runs, so the values are available as `import.meta.env.VITE_*` in Svelte components.
@@ -108,6 +108,35 @@ when your config lives outside the repo (e.g. in a private config repo):
 ```bash
 SITE_ENV=~/work/my-config/site.env make web-npm-run-dev
 ```
+
+### Album Location Variables
+
+Two variables tell the dev server, build, and Docker container where to find album data:
+
+| Variable              | Default  | Description                                                                     |
+|-----------------------|----------|---------------------------------------------------------------------------------|
+| `DDPHOTOS_ALBUMS_DIR` | `albums` | Path to the root albums directory (absolute or repo-root-relative)              |
+| `DDPHOTOS_SITE_ID`    | `sample` | Site ID — selects `<DDPHOTOS_ALBUMS_DIR>/<DDPHOTOS_SITE_ID>` as the active site |
+
+Defaults are defined in `config/defaults.env` and are automatically picked up by the Makefile
+and `vite.config.ts`. Override them on the command line as needed:
+
+```bash
+# Use a different site ID
+DDPHOTOS_SITE_ID=prod make web-npm-run-dev
+
+# Albums directory outside the repo
+DDPHOTOS_ALBUMS_DIR=~/photos/albums DDPHOTOS_SITE_ID=mySite make web-npm-build
+
+# Both via SITE_ENV and album vars together
+SITE_ENV=~/work/my-config/site.env DDPHOTOS_ALBUMS_DIR=~/photos/albums DDPHOTOS_SITE_ID=prod make web-npm-build
+```
+
+These variables are consumed by:
+- `vite.config.ts` — dev server middleware serves `/albums/**` from `<DDPHOTOS_ALBUMS_DIR>/<DDPHOTOS_SITE_ID>/`
+- `web/svelte.config.js` — build output goes to `build/<DDPHOTOS_SITE_ID>/`; album slugs are read for pre-rendered entries
+- `web/hooks.server.ts` — intercepts fetch calls to `/albums/**` during `npm run build`
+- `web/entrypoint.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the Apache document root at container startup
 
 ## Makefile Targets
 
@@ -124,26 +153,20 @@ Common tasks are available via `make` from the repo root:
 | `web-nvm-install`            | Install the Node version specified in `web/.nvmrc`                                 |
 | `web-npm-install`            | Install npm dependencies in `web/`                                                 |
 | `web-npm-run-dev`            | Start Vite dev server and open browser                                             |
-| `web-npm-build`              | Build the static site into `web/build/`                                            |
+| `web-npm-build`              | Build the static site into `build/<site-id>/`                                      |
 | `web-docker-build`           | Build the `photos-apache` Docker image                                             |
-| `web-docker-run`             | Run Apache on port 8080 with `web/` mounted as document root                       |
+| `web-docker-run`             | Run Apache on port 8080 (mounts `build/` and `albums/<site-id>/`)                  |
 | `web-docker-stop`            | Stop the running `photos-apache` container                                         |
 | `web-docker-test`            | Run `bin/test-photos-apache.sh` against `localhost:8080`                           |
 | `web-playwright-install`     | One-time setup: install `@playwright/test` and Chromium binary                     |
 | `web-playwright-test-apache` | Run Playwright e2e tests (starts Docker on port 8081, runs, stops)                 |
 | `web-playwright-test-dev`    | Run Playwright e2e tests (against Vite dev server)                                 |
 | `web-playwright-test-all`    | Run `bin/test-all.sh` across all password/CSS variants                             |
-| `use-sample`                 | Symlink `web/static/albums` → `../albums/sample`                                   |
-| `use-sample-pw-all`          | Symlink `web/static/albums` → `../albums/sample-pw-all`                            |
-| `use-sample-pw-uganda`       | Symlink `web/static/albums` → `../albums/sample-pw-uganda`                         |
-| `use-sample-css`             | Symlink `web/static/albums` → `../albums/sample-css`                               |
-| `use-prod`                   | Symlink `web/static/albums` → `../albums/prod`                                     |
 | `sample-photogen`            | Run photogen using `sample/config/albums.yaml`                                     |
 | `sample-photogen-pw-all`     | Run photogen using sample config, all albums password-protected                    |
 | `sample-photogen-pw-uganda`  | Run photogen using sample config, Uganda album password-protected                  |
 | `sample-photogen-css`        | Run photogen using sample config with custom CSS injected                          |
 | `sample-photogen-demo`       | Run photogen using sample config with custom CSS and all albums password-protected |
-| `use-sample-demo`            | Symlink `web/static/albums` → `../albums/sample-demo`                              |
 | `sample-demo`                | One-step demo: photogen (CSS + passwords) and run dev server                       |
 | `sample-build`               | Build the static site using sample config                                          |
 | `sample-npm-run-dev`         | Run the Vite dev server using sample config                                        |
@@ -231,17 +254,14 @@ go run cmd/photogen/photogen.go -albums albums-dev.yaml -resize -index -doit
 | `-hero-only`  | `false`       | Regenerate the hero image only; skips all album processing and index/JSON generation           |
 
 `settings.id` is required and determines the output directory name (e.g. `id: prod`
-produces `web/albums/prod`). It must contain only lowercase letters, digits, and hyphens.
+produces `albums/prod`). It must contain only lowercase letters, digits, and hyphens.
 The `-site-id` flag overrides this, which is useful when generating an encrypted variant
 alongside the standard output from the same config.
 
 Output goes to `{output_dir}/albums/{id}` (configured via `settings.output_dir` and
-`settings.id` in the YAML; git-ignored). Set `output_dir: web` - the code appends
-`albums/{id}` automatically. Do not set it to `web/static` or Vite will double-copy
+`settings.id` in the YAML; git-ignored). Set `output_dir: .` so that output lands in
+`albums/{id}` at the repo root. Do not set it to `web/static` or Vite will double-copy
 the generated files during build.
-
-Use `make use-sample` or `make use-prod` to point `web/static/albums` at the desired
-output via symlink before running the dev server or building.
 
 ### Photo Descriptions (`photogen.txt`)
 
@@ -326,10 +346,10 @@ This makes it easy to find the prefixed `fileName` for a given original file:
 
 ```bash
 # plain album
-grep -B2 "IMG_0436" web/albums/my-site/my-album/index.json
+grep -B2 "IMG_0436" albums/my-site/my-album/index.json
 
 # encrypted album
-go run cmd/decode/decode.go web/albums/my-site/my-album/index.enc.json | grep -B2 "IMG_0436"
+go run cmd/decode/decode.go albums/my-site/my-album/index.enc.json | grep -B2 "IMG_0436"
 ```
 
 ### Passwords File
@@ -437,8 +457,8 @@ go run cmd/decode/decode.go -passwords <pw-file> <path.enc.json>
 cases no flags are needed:
 
 ```bash
-go run cmd/decode/decode.go web/albums/sample-pw-uganda/uganda/index.enc.json
-go run cmd/decode/decode.go web/albums/sample-pw-all/albums.enc.json
+go run cmd/decode/decode.go albums/sample-pw-uganda/uganda/index.enc.json
+go run cmd/decode/decode.go albums/sample-pw-all/albums.enc.json
 ```
 
 If the passwords file has moved, or the file was generated without an embedded path,
@@ -446,7 +466,7 @@ pass `-passwords` explicitly:
 
 ```bash
 go run cmd/decode/decode.go -passwords sample/config/passwords-uganda.yaml \
-  web/albums/sample-pw-uganda/uganda/index.enc.json
+  albums/sample-pw-uganda/uganda/index.enc.json
 ```
 
 The correct password is selected automatically from the filename:
@@ -455,6 +475,38 @@ The correct password is selected automatically from the filename:
 |-------------------|--------------------------------------------------|
 | `albums.enc.json` | Site-wide password (`site.password`)             |
 | `index.enc.json`  | Per-album password for the parent directory slug |
+
+## Finding a Cover Photo (`search_cover.sh`)
+
+When browsing the site and you want to set a photo as an album cover, you need its
+`fileName` value for the `cover:` field in `albums.yaml`. The easiest way to get it is
+to right-click the photo, copy the image URL, and pass it to `bin/search_cover.sh`:
+
+```bash
+bin/search_cover.sh <url>
+```
+
+Example:
+
+```bash
+bin/search_cover.sh http://localhost:5173/albums/banff-2002/full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+```
+
+Output:
+
+```
+Album:  banff-2002
+Index:  albums/sample/banff-2002/index.json
+src:    full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+
+fileName:   banff-2002-original-name.webp
+id:         banff-2002-original-name
+```
+
+The script parses the album slug and image path from the URL, locates the album's
+`index.json` (or `index.enc.json` for encrypted albums — decoded automatically via
+`cmd/decode`), and searches for the matching `src` entry to print the `fileName`, `id`,
+and `sourcePath` (for recursive albums).
 
 ## Testing
 
@@ -476,7 +528,6 @@ any of the SvelteKit files change or even when `photogen` is re-run.
 # Sample site
 make sample-npm-run-dev
 
-# Uses current web/static/albums symlink
 make web-npm-run-dev
 
 # Uses custom site.env
@@ -498,7 +549,6 @@ make sample-build
 make web-npm-build
 
 # Uses custom site.env
-ln -sfn ../albums/private web/static/albums
 SITE_ENV=private/config/site.env make web-npm-build
 ```
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -460,7 +460,7 @@ The correct password is selected automatically from the filename:
 
 There are three ways of testing the website:
 
-1. **Manual testing** in a browser, against the Vite dev server or a local static build (via Python or Docker/Apache)
+1. **Manual testing** in a browser, against the Vite dev server or a local static build (via Docker/Apache)
 2. **Playwright e2e tests** that drive a headless Chromium browser to verify UI behavior
 3. **Apache routing tests** using `curl` to verify `.htaccess` URL routing, redirects, and 404 handling
 
@@ -502,25 +502,13 @@ ln -sfn ../albums/private web/static/albums
 SITE_ENV=private/config/site.env make web-npm-build
 ```
 
-Once the site is built (into `web/build`), you can serve
-it via Python or Docker/Apache.
-
-### Manual Testing - Build Served via Python
-
-If you have Python installed, this will serve up the site:
-
-```bash
-python3 -m http.server 8000 --directory web/build
-```
-
-Note: Python's server doesn't apply `.htaccess` rules, so URL routing won't
-match Apache. Use the Docker setup below for accurate Apache testing.
+Once the site is built, you can serve it via Docker/Apache.
 
 ### Manual Testing - Build Served via Docker/Apache
 
 The Docker/Apache environment mirrors one possible production setup and applies
-`.htaccess` routing locally. The `web` directory is mounted in the container (not
-`web/build`) so that npm rebuilds (which delete and recreate `build`)
+`.htaccess` routing locally. The `build/` directory is mounted in the container (not
+`build/<site-id>/`) so that npm rebuilds (which delete and recreate `build/<site-id>/`)
 don't break the container's bind mount.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -221,9 +221,6 @@ cp config/descriptions.example.txt config/descriptions.txt
 cp config/site.example.env config/site.env
 ```
 
-**TIP**: If you use `prod` as your `settings.id` value in `albums.yaml`,
-you can use some provided make targets, like `use-prod`.
-
 ## Commands
 
 The `Makefile` is a good reference for the commands (you used them to run the sample site).
@@ -239,11 +236,8 @@ go run cmd/photogen/photogen.go -resize -index
 go run cmd/photogen/photogen.go -resize -index -doit
 ```
 
-**NOTE**: output goes to `web/albums/[ID]` by default.  For example,
-the sample site is in `web/albums/sample`.  A symlink from
-`web/static/albums` points to the current site data you are working
-with.  See the `use-prod` Makefile target for an example of
-how this symlink is created.
+**NOTE**: output goes to `albums/[ID]` at the repo root by default. For example,
+the sample site is in `albums/sample`.
 
 ### Run Site
 
@@ -251,11 +245,6 @@ Once `photogen` has been successfully run, you can run the
 dev server.
 
 ```bash
-# Make sure symlink is correct
-ln -sfn ../albums/my-site web/static/albums # if id is not 'prod'
-make use-prod # if id is 'prod'
-
-# Run dev server
 make web-npm-run-dev
 ```
 
@@ -267,7 +256,7 @@ To test the build process:
 make web-npm-build
 ```
 
-This deletes and recreates the `web/build` directory, which will have all
+This deletes and recreates the `build/<site-id>` directory, which will have all
 the files needed to run the site, including copies of your resized photos.
 
 To run it using the Docker/Apache image:

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -99,12 +99,11 @@ _docker_cleanup() {
     fi
 }
 trap _docker_cleanup EXIT
-
 if [ "$SKIP_APACHE_TEST" = true ]; then
     echo "Skipping local Apache tests (--no-apache-test)"
 else
     # Verify Docker image schema before running
-    _schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null)
+    _schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null || true)
     if [ "$_schema" != "2" ]; then
         echo "ERROR: photos-apache image is stale or missing (expected schema=2, got '$_schema')."
         echo "Run: make web-docker-build"
@@ -148,10 +147,12 @@ else
 
     # Deploy app files + pre-rendered album HTML/JSON.
     # --checksum: rsync skips files with matching content (Vite resets timestamps on static/ files)
-    # --exclude=albums/*/: skip album image subdirs (rsynced separately below)
+    # --filter='protect albums/**': prevent --delete from touching albums/ content (hero.jpg,
+    #   sitemap.xml, images, JSON) — those files are managed by the second rsync pass below.
+    #   Note: 'protect' only suppresses deletion; it still transfers new files from the source.
     # shellcheck disable=SC2086
     rsync $RSYNC_OPTS \
-        --exclude=albums/*/ \
+        --filter='protect albums/**' \
         "$REPO_ROOT/build/$DDPHOTOS_SITE_ID/" "$AWS_APACHE":"$RSYNC_DEST"
 
     # Deploy album data (images + JSON) independently.

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -45,9 +45,20 @@ fi
 [ -f "$SITE_ENV" ] || { echo "Error: $SITE_ENV not found"; exit 1; }
 source "$SITE_ENV"
 
-# These must be set by the caller (e.g. Makefile)
-[ -n "$DDPHOTOS_ALBUMS_DIR" ] || { echo "Error: DDPHOTOS_ALBUMS_DIR not set"; exit 1; }
-[ -n "$DDPHOTOS_SITE_ID" ]    || { echo "Error: DDPHOTOS_SITE_ID not set"; exit 1; }
+# Load defaults.env as a fallback for vars not already set (e.g. DDPHOTOS_ALBUMS_DIR, DDPHOTOS_SITE_ID)
+DEFAULTS_ENV="$(dirname "$SDIR")/config/defaults.env"
+if [ -f "$DEFAULTS_ENV" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        [[ "$line" =~ ^#|^$ ]] && continue
+        key="${line%%=*}"
+        val="${line#*=}"
+        [ -z "${!key+x}" ] && export "$key"="$val"
+    done < "$DEFAULTS_ENV"
+fi
+
+# These must be set — either by the caller, site.env, or defaults.env
+[ -n "$DDPHOTOS_ALBUMS_DIR" ] || { echo "Error: DDPHOTOS_ALBUMS_DIR not set (not in environment or config/defaults.env)"; exit 1; }
+[ -n "$DDPHOTOS_SITE_ID" ]    || { echo "Error: DDPHOTOS_SITE_ID not set (not in environment or config/defaults.env)"; exit 1; }
 
 # These must be set in site.env — guard early so a missing value can't
 # cause rsync --delete to target the wrong (or empty) remote path.

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -103,6 +103,14 @@ trap _docker_cleanup EXIT
 if [ "$SKIP_APACHE_TEST" = true ]; then
     echo "Skipping local Apache tests (--no-apache-test)"
 else
+    # Verify Docker image schema before running
+    _schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null)
+    if [ "$_schema" != "2" ]; then
+        echo "ERROR: photos-apache image is stale or missing (expected schema=2, got '$_schema')."
+        echo "Run: make web-docker-build"
+        exit 1
+    fi
+
     DOCKER_RUNNING=$(docker ps -q --filter publish=8080)
     if [ -n "$DOCKER_RUNNING" ]; then
         echo "Docker already running on port 8080, using existing container..."

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -25,9 +25,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# cd
+# cd to root of repo
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 cd "$SDIR/.."
+REPO_ROOT="$(pwd)"
 
 # Resolve CONFIG_DIR and SITE_ENV_ARG to absolute paths (relative paths break after subsequent cd's)
 [ -n "$CONFIG_DIR" ]    && CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)"
@@ -97,7 +98,8 @@ else
     else
         echo "Starting local Docker container for testing..."
         docker run -d --rm -p 8080:80 \
-            -v "$PWD":/usr/local/apache2/htdocs \
+            -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
+            -v "$REPO_ROOT/build":/build:ro \
             -v "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID":/albums:ro \
             photos-apache > /dev/null
         DOCKER_STARTED=true
@@ -125,23 +127,16 @@ if [ "$SKIP_RSYNC" = true ]; then
 else
     [ "$DRY_RUN" = true ] && echo "=== DRY RUN: rsync will not transfer any files ==="
 
-    # Remove Docker-created symlinks from build/albums/ before rsyncing.
-    # The entrypoint.sh creates symlinks in build/albums/ at container startup;
-    # they persist on the host and must not be rsynced to the server.
-    find build/albums -maxdepth 1 -type l -delete
-
-    # Deploy app files + prerendered album HTML/JSON.
+    # Deploy app files + pre-rendered album HTML/JSON.
     # --checksum: rsync skips files with matching content (Vite resets timestamps on static/ files)
     # --exclude=albums/*/: skip album image subdirs (rsynced separately below)
-    # --exclude=albums/README.md: skip the Docker placeholder file
     # shellcheck disable=SC2086
     rsync $RSYNC_OPTS \
         --exclude=albums/*/ \
-        --exclude=albums/README.md \
-        build/ "$AWS_APACHE":"$RSYNC_DEST"
+        "$REPO_ROOT/build/$DDPHOTOS_SITE_ID/" "$AWS_APACHE":"$RSYNC_DEST"
 
     # Deploy album data (images + JSON) independently.
-    # --exclude=*.html: don't delete prerendered .html pages synced above
+    # --exclude=*.html: don't delete pre-rendered .html pages synced above
     # shellcheck disable=SC2086
     rsync $RSYNC_OPTS \
         --exclude=*.html \

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -7,15 +7,20 @@ SKIP_PHOTOGEN=false
 SKIP_RSYNC=false
 SKIP_PLAYWRIGHT=false
 SKIP_APACHE_TEST=false
+DRY_RUN=false
 CONFIG_DIR=""
+SITE_ENV_ARG=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --no-photogen)  SKIP_PHOTOGEN=true; shift ;;
         --no-rsync)     SKIP_RSYNC=true; shift ;;
         --no-playwright) SKIP_PLAYWRIGHT=true; shift ;;
         --no-apache-test) SKIP_APACHE_TEST=true; shift ;;
+        --dry-run)      DRY_RUN=true; shift ;;
         --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
         --config-dir=*) CONFIG_DIR="${1#*=}"; shift ;;
+        --site-env)     SITE_ENV_ARG="$2"; shift 2 ;;
+        --site-env=*)   SITE_ENV_ARG="${1#*=}"; shift ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
@@ -24,17 +29,38 @@ done
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 cd "$SDIR/.."
 
-# Resolve CONFIG_DIR to absolute path (relative paths break after subsequent cd's)
-[ -n "$CONFIG_DIR" ] && CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)"
+# Resolve CONFIG_DIR and SITE_ENV_ARG to absolute paths (relative paths break after subsequent cd's)
+[ -n "$CONFIG_DIR" ]    && CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)"
+[ -n "$SITE_ENV_ARG" ]  && SITE_ENV_ARG="$(cd "$(dirname "$SITE_ENV_ARG")" && pwd)/$(basename "$SITE_ENV_ARG")"
 
-# Load site config
-if [ -n "$CONFIG_DIR" ]; then
-    CONFIG="$CONFIG_DIR/site.env"
+# Resolve site.env: --site-env takes priority, then --config-dir/site.env, then config/site.env
+if [ -n "$SITE_ENV_ARG" ]; then
+    SITE_ENV="$SITE_ENV_ARG"
+elif [ -n "$CONFIG_DIR" ]; then
+    SITE_ENV="$CONFIG_DIR/site.env"
 else
-    CONFIG="config/site.env"
+    SITE_ENV="config/site.env"
 fi
-[ -f "$CONFIG" ] || { echo "Error: $CONFIG not found"; exit 1; }
-source "$CONFIG"
+[ -f "$SITE_ENV" ] || { echo "Error: $SITE_ENV not found"; exit 1; }
+source "$SITE_ENV"
+
+# These must be set by the caller (e.g. Makefile)
+[ -n "$DDPHOTOS_ALBUMS_DIR" ] || { echo "Error: DDPHOTOS_ALBUMS_DIR not set"; exit 1; }
+[ -n "$DDPHOTOS_SITE_ID" ]    || { echo "Error: DDPHOTOS_SITE_ID not set"; exit 1; }
+
+# These must be set in site.env — guard early so a missing value can't
+# cause rsync --delete to target the wrong (or empty) remote path.
+[ -n "$AWS_APACHE" ]      || { echo "Error: AWS_APACHE not set in $SITE_ENV"; exit 1; }
+[ -n "$RSYNC_DEST" ]      || { echo "Error: RSYNC_DEST not set in $SITE_ENV"; exit 1; }
+[ -n "$CLOUDFRONT_ID" ]   || { echo "Error: CLOUDFRONT_ID not set in $SITE_ENV"; exit 1; }
+[ -n "$VITE_SITE_URL" ]   || { echo "Error: VITE_SITE_URL not set in $SITE_ENV"; exit 1; }
+
+# Ensure RSYNC_DEST ends with / so rsync targets an explicit directory path,
+# never a bare or empty string that could default to the remote home directory.
+[[ "$RSYNC_DEST" == */ ]] || RSYNC_DEST="${RSYNC_DEST}/"
+
+# Resolve DDPHOTOS_ALBUMS_DIR to absolute path
+DDPHOTOS_ALBUMS_DIR="$(cd "$DDPHOTOS_ALBUMS_DIR" && pwd)"
 
 # Generate photos
 if [ "$SKIP_PHOTOGEN" = true ]; then
@@ -49,8 +75,7 @@ fi
 # Build static site
 cd web
 source "$HOME/.nvm/nvm.sh"
-[ -n "$CONFIG_DIR" ] && export SITE_ENV="$CONFIG_DIR/site.env"
-npm run build
+SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$DDPHOTOS_ALBUMS_DIR" DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" npm run build
 
 # Local Apache test before deploying.
 # Start Docker container if not already running on port 8080, and stop it on exit.
@@ -71,7 +96,10 @@ else
         echo "Docker already running on port 8080, using existing container..."
     else
         echo "Starting local Docker container for testing..."
-        docker run -d --rm -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs:ro photos-apache > /dev/null
+        docker run -d --rm -p 8080:80 \
+            -v "$PWD":/usr/local/apache2/htdocs \
+            -v "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID":/albums:ro \
+            photos-apache > /dev/null
         DOCKER_STARTED=true
         sleep 1
     fi
@@ -89,18 +117,48 @@ else
     npx playwright test
 fi
 
+RSYNC_OPTS="-avz --checksum --delete"
+[ "$DRY_RUN" = true ] && RSYNC_OPTS="$RSYNC_OPTS --dry-run"
+
 if [ "$SKIP_RSYNC" = true ]; then
     echo "Skipping rsync, CloudFront invalidation, and post-deploy test (--no-rsync)"
 else
-    # Deploy (--checksum so rsync skips files with matching content, since
-    # Vite resets timestamps on static/ files copied into build/)
-    rsync -avz --checksum --delete build/ "$AWS_APACHE":"$RSYNC_DEST"
+    [ "$DRY_RUN" = true ] && echo "=== DRY RUN: rsync will not transfer any files ==="
 
-    # Clear cache
-    aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/*"
+    # Remove Docker-created symlinks from build/albums/ before rsyncing.
+    # The entrypoint.sh creates symlinks in build/albums/ at container startup;
+    # they persist on the host and must not be rsynced to the server.
+    find build/albums -maxdepth 1 -type l -delete
+
+    # Deploy app files + prerendered album HTML/JSON.
+    # --checksum: rsync skips files with matching content (Vite resets timestamps on static/ files)
+    # --exclude=albums/*/: skip album image subdirs (rsynced separately below)
+    # --exclude=albums/README.md: skip the Docker placeholder file
+    # shellcheck disable=SC2086
+    rsync $RSYNC_OPTS \
+        --exclude=albums/*/ \
+        --exclude=albums/README.md \
+        build/ "$AWS_APACHE":"$RSYNC_DEST"
+
+    # Deploy album data (images + JSON) independently.
+    # --exclude=*.html: don't delete prerendered .html pages synced above
+    # shellcheck disable=SC2086
+    rsync $RSYNC_OPTS \
+        --exclude=*.html \
+        "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/" \
+        "$AWS_APACHE":"${RSYNC_DEST}albums/"
+
+    # Clear cache (skipped in dry-run mode)
+    if [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping CloudFront invalidation"
+    else
+        aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/*"
+    fi
 
     if [ "$SKIP_APACHE_TEST" = true ]; then
         echo "Skipping post-deploy Apache tests (--no-apache-test)"
+    elif [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping post-deploy Apache tests"
     else
         # Wait, run test
         echo "Sleeping 5 to allow cache to clear..."
@@ -112,6 +170,8 @@ else
 
     if [ "$SKIP_PLAYWRIGHT" = true ]; then
         echo "Skipping Playwright tests against production (--no-playwright)"
+    elif [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping Playwright tests against production"
     else
         echo "Running Playwright e2e tests against production..."
         PLAYWRIGHT_BASE_URL="$VITE_SITE_URL" npx playwright test

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -77,26 +77,25 @@ if [ -n "$CSS_FILE" ]; then
     [ -f "$CSS_FILE" ] || { echo "Error: CSS file not found: $CSS_FILE" >&2; exit 1; }
 fi
 
-# Derive site-id and symlink target from flags.
+# Derive site-id from flags.
 # Convention: passwords-all.yaml -> site-id "sample-pw-all"
 #             passwords-uganda.yaml -> site-id "sample-pw-uganda"
 #             --css <file> -> site-id "sample-css"
 #             (no flags) -> site-id "sample"
 SITE_ID="sample"
-SYMLINK_TARGET="../albums/sample"
 PHOTOGEN_FLAGS="-config-dir sample/config -resize -index -clean -doit"
 if [ -n "$PASSWORDS_FILE" ]; then
     BASENAME=$(basename "$PASSWORDS_FILE" .yaml)  # e.g. "passwords-all"
     VARIANT="${BASENAME#passwords-}"               # e.g. "all"
     SITE_ID="sample-pw-${VARIANT}"
-    SYMLINK_TARGET="../albums/sample-pw-${VARIANT}"
     PHOTOGEN_FLAGS="-config-dir sample/config -resize -index -clean -passwords $PASSWORDS_FILE -site-id $SITE_ID -doit"
 fi
 if [ -n "$CSS_FILE" ]; then
     SITE_ID="sample-css"
-    SYMLINK_TARGET="../albums/sample-css"
     PHOTOGEN_FLAGS="-config-dir sample/config -resize -index -clean -css $CSS_FILE -site-id $SITE_ID -doit"
 fi
+
+ALBUMS_DIR="$(pwd)/albums"
 
 SITE_ENV="$(pwd)/sample/config/site.env"
 DEV_PORT=5174
@@ -117,9 +116,6 @@ echo ""
 echo "=== Generating sample data (site-id: $SITE_ID) ==="
 # shellcheck disable=SC2086
 go run cmd/photogen/photogen.go $PHOTOGEN_FLAGS
-
-echo "=== Setting symlink: web/static/albums -> $SYMLINK_TARGET ==="
-ln -sfn "$SYMLINK_TARGET" web/static/albums
 
 # --- helper: run Playwright against a base URL ---
 run_playwright() {
@@ -153,7 +149,7 @@ wait_for_http() {
 run_dev() {
     echo ""
     echo "=== [dev] Starting Vite dev server on port $DEV_PORT ==="
-    (cd web && SITE_ENV="$SITE_ENV" npx vite dev --port "$DEV_PORT" --clearScreen false) &
+    (cd web && SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npx vite dev --port "$DEV_PORT" --clearScreen false) &
     DEV_PID=$!
 
     wait_for_http "http://localhost:$DEV_PORT" "dev server"
@@ -174,7 +170,7 @@ run_apache() {
     echo "=== [apache] Building static site ==="
     # Explicit error check: set -e is suppressed inside functions called via ||
     # (see run_apache || OVERALL_EXIT=$? below), so failures must be caught manually.
-    (cd web && SITE_ENV="$SITE_ENV" npm run build) || return 1
+    (cd web && SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
 
     # Build Docker image if it doesn't already exist
     if ! docker image inspect photos-apache &>/dev/null 2>&1; then
@@ -184,7 +180,9 @@ run_apache() {
 
     echo "=== [apache] Starting Apache on port $DOCKER_PORT ==="
     docker run -d --rm --name "$DOCKER_CONTAINER" -p "$DOCKER_PORT:80" \
-        -v "$(pwd)/web":/usr/local/apache2/htdocs:ro photos-apache
+        -v "$(pwd)/web":/usr/local/apache2/htdocs \
+        -v "$ALBUMS_DIR/$SITE_ID":/albums:ro \
+        photos-apache
 
     wait_for_http "http://localhost:$DOCKER_PORT" "Apache"
 

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -174,7 +174,7 @@ run_apache() {
 
     # Build Docker image if missing or schema label is stale
     local schema
-    schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null)
+    schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null || true)
     if [ "$schema" != "2" ]; then
         echo "=== [apache] Building Docker image (schema stale or missing) ==="
         docker build -t photos-apache web/ || return 1

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -180,7 +180,8 @@ run_apache() {
 
     echo "=== [apache] Starting Apache on port $DOCKER_PORT ==="
     docker run -d --rm --name "$DOCKER_CONTAINER" -p "$DOCKER_PORT:80" \
-        -v "$(pwd)/web":/usr/local/apache2/htdocs \
+        -e DDPHOTOS_SITE_ID="$SITE_ID" \
+        -v "$(pwd)/build":/build:ro \
         -v "$ALBUMS_DIR/$SITE_ID":/albums:ro \
         photos-apache
 

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -172,9 +172,11 @@ run_apache() {
     # (see run_apache || OVERALL_EXIT=$? below), so failures must be caught manually.
     (cd web && SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
 
-    # Build Docker image if it doesn't already exist
-    if ! docker image inspect photos-apache &>/dev/null 2>&1; then
-        echo "=== [apache] Building Docker image ==="
+    # Build Docker image if missing or schema label is stale
+    local schema
+    schema=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.schema"}}' 2>/dev/null)
+    if [ "$schema" != "2" ]; then
+        echo "=== [apache] Building Docker image (schema stale or missing) ==="
         docker build -t photos-apache web/ || return 1
     fi
 

--- a/bin/search_cover.sh
+++ b/bin/search_cover.sh
@@ -26,8 +26,8 @@ if [[ -z "$slug" || -z "$src_path" ]]; then
     exit 1
 fi
 
-# Find index.enc.json (or index.json) for this album under web/albums/
-index_file=$(find web/albums -maxdepth 3 -type f \( -name "index.enc.json" -o -name "index.json" \) \
+# Find index.enc.json (or index.json) for this album under albums/
+index_file=$(find albums -maxdepth 3 -type f \( -name "index.enc.json" -o -name "index.json" \) \
     | grep "/${slug}/" | head -1)
 
 if [[ -z "$index_file" ]]; then

--- a/bin/search_cover.sh
+++ b/bin/search_cover.sh
@@ -6,6 +6,8 @@
 #
 # Example:
 #   bin/search_cover.sh http://localhost:5173/albums/banff-2002/full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+#
+# Respects DDPHOTOS_ALBUMS_DIR and DDPHOTOS_SITE_ID (falls back to config/defaults.env).
 
 set -eo pipefail
 
@@ -15,6 +17,28 @@ if [[ $# -ne 1 ]]; then
 fi
 
 url="$1"
+
+# cd to repo root
+SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+cd "$SDIR/.."
+
+# Load defaults.env for DDPHOTOS_ALBUMS_DIR / DDPHOTOS_SITE_ID if not already set
+if [ -f config/defaults.env ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        [[ "$line" =~ ^#|^$ ]] && continue
+        key="${line%%=*}"
+        val="${line#*=}"
+        [ -z "${!key+x}" ] && export "$key"="$val"
+    done < config/defaults.env
+fi
+
+ALBUMS_DIR="${DDPHOTOS_ALBUMS_DIR:-albums}"
+SITE_ID="${DDPHOTOS_SITE_ID:-sample}"
+
+# Resolve relative ALBUMS_DIR against repo root
+[[ "$ALBUMS_DIR" = /* ]] || ALBUMS_DIR="$(pwd)/$ALBUMS_DIR"
+
+SEARCH_ROOT="$ALBUMS_DIR/$SITE_ID"
 
 # Extract slug (e.g. "banff-2002") and src path (e.g. "full/0918bedf-....webp")
 # URL form: .../albums/{slug}/full/{uuid}.webp  or  .../albums/{slug}/grid/{uuid}.webp
@@ -26,12 +50,12 @@ if [[ -z "$slug" || -z "$src_path" ]]; then
     exit 1
 fi
 
-# Find index.enc.json (or index.json) for this album under albums/
-index_file=$(find albums -maxdepth 3 -type f \( -name "index.enc.json" -o -name "index.json" \) \
+# Find index.enc.json (or index.json) for this album under the active site
+index_file=$(find "$SEARCH_ROOT" -maxdepth 2 -type f \( -name "index.enc.json" -o -name "index.json" \) \
     | grep "/${slug}/" | head -1)
 
 if [[ -z "$index_file" ]]; then
-    echo "No index file found for album slug: $slug" >&2
+    echo "No index file found for album slug '$slug' under $SEARCH_ROOT" >&2
     exit 1
 fi
 

--- a/bin/search_cover.sh
+++ b/bin/search_cover.sh
@@ -52,10 +52,11 @@ fi
 
 # Find index.enc.json (or index.json) for this album under the active site
 index_file=$(find "$SEARCH_ROOT" -maxdepth 2 -type f \( -name "index.enc.json" -o -name "index.json" \) \
-    | grep "/${slug}/" | head -1)
+    | grep "/${slug}/" | head -1 || true)
 
 if [[ -z "$index_file" ]]; then
     echo "No index file found for album slug '$slug' under $SEARCH_ROOT" >&2
+    echo "Try another site with DDPHOTOS_SITE_ID=<site-id> search_cover.sh $url" >&2
     exit 1
 fi
 

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -10,10 +11,51 @@ import (
 	"github.com/dougdonohoe/ddphotos/pkg/photogen"
 )
 
+// repoRoot is embedded at build time via:
+//
+//	go build -ldflags "-X main.repoRoot=/path/to/repo"
+//
+// When set, loadDefaultsEnv looks for config/defaults.env there first.
+// Falls back to cwd-relative path so `go run ./cmd/photogen` still works from the repo root.
+var repoRoot string
+
+// loadDefaultsEnv reads config/defaults.env and sets any keys not already in the environment.
+// This mirrors the behaviour of vite.config.ts and the shell scripts.
+func loadDefaultsEnv() {
+	candidates := []string{filepath.Join("config", "defaults.env")}
+	if repoRoot != "" {
+		candidates = append([]string{filepath.Join(repoRoot, "config", "defaults.env")}, candidates...)
+	}
+
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			eq := strings.IndexByte(line, '=')
+			if eq < 0 {
+				continue
+			}
+			key := strings.TrimSpace(line[:eq])
+			val := strings.TrimSpace(line[eq+1:])
+			if _, exists := os.LookupEnv(key); !exists {
+				os.Setenv(key, val) //nolint:errcheck
+			}
+		}
+		return // parsed successfully
+	}
+	// No defaults.env found — explicit env var or -out flag must provide the albums dir.
+}
+
 var (
 	configDir  = flag.String("config-dir", "config", "directory containing albums YAML and descriptions files")
 	albumsFile = flag.String("albums", "albums.yaml", "albums YAML filename within config-dir")
-	outputDir  = flag.String("out", "", "output directory for generated albums (overrides YAML output_dir)")
+	outputDir  = flag.String("out", "", "albums directory override (overrides DDPHOTOS_ALBUMS_DIR env var)")
 	doit       = flag.Bool("doit", false, "do actual work; otherwise log planned work without writing any files")
 	limit      = flag.Int("limit", 0, "limit number of photos per album (0 = no limit)")
 	force      = flag.Bool("force", false, "regenerate output files even if they already exist")
@@ -32,6 +74,7 @@ var (
 func main() {
 	flag.Parse()
 	exit.HandleSignal()
+	loadDefaultsEnv()
 
 	albums, settings, err := photogen.LoadAlbumConfigs(*configDir, *albumsFile)
 	if err != nil {
@@ -48,10 +91,19 @@ func main() {
 	if *siteURL != "" {
 		resolvedSiteURL = *siteURL
 	}
-	resolvedOutputDir := settings.OutputDir
+
+	// Albums directory: -out flag > DDPHOTOS_ALBUMS_DIR env var > defaults.env (loaded above)
+	resolvedAlbumsDir := os.Getenv("DDPHOTOS_ALBUMS_DIR")
 	if *outputDir != "" {
-		resolvedOutputDir = *outputDir
+		resolvedAlbumsDir = *outputDir
 	}
+	if resolvedAlbumsDir == "" {
+		fmt.Println("Error: albums output directory is not set.")
+		fmt.Println("  Set DDPHOTOS_ALBUMS_DIR in the environment, use the -out flag,")
+		fmt.Println("  or ensure config/defaults.env is present in the working directory.")
+		exit.ExitWithStatus(fmt.Errorf("DDPHOTOS_ALBUMS_DIR not set"))
+	}
+
 	resolvedCSSPath := settings.CustomCSSPath
 	if *css != "" {
 		resolvedCSSPath = *css
@@ -59,7 +111,7 @@ func main() {
 
 	warn := &photogen.WarnCollector{}
 	cfg := &photogen.Config{
-		OutputRoot:  filepath.Clean(resolvedOutputDir),
+		OutputRoot:  filepath.Clean(resolvedAlbumsDir),
 		SiteID:      resolvedSiteID,
 		DryRun:      !(*doit),
 		SkipVariant: true,

--- a/config/albums.example.yaml
+++ b/config/albums.example.yaml
@@ -6,24 +6,18 @@
 #
 # CLI flags override YAML settings when provided:
 #   -site-url   overrides settings.site_url
-#   -out        overrides settings.output_dir
+#   -out        overrides DDPHOTOS_ALBUMS_DIR
 #   -album      filters to specific slugs (comma-separated)
 #   -workers    sets concurrent resize workers
 # =============================================================================
 
 settings:
-  # Site identifier — used to name the output directory: web/albums/{id}
+  # Site identifier — used to name the output directory: {DDPHOTOS_ALBUMS_DIR}/{id}
   # Lowercase letters, digits, and hyphens only (e.g. "prod", "my-site").
-  # Symlink web/static/albums -> albums-{id} to make the site live.
   id: my-site
 
   # Base URL used when generating sitemap.xml
   site_url: https://photos.example.com
-
-  # Where to write generated images and JSON. Relative paths are resolved from
-  # the working directory when photogen is run. Output lands in {output_dir}/albums/{id}/
-  # so set this to web/ (not web/static/) to keep generated dirs outside the static tree.
-  output_dir: web
 
   # Descriptions file (relative to this config dir). Each line:
   #   slug<whitespace>description

--- a/config/defaults.env
+++ b/config/defaults.env
@@ -1,0 +1,4 @@
+# Default albums directory (relative to repo root) and site ID.
+# Override via environment variable or SITE_ENV when building for a specific site.
+DDPHOTOS_ALBUMS_DIR=albums
+DDPHOTOS_SITE_ID=sample

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -863,3 +863,56 @@ Added an optional full-width banner image to the home page, configured in `album
 **`cmd/photogen/photogen.go`** — added `-hero-only` boolean flag. When set, photogen regenerates the hero image and exits immediately, skipping all album processing, JSON/index generation, sitemap, CSS copying, and clean. It forces `Config.Force = true` so the existing `hero.jpg` is always overwritten. Exits with an error if no hero is configured in `albums.yaml`.
 
 **`README-DEV.md`** — added `-hero-only` to the CLI flags table; added a usage note and example command under the Hero Image section.
+
+### 52. Decouple Album Data from Web Directory (branch: `decouple`)
+
+The symlink-based approach for serving album data (`web/static/albums` → `web/albums/<site-id>`) was replaced with two environment variables (`DDPHOTOS_ALBUMS_DIR`, `DDPHOTOS_SITE_ID`) and a new per-site build output structure (`build/<site-id>/`). This eliminates the need for manual symlink management and allows multiple site builds to coexist.
+
+#### Core Architecture Change
+
+**Before:** `photogen` wrote output to `web/albums/<site-id>/`; a `web/static/albums` symlink pointed at the active site; the SvelteKit build consumed files via that symlink; Docker mounted `web/` with DocumentRoot at `web/build/`.
+
+**After:** `photogen` writes output to `albums/<site-id>/` at the repo root (set via `output_dir: .` in `albums.yaml`). Two env vars — `DDPHOTOS_ALBUMS_DIR` (default: `albums`) and `DDPHOTOS_SITE_ID` (default: `sample`) — select the active site. The SvelteKit build outputs to `build/<site-id>/`. Docker mounts `build/` and `albums/<site-id>/` separately, with `entrypoint.sh` creating all symlinks inside the container.
+
+#### Files Changed
+
+**`config/defaults.env`** (new) — single source of truth for default values of `DDPHOTOS_ALBUMS_DIR` and `DDPHOTOS_SITE_ID`; read by both the Makefile and `vite.config.ts`.
+
+**`web/svelte.config.js`** — adapter output dir is now dynamic: `pages`/`assets` set to `../build/${siteId}` so each site ID gets its own build directory at the repo root.
+
+**`web/vite.config.ts`** — added `loadDefaultsEnv()` to read `config/defaults.env` as a lower-priority fallback; added `resolveAlbumsDir()` combining `DDPHOTOS_ALBUMS_DIR` + `DDPHOTOS_SITE_ID`; replaced the static-reload plugin with `albums-dev-server` plugin that serves `/albums/**` from the resolved albums dir via middleware and watches it for live reload.
+
+**`web/src/hooks.server.ts`** (new) — build-time hook; `handleFetch` intercepts `fetch()` calls to `/albums/**` during `npm run build` and reads the files directly from disk, eliminating the need for any symlink at build time.
+
+**`web/svelte.config.js`** — added `handleHttpError` to `prerender` config to silently ignore 404s on `/albums/**` paths (images and other assets are not pre-rendered, only served at runtime).
+
+**`web/Dockerfile`** — removed DocumentRoot `sed` lines (no longer needed); kept `mod_rewrite`, `AllowOverride All`, `FollowSymLinks`, `ServerName`; updated to use `entrypoint.sh` for container startup.
+
+**`web/entrypoint.sh`** (rewritten) — populates `/usr/local/apache2/htdocs` with symlinks at container startup: (1) uses `find` (not glob, so `.htaccess` is included) to symlink everything from `/build/<site-id>/` except `albums/`; (2) creates `htdocs/albums/` as a real directory; (3) symlinks `*.html` files from `/build/<site-id>/albums/` (pre-rendered album pages); (4) symlinks everything from `/albums/` (photogen output: image dirs, JSON). All symlinks live inside the container — nothing dangling is left on the host.
+
+**`web/static/albums/README.md`** — removed; was only needed as a Docker mountpoint placeholder, which is no longer required.
+
+**`web/.gitignore`** — removed `/build` entry (build output no longer lives in `web/`).
+
+**`.gitignore`** — added `/build` (new output location at repo root).
+
+**`Makefile`** — removed all `use-sample*`, `use-prod`, `use-sample-css`, `use-sample-demo` symlink targets; added migration check (`$(warning)` + `$(error)`) if `web/albums/` still exists; `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID` read from `config/defaults.env` via `sed` (using `?=` to allow env var override); all npm build/dev targets pass the two env vars; `web-docker-run` updated to mount `$(PWD)/build:/build:ro` and pass `-e DDPHOTOS_SITE_ID`.
+
+**`sample/config/albums.yaml`** and **`infra/photos/*/albums.yaml`** — changed `output_dir: web` → `output_dir: .`.
+
+**`bin/run-tests.sh`** — removed symlink step; Docker run updated to mount `$(pwd)/build:/build:ro` and pass `-e DDPHOTOS_SITE_ID`; removed `mkdir -p web/build/albums`.
+
+**`bin/deploy-photos.sh`** — added `--site-env` flag (separate from `--config-dir`) for specifying `site.env` location independently; added `--dry-run` flag that passes `--dry-run` to both rsync calls and skips CloudFront invalidation and post-deploy tests; added early guards for `AWS_APACHE`, `RSYNC_DEST`, `CLOUDFRONT_ID`, `VITE_SITE_URL` (prevents rsync `--delete` targeting wrong path if a var is unset); enforces trailing `/` on `RSYNC_DEST`; stored `REPO_ROOT` before `cd web`; Docker run updated to new mount strategy; removed `find build/albums -type l -delete` (no longer needed); rsync source changed from `build/` to `$REPO_ROOT/build/$DDPHOTOS_SITE_ID/`.
+
+**`infra/Makefile`** — added `DDPHOTOS_ALBUMS`; removed all `ddphotos-use-*` targets; all deploy targets pass `DDPHOTOS_ALBUMS_DIR` and `DDPHOTOS_SITE_ID` inline.
+
+**`bin/search_cover.sh`** — updated stale `web/albums` path to `albums`.
+
+**`README.md`** and **`README-DEV.md`** — updated throughout: removed symlink-based workflow, updated output paths (`web/albums/` → `albums/`, `web/build` → `build/<site-id>`), removed `use-*` targets from Makefile table, added "Album Location Variables" section documenting `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID`, added `bin/search_cover.sh` section, removed Python static server section (no longer viable), updated Docker/Apache description.
+
+#### Key Design Decisions
+
+- **No Docker restart on rebuild**: `build/` (parent) is mounted rather than `build/<site-id>/` (the actual output dir), so npm rebuilds that delete and recreate `build/<site-id>/` don't break the bind mount's inode binding.
+- **Dangling symlinks eliminated**: all symlinks live inside the container's writable layer; the host filesystem is never written to by Docker.
+- **Rsync safety**: two-pass rsync strategy — pass 1 syncs app files + pre-rendered HTML (excludes album image subdirs); pass 2 syncs album data (excludes `*.html` so pre-rendered pages aren't deleted). Early variable guards prevent `--delete` from targeting an empty or wrong remote path.
+- **Migration**: Makefile detects if `web/albums/` still exists (old layout) and aborts with instructions to run `mv web/albums albums/`. Git cleanly replaces the old `web/static/albums` symlink with the new `web/static/albums/` directory on branch checkout.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -898,7 +898,7 @@ The symlink-based approach for serving album data (`web/static/albums` → `web/
 
 **`Makefile`** — removed all `use-sample*`, `use-prod`, `use-sample-css`, `use-sample-demo` symlink targets; added migration check (`$(warning)` + `$(error)`) if `web/albums/` still exists; `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID` read from `config/defaults.env` via `sed` (using `?=` to allow env var override); all npm build/dev targets pass the two env vars; `web-docker-run` updated to mount `$(PWD)/build:/build:ro` and pass `-e DDPHOTOS_SITE_ID`.
 
-**`sample/config/albums.yaml`** and **`infra/photos/*/albums.yaml`** — changed `output_dir: web` → `output_dir: .`.
+**`sample/config/albums.yaml`** and **`infra/photos/*/albums.yaml`** — removed `output_dir` entirely (now driven by `DDPHOTOS_ALBUMS_DIR`).
 
 **`bin/run-tests.sh`** — removed symlink step; Docker run updated to mount `$(pwd)/build:/build:ro` and pass `-e DDPHOTOS_SITE_ID`; removed `mkdir -p web/build/albums`.
 
@@ -909,6 +909,22 @@ The symlink-based approach for serving album data (`web/static/albums` → `web/
 **`bin/search_cover.sh`** — updated stale `web/albums` path to `albums`.
 
 **`README.md`** and **`README-DEV.md`** — updated throughout: removed symlink-based workflow, updated output paths (`web/albums/` → `albums/`, `web/build` → `build/<site-id>`), removed `use-*` targets from Makefile table, added "Album Location Variables" section documenting `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID`, added `bin/search_cover.sh` section, removed Python static server section (no longer viable), updated Docker/Apache description.
+
+#### Eliminating `settings.output_dir` from `albums.yaml`
+
+`output_dir` was removed entirely from the YAML schema. `photogen` now reads its output directory from `DDPHOTOS_ALBUMS_DIR` (env var), falling back to `config/defaults.env`, with the `-out` CLI flag as an explicit override.
+
+**`pkg/photogen/config.go`** — `SiteOutputPath()` simplified: no longer inserts an `albums/` component. `OutputRoot` is now the albums dir itself (e.g. `albums/`), so `SiteOutputPath()` = `OutputRoot/SiteID`.
+
+**`pkg/photogen/albums_config.go`** — removed `OutputDir` field from `AlbumsSettings`.
+
+**`cmd/photogen/photogen.go`** — added `repoRoot` var embedded at build time via `-ldflags "-X main.repoRoot=$(PWD)"`; `loadDefaultsEnv()` tries the compile-time repo root first, then falls back to cwd-relative `config/defaults.env` (so `go run ./cmd/photogen` still works from the repo root); fails fast with a clear error if `DDPHOTOS_ALBUMS_DIR` is still unresolved after all attempts.
+
+**`Makefile`** — `build` target updated to pass `-ldflags "-X main.repoRoot=$(PWD)"`.
+
+**Tests** (`config_test.go`, `albums_config_test.go`, `json_test.go`, `testdata/albums.yaml`) — updated to match new path structure; `OutputDir` references removed.
+
+**`config/albums.example.yaml`** — removed `output_dir` setting; updated comments to reference `DDPHOTOS_ALBUMS_DIR`.
 
 #### Key Design Decisions
 

--- a/pkg/photogen/albums_config.go
+++ b/pkg/photogen/albums_config.go
@@ -18,9 +18,8 @@ type AlbumsFile struct {
 
 // AlbumsSettings holds site-level configuration from the YAML settings block.
 type AlbumsSettings struct {
-	ID           string     `yaml:"id"` // site identifier; output goes to albums-{id}/
+	ID           string     `yaml:"id"` // site identifier; output goes to {DDPHOTOS_ALBUMS_DIR}/{id}/
 	SiteURL      string     `yaml:"site_url"`
-	OutputDir    string     `yaml:"output_dir"`
 	Descriptions string     `yaml:"descriptions"` // filename relative to config dir
 	Passwords    string     `yaml:"passwords"`    // filename relative to config dir; enables encryption
 	CustomCSS    string     `yaml:"css"`          // filename relative to config dir; copied to output

--- a/pkg/photogen/albums_config_test.go
+++ b/pkg/photogen/albums_config_test.go
@@ -18,7 +18,6 @@ func TestLoadAlbumsFile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://photos.example.com", af.Settings.SiteURL)
-		assert.Equal(t, "web/static", af.Settings.OutputDir)
 		assert.Equal(t, "descriptions.txt", af.Settings.Descriptions)
 
 		assert.Equal(t, "/Volumes/T7/Photos", af.Bases["t7"])
@@ -289,7 +288,6 @@ func TestLoadAlbumConfigs(t *testing.T) {
 			[]byte(`
 settings:
   site_url: https://my.example.com
-  output_dir: /tmp/output
   descriptions: descriptions.txt
 albums:
   - slug: myalbum
@@ -306,7 +304,6 @@ albums:
 		assert.Equal(t, "A great album.", configs[0].Description)
 		assert.Equal(t, photoDir, configs[0].Path)
 		assert.Equal(t, "https://my.example.com", settings.SiteURL)
-		assert.Equal(t, "/tmp/output", settings.OutputDir)
 	})
 
 	t.Run("missing albums file", func(t *testing.T) {

--- a/pkg/photogen/config.go
+++ b/pkg/photogen/config.go
@@ -92,9 +92,11 @@ func (c *Config) Validate() error {
 }
 
 // SiteOutputPath returns the root output directory for all photogen-generated content:
-// {OutputRoot}/albums/{SiteID}[/parts...]
+// {OutputRoot}/{SiteID}[/parts...]
+// OutputRoot is the albums directory (e.g. "albums" or an absolute path), set from
+// DDPHOTOS_ALBUMS_DIR. The SiteID subdirectory is appended automatically.
 func (c *Config) SiteOutputPath(parts ...string) string {
-	base := []string{c.OutputRoot, "albums", c.SiteID}
+	base := []string{c.OutputRoot, c.SiteID}
 	return filepath.Join(append(base, parts...)...)
 }
 

--- a/pkg/photogen/config_test.go
+++ b/pkg/photogen/config_test.go
@@ -85,8 +85,8 @@ func TestConfigValidate(t *testing.T) {
 func TestConfigSiteOutputPath(t *testing.T) {
 	t.Parallel()
 
-	cfg := Config{OutputRoot: "/tmp/out", SiteID: "prod"}
-	assert.Equal(t, "/tmp/out/albums/prod", cfg.SiteOutputPath())
-	assert.Equal(t, "/tmp/out/albums/prod/albums.json", cfg.SiteOutputPath("albums.json"))
-	assert.Equal(t, "/tmp/out/albums/prod/theway/grid/photo.webp", cfg.SiteOutputPath("theway", "grid", "photo.webp"))
+	cfg := Config{OutputRoot: "/tmp/albums", SiteID: "prod"}
+	assert.Equal(t, "/tmp/albums/prod", cfg.SiteOutputPath())
+	assert.Equal(t, "/tmp/albums/prod/albums.json", cfg.SiteOutputPath("albums.json"))
+	assert.Equal(t, "/tmp/albums/prod/theway/grid/photo.webp", cfg.SiteOutputPath("theway", "grid", "photo.webp"))
 }

--- a/pkg/photogen/json_test.go
+++ b/pkg/photogen/json_test.go
@@ -143,9 +143,9 @@ func TestWriteAlbumIndex(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, makeAP(dir, nil).WriteAlbumIndex())
 
-		outPath := filepath.Join(dir, "albums", "testsite", "myalbum", "index.json")
+		outPath := filepath.Join(dir, "testsite", "myalbum", "index.json")
 		assert.FileExists(t, outPath)
-		assert.NoFileExists(t, filepath.Join(dir, "albums", "testsite", "myalbum", "index.enc.json"))
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "myalbum", "index.enc.json"))
 
 		idx, err := LoadAlbumIndex(outPath)
 		require.NoError(t, err)
@@ -161,9 +161,9 @@ func TestWriteAlbumIndex(t *testing.T) {
 		encrypt := &EncryptConfig{SitePassword: "test-pass"}
 		require.NoError(t, makeAP(dir, encrypt).WriteAlbumIndex())
 
-		encPath := filepath.Join(dir, "albums", "testsite", "myalbum", "index.enc.json")
+		encPath := filepath.Join(dir, "testsite", "myalbum", "index.enc.json")
 		assert.FileExists(t, encPath)
-		assert.NoFileExists(t, filepath.Join(dir, "albums", "testsite", "myalbum", "index.json"))
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "myalbum", "index.json"))
 
 		data, err := os.ReadFile(encPath)
 		require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestWriteAlbumIndex(t *testing.T) {
 	t.Run("switching to unencrypted removes stale index.enc.json", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		albumDir := filepath.Join(dir, "albums", "testsite", "myalbum")
+		albumDir := filepath.Join(dir, "testsite", "myalbum")
 		require.NoError(t, os.MkdirAll(albumDir, 0o755))
 
 		staleEnc := filepath.Join(albumDir, "index.enc.json")
@@ -204,9 +204,9 @@ func TestWriteAlbumsIndex(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, makeSiteCfg(dir, nil).WriteAlbumsIndex(summaries))
 
-		outPath := filepath.Join(dir, "albums", "testsite", "albums.json")
+		outPath := filepath.Join(dir, "testsite", "albums.json")
 		assert.FileExists(t, outPath)
-		assert.NoFileExists(t, filepath.Join(dir, "albums", "testsite", "albums.enc.json"))
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "albums.enc.json"))
 
 		loaded, err := LoadAlbumSummaries(outPath)
 		require.NoError(t, err)
@@ -220,9 +220,9 @@ func TestWriteAlbumsIndex(t *testing.T) {
 		encrypt := &EncryptConfig{SitePassword: "site-pass"}
 		require.NoError(t, makeSiteCfg(dir, encrypt).WriteAlbumsIndex(summaries))
 
-		encPath := filepath.Join(dir, "albums", "testsite", "albums.enc.json")
+		encPath := filepath.Join(dir, "testsite", "albums.enc.json")
 		assert.FileExists(t, encPath)
-		assert.NoFileExists(t, filepath.Join(dir, "albums", "testsite", "albums.json"))
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "albums.json"))
 
 		data, err := os.ReadFile(encPath)
 		require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestWriteAlbumsIndex(t *testing.T) {
 	t.Run("switching to unencrypted removes stale albums.enc.json", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		siteDir := filepath.Join(dir, "albums", "testsite")
+		siteDir := filepath.Join(dir, "testsite")
 		require.NoError(t, os.MkdirAll(siteDir, 0o755))
 
 		staleEnc := filepath.Join(siteDir, "albums.enc.json")
@@ -253,7 +253,7 @@ func TestWriteConfigJSON(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, makeSiteCfg(dir, nil).WriteConfigJSON())
 
-		data, err := os.ReadFile(filepath.Join(dir, "albums", "testsite", "config.json"))
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"siteId": "testsite"`)
 		assert.Contains(t, string(data), `"albumsFile": "albums.json"`)
@@ -265,7 +265,7 @@ func TestWriteConfigJSON(t *testing.T) {
 		encrypt := &EncryptConfig{SitePassword: "passw0rd"}
 		require.NoError(t, makeSiteCfg(dir, encrypt).WriteConfigJSON())
 
-		data, err := os.ReadFile(filepath.Join(dir, "albums", "testsite", "config.json"))
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"siteId": "testsite"`)
 		assert.Contains(t, string(data), `"albumsFile": "albums.enc.json"`)

--- a/pkg/photogen/testdata/albums.yaml
+++ b/pkg/photogen/testdata/albums.yaml
@@ -5,7 +5,6 @@
 
 settings:
   site_url: https://photos.example.com
-  output_dir: web/static
   descriptions: descriptions.txt
 
 bases:

--- a/sample/config/albums.yaml
+++ b/sample/config/albums.yaml
@@ -1,7 +1,6 @@
 settings:
   id: sample
   site_url: https://sample.donohoe.info
-  output_dir: .
   descriptions: descriptions.txt
   hero:
     image: theway/2024-The-Way-13.jpg

--- a/sample/config/albums.yaml
+++ b/sample/config/albums.yaml
@@ -1,7 +1,7 @@
 settings:
   id: sample
   site_url: https://sample.donohoe.info
-  output_dir: web
+  output_dir: .
   descriptions: descriptions.txt
   hero:
     image: theway/2024-The-Way-13.jpg

--- a/sample/config/site.env
+++ b/sample/config/site.env
@@ -1,6 +1,6 @@
 # Site identity — consumed by Vite (VITE_* prefix) and bin/ scripts
 VITE_SITE_NAME="Sample Photo Albums"
-VITE_SITE_URL=https://samples.donohoe.info
+VITE_SITE_URL=https://sample.donohoe.info
 VITE_SITE_DESCRIPTION="Photo albums from our travels and adventures"
 VITE_COPYRIGHT_OWNER="Doug and Cindy Donohoe"
 VITE_COPYRIGHT_YEAR=2001

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -6,7 +6,6 @@ node_modules
 .netlify
 .wrangler
 /.svelte-kit
-/build
 
 # OS
 .DS_Store

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -26,7 +26,6 @@ vite.config.ts.timestamp-*
 /test-results
 /playwright-report
 
-# Generated photo albums
-/static/albums
+# Generated photo albums (sitemap.xml is generated; static/albums/ is a committed placeholder dir)
 /static/sitemap.xml
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,13 @@ RUN sed -i 's|DocumentRoot "/usr/local/apache2/htdocs"|DocumentRoot "/usr/local/
     && sed -i 's|<Directory "/usr/local/apache2/htdocs">|<Directory "/usr/local/apache2/htdocs/build">|g' /usr/local/apache2/conf/httpd.conf \
     && sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/apache2/conf/httpd.conf \
     && sed -i 's/AllowOverride None/AllowOverride All/g' /usr/local/apache2/conf/httpd.conf \
-    && echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
+    && echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf \
+    && printf '\n<Directory "/usr/local/apache2/htdocs/build">\n    Options +FollowSymLinks\n</Directory>\n' >> /usr/local/apache2/conf/httpd.conf
 
-# web/ dir is mounted at runtime via -v; nothing to COPY here.
-# docker run --rm -p 8080:80 -v $(PWD)/web:/usr/local/apache2/htdocs:ro photos-apache
+# entrypoint.sh symlinks album data from /albums into build/albums/ at startup,
+# then hands off to httpd-foreground.
+COPY entrypoint.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]
+
+# web/ dir is mounted at runtime via -v; album data at /albums; nothing to COPY here.
+# docker run --rm -p 8080:80 -v $(PWD)/web:/usr/local/apache2/htdocs -v $ALBUMS_DIR/$SITE_ID:/albums:ro photos-apache

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,5 @@
 FROM httpd:2.4
+LABEL ddphotos.schema="2"
 
 # Enable mod_rewrite, AllowOverride for .htaccess, FollowSymLinks for entrypoint symlinks.
 RUN sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/apache2/conf/httpd.conf \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,19 +1,17 @@
 FROM httpd:2.4
 
-# Point DocumentRoot at build/ inside the mounted web/ directory.
-# Mounting web/ (not web/build/) means npm rebuilds, which delete and
-# recreate build/, don't break the bind mount's inode binding.
-RUN sed -i 's|DocumentRoot "/usr/local/apache2/htdocs"|DocumentRoot "/usr/local/apache2/htdocs/build"|g' /usr/local/apache2/conf/httpd.conf \
-    && sed -i 's|<Directory "/usr/local/apache2/htdocs">|<Directory "/usr/local/apache2/htdocs/build">|g' /usr/local/apache2/conf/httpd.conf \
-    && sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/apache2/conf/httpd.conf \
+# Enable mod_rewrite, AllowOverride for .htaccess, FollowSymLinks for entrypoint symlinks.
+RUN sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/apache2/conf/httpd.conf \
     && sed -i 's/AllowOverride None/AllowOverride All/g' /usr/local/apache2/conf/httpd.conf \
     && echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf \
-    && printf '\n<Directory "/usr/local/apache2/htdocs/build">\n    Options +FollowSymLinks\n</Directory>\n' >> /usr/local/apache2/conf/httpd.conf
+    && printf '\n<Directory "/usr/local/apache2/htdocs">\n    Options +FollowSymLinks\n</Directory>\n' >> /usr/local/apache2/conf/httpd.conf
 
-# entrypoint.sh symlinks album data from /albums into build/albums/ at startup,
-# then hands off to httpd-foreground.
+# entrypoint.sh populates /usr/local/apache2/htdocs with symlinks into /build/<site-id>
+# and /albums at container startup, then hands off to httpd-foreground.
 COPY entrypoint.sh /entrypoint.sh
 CMD ["/entrypoint.sh"]
 
-# web/ dir is mounted at runtime via -v; album data at /albums; nothing to COPY here.
-# docker run --rm -p 8080:80 -v $(PWD)/web:/usr/local/apache2/htdocs -v $ALBUMS_DIR/$SITE_ID:/albums:ro photos-apache
+# Mounts at runtime:
+#   -v <root>/build:/build:ro
+#   -v <root>/albums/<site-id>:/albums:ro
+#   -e DDPHOTOS_SITE_ID=<site-id>

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,31 +1,45 @@
 #!/bin/sh
 set -e
 
-# Symlink album data from /albums (the external mount) into build/albums/ so
-# Apache can serve images alongside the pre-rendered .html pages.
+# Populate /usr/local/apache2/htdocs with symlinks so Apache can serve the site.
 #
-# Only items not already present in build/albums/ get a symlink — this preserves
-# pre-rendered files (antarctica.html, config.json, etc.) from the build step.
-# Existing dangling symlinks (from a previous container run) are refreshed.
+# Mounts:
+#   /build        — <root>/build  (all site builds)
+#   /albums       — <root>/albums/<site-id>  (photogen output: image dirs + JSON)
+#
+# Strategy:
+#   1. Symlink everything from /build/<site-id>/ into htdocs/, except albums/.
+#   2. Create htdocs/albums/ as a real directory, then populate it with:
+#        - symlinks to *.html files from /build/<site-id>/albums/  (pre-rendered pages)
+#        - symlinks to everything in /albums/                       (image dirs, JSON, etc.)
+#
+# All symlinks live inside the container — nothing dangling is left on the host.
 
-BUILD_ALBUMS=/usr/local/apache2/htdocs/build/albums
+SITE_ID="${DDPHOTOS_SITE_ID:-sample}"
+BUILD_SITE="/build/$SITE_ID"
+HTDOCS="/usr/local/apache2/htdocs"
 
-for item in /albums/*; do
-    [ -e "$item" ] || continue          # skip if glob matched nothing
+# 1. Symlink build output into htdocs (skip albums/ — handled separately below).
+# Use find rather than glob so dotfiles like .htaccess are included.
+find "$BUILD_SITE" -maxdepth 1 -mindepth 1 | while IFS= read -r item; do
     name=$(basename "$item")
-    target="$BUILD_ALBUMS/$name"
-    if [ -d "$item" ]; then
-        # Album slug directory: always replace with a symlink to /albums/<slug>.
-        # The pre-rendered dir only has index.json; images live in /albums/<slug>.
-        # The symlink serves index.json correctly (identical content).
-        rm -rf "$target"
-        ln -s "$item" "$target"
-    elif [ -L "$target" ]; then
-        ln -sf "$item" "$target"        # refresh existing file symlink
-    elif [ ! -e "$target" ]; then
-        ln -s "$item" "$target"         # create symlink for files not in build
-    fi
-    # real file already exists (pre-rendered .html / .json) — leave it alone
+    [ "$name" = "albums" ] && continue
+    ln -sf "$item" "$HTDOCS/$name"
+done
+
+# 2. Create htdocs/albums/ and populate with symlinks
+mkdir -p "$HTDOCS/albums"
+
+# Pre-rendered album HTML pages from the build
+for item in "$BUILD_SITE/albums"/*.html; do
+    [ -e "$item" ] || continue
+    ln -sf "$item" "$HTDOCS/albums/$(basename "$item")"
+done
+
+# Album data (image dirs, albums.json, sitemap.xml, etc.) from the photogen mount
+for item in /albums/*; do
+    [ -e "$item" ] || continue
+    ln -sf "$item" "$HTDOCS/albums/$(basename "$item")"
 done
 
 exec httpd-foreground

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# Symlink album data from /albums (the external mount) into build/albums/ so
+# Apache can serve images alongside the pre-rendered .html pages.
+#
+# Only items not already present in build/albums/ get a symlink — this preserves
+# pre-rendered files (antarctica.html, config.json, etc.) from the build step.
+# Existing dangling symlinks (from a previous container run) are refreshed.
+
+BUILD_ALBUMS=/usr/local/apache2/htdocs/build/albums
+
+for item in /albums/*; do
+    [ -e "$item" ] || continue          # skip if glob matched nothing
+    name=$(basename "$item")
+    target="$BUILD_ALBUMS/$name"
+    if [ -d "$item" ]; then
+        # Album slug directory: always replace with a symlink to /albums/<slug>.
+        # The pre-rendered dir only has index.json; images live in /albums/<slug>.
+        # The symlink serves index.json correctly (identical content).
+        rm -rf "$target"
+        ln -s "$item" "$target"
+    elif [ -L "$target" ]; then
+        ln -sf "$item" "$target"        # refresh existing file symlink
+    elif [ ! -e "$target" ]; then
+        ln -s "$item" "$target"         # create symlink for files not in build
+    fi
+    # real file already exists (pre-rendered .html / .json) — leave it alone
+done
+
+exec httpd-foreground

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,0 +1,45 @@
+// hooks.server.ts — build-time hook (not the dev server).
+//
+// handleFetch intercepts fetch() calls made in SvelteKit load functions (+page.ts)
+// during `npm run build` prerendering. In practice only JSON files are fetched here
+// (config.json, albums.json, index.json, etc.) — images are just strings in the
+// rendered HTML and are never fetched server-side.
+//
+// Dev server asset serving (/albums/**) is handled separately in vite.config.ts.
+// At runtime (Apache/Docker), neither applies — Apache serves everything directly.
+
+import { readFileSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import type { Handle, HandleFetch } from '@sveltejs/kit';
+
+// Resolve albums dir the same way vite.config.ts does (repo-root-relative default).
+function resolveAlbumsDir(): string {
+	const albumsDir = process.env.DDPHOTOS_ALBUMS_DIR ?? 'albums';
+	const siteId = process.env.DDPHOTOS_SITE_ID ?? 'sample';
+	// __dirname is web/src; repo root is two levels up
+	const root = resolve(import.meta.dirname, '..', '..');
+	const base = albumsDir.startsWith('/') ? albumsDir : resolve(root, albumsDir);
+	return join(base, siteId);
+}
+const albumsDir = resolveAlbumsDir();
+
+// During prerender, SvelteKit fetch('/albums/...') calls never hit a real server.
+// Intercept them and read directly from the filesystem instead.
+export const handleFetch: HandleFetch = async ({ request, fetch }) => {
+	const url = new URL(request.url);
+	if (url.pathname.startsWith('/albums/')) {
+		const filePath = join(albumsDir, url.pathname.slice('/albums/'.length));
+		if (existsSync(filePath)) {
+			const body = readFileSync(filePath);
+			const ext = filePath.split('.').pop() ?? '';
+			const contentType =
+				ext === 'json' ? 'application/json' :
+				ext === 'webp' ? 'image/webp' :
+				'application/octet-stream';
+			return new Response(body, { headers: { 'Content-Type': contentType } });
+		}
+	}
+	return fetch(request);
+};
+
+export const handle: Handle = async ({ event, resolve }) => resolve(event);

--- a/web/static/albums/README.md
+++ b/web/static/albums/README.md
@@ -1,7 +1,0 @@
-# albums placeholder
-
-This directory exists so that `adapter-static` copies it to `web/build/albums/`,
-giving Docker a mountpoint for the second `-v` bind mount at runtime.
-
-The actual album data (JSON + images) lives outside the build, in the directory
-pointed to by `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (see `config/defaults.env`).

--- a/web/static/albums/README.md
+++ b/web/static/albums/README.md
@@ -1,0 +1,7 @@
+# albums placeholder
+
+This directory exists so that `adapter-static` copies it to `web/build/albums/`,
+giving Docker a mountpoint for the second `-v` bind mount at runtime.
+
+The actual album data (JSON + images) lives outside the build, in the directory
+pointed to by `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (see `config/defaults.env`).

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -1,9 +1,13 @@
 import adapter from '@sveltejs/adapter-static';
 import { readdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * Return /albums/<slug> prerender entries for every album directory found under
- * static/albums/ (which may be a symlink to the active album set).
+ * DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID.
  *
  * This is necessary for encrypted builds: when all albums require a password the
  * SvelteKit crawler never finds links to album pages, so without explicit entries
@@ -13,7 +17,12 @@ import { readdirSync } from 'fs';
  */
 function albumEntries() {
 	try {
-		return readdirSync('static/albums', { withFileTypes: true })
+		const albumsDir = process.env.DDPHOTOS_ALBUMS_DIR ?? 'albums';
+		const siteId = process.env.DDPHOTOS_SITE_ID ?? 'sample';
+		const root = resolve(__dirname, '..');
+		const base = albumsDir.startsWith('/') ? albumsDir : resolve(root, albumsDir);
+		const dir = join(base, siteId);
+		return readdirSync(dir, { withFileTypes: true })
 			.filter((d) => d.isDirectory())
 			.map((d) => `/albums/${d.name}`);
 	} catch {
@@ -35,7 +44,13 @@ const config = {
 			relative: false
 		},
 		prerender: {
-			entries: ['*', ...albumEntries()]
+			entries: ['*', ...albumEntries()],
+			handleHttpError: ({ path, message }) => {
+				// Album assets (/albums/**) are served at runtime, not prerendered.
+				// Ignore 404s the crawler encounters for images, JSON, etc.
+				if (path.startsWith('/albums/')) return;
+				throw new Error(message);
+			}
 		}
 	}
 };

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -30,12 +30,14 @@ function albumEntries() {
 	}
 }
 
+const siteId = process.env.DDPHOTOS_SITE_ID ?? 'sample';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
 		adapter: adapter({
-			pages: 'build',
-			assets: 'build',
+			pages: `../build/${siteId}`,
+			assets: `../build/${siteId}`,
 			fallback: null,
 			precompress: false,
 			strict: true

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'fs';
-import { resolve, dirname } from 'path';
+import { readFileSync, existsSync, createReadStream, statSync } from 'fs';
+import { resolve, join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
@@ -28,6 +28,37 @@ function loadSiteEnv() {
 	}
 }
 loadSiteEnv();
+
+// Load defaults.env (lower priority than site.env — only fills gaps)
+function loadDefaultsEnv() {
+	const path = resolve(__dirname, '..', 'config', 'defaults.env');
+	if (!existsSync(path)) return;
+	for (const line of readFileSync(path, 'utf-8').split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+		const eq = trimmed.indexOf('=');
+		if (eq < 0) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+			val = val.slice(1, -1);
+		}
+		if (!(key in process.env)) process.env[key] = val;
+	}
+}
+loadDefaultsEnv();
+
+// Full path to the active site's album data: DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID
+// Paths in defaults.env are repo-root-relative; absolute paths are used as-is.
+function resolveAlbumsDir(): string {
+	const albumsDir = process.env.DDPHOTOS_ALBUMS_DIR ?? 'albums';
+	const siteId = process.env.DDPHOTOS_SITE_ID ?? 'sample';
+	const root = resolve(__dirname, '..');
+	const base = albumsDir.startsWith('/') ? albumsDir : resolve(root, albumsDir);
+	return join(base, siteId);
+}
+const albumsDir = resolveAlbumsDir();
+
 process.env.VITE_BUILD_TIME = new Date().toISOString();
 
 export default defineConfig({
@@ -36,15 +67,21 @@ export default defineConfig({
 	},
 	plugins: [
 		sveltekit(),
-		// Custom plugin to trigger browser reload when static files change.
-		// By default, Vite doesn't reload the browser when files in static/ are modified
-		// (e.g., albums.json). This plugin watches for changes in the static directory
-		// and sends a full-reload signal to the browser via WebSocket.
 		{
-			name: 'static-reload',
+			name: 'albums-dev-server',
 			configureServer(server) {
+				// Serve DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID at /albums/** during dev.
+				server.middlewares.use('/albums', (req, res, next) => {
+					const filePath = join(albumsDir, req.url ?? '/');
+					let stat;
+					try { stat = statSync(filePath); } catch { return next(); }
+					if (!stat.isFile()) return next();
+					createReadStream(filePath).pipe(res);
+				});
+				// Reload browser when album data changes.
+				server.watcher.add(albumsDir);
 				server.watcher.on('change', (path) => {
-					if (path.includes('/static/')) {
+					if (path.startsWith(albumsDir)) {
 						server.ws.send({ type: 'full-reload' });
 					}
 				});


### PR DESCRIPTION
## Summary

Replaces the symlink-based approach for serving album data with environment variables and a cleaner directory structure, eliminating manual symlink management and allowing multiple site builds to coexist.

### Core Architecture Change

**Before:** `photogen` wrote to `web/albums/<site-id>/`; a `web/static/albums` symlink pointed at the active site; Docker mounted `web/` with DocumentRoot at `web/build/`.

**After:** Two env vars — `DDPHOTOS_ALBUMS_DIR` (default: `albums`) and `DDPHOTOS_SITE_ID` (default: `sample`) — select the active site. `photogen` writes to `albums/<site-id>/` at the repo root. The SvelteKit build outputs to `build/<site-id>/`. Docker mounts `build/` and `albums/<site-id>/` separately; `entrypoint.sh` creates all symlinks inside the container so nothing dangling is left on the host.

### Key Changes

#### photogen
- **`settings.output_dir` eliminated** from `albums.yaml` — the output directory is now controlled entirely by env var / CLI flag, not embedded in config files.
- **`DDPHOTOS_ALBUMS_DIR` env var** is the new source of truth for the albums output directory; `config/defaults.env` is loaded as fallback; `-out` flag overrides all. Fails fast with a clear error if none of these resolve.
- **Compile-time `repoRoot`** embedded via `-ldflags "-X main.repoRoot=..."` so the compiled binary can always locate `defaults.env` regardless of working directory.
- **`SiteOutputPath()` simplified** — now `OutputRoot/SiteID` (no `albums/` component); `OutputRoot` IS the albums dir.

#### Docker
- **`web/entrypoint.sh`** rewritten — populates Apache `htdocs/` with symlinks at container startup: build assets from `/build/<site-id>/` and album data from `/albums/`; uses `find` (not glob) so `.htaccess` is included.
- **`web/Dockerfile`** simplified — removed DocumentRoot `sed` rewrites; Apache serves directly from `htdocs/`. Added `LABEL ddphotos.schema="2"` for stale-image detection.
- **Stale image detection** — `make web-docker-run` and `make sample-test-apache` check the image schema label before running and fail with a clear rebuild instruction; `bin/run-tests.sh` auto-rebuilds if stale.

#### Frontend build
- **`web/vite.config.ts`** — new `albums-dev-server` plugin serves `/albums/**` from the resolved albums dir during dev and watches for live reload.
- **`web/src/hooks.server.ts`** (new) — build-time `handleFetch` hook intercepts `/albums/**` fetches during `npm run build` and reads files directly from disk.

#### Deployment / tooling
- **`bin/deploy-photos.sh`** — added `--dry-run` and `--site-env` flags; added early guards on all rsync-critical vars (`AWS_APACHE`, `RSYNC_DEST`, etc.) to prevent `--delete` targeting a wrong path; two-pass rsync (app files + album data separately).
- **`bin/search_cover.sh`** — respects `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID` to scope search to the active site.
- All `use-sample*` / `use-prod` symlink Makefile targets removed; migration guard added if `web/albums/` still exists.
- Docs updated throughout (`README.md`, `README-DEV.md`, `HISTORY.md`).

### Design Decisions

- **No Docker restart on rebuild**: `build/` (parent dir) is mounted rather than `build/<site-id>/`, so npm rebuilds don't break the bind mount's inode binding.
- **Dangling symlinks eliminated**: all symlinks live inside the container's writable layer only.
- **Rsync safety**: two-pass strategy with early variable guards and `--dry-run` support.

### Migration

Move album data to preserve existing output:

```
mv web/albums albums/
```

Remove old build location, symlink and `sitemap.xml`:

```
rm -f web/build
rm -f web/static/albums
rm -f web/static/sitemap.xml
```

Rebuild Docker image:

```
make web-docker-build
```