### PR TITLE
Add nginx support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,17 @@ jobs:
       - name: Install Playwright system dependencies
         run: cd web && npx playwright install-deps chromium
 
-      - name: Run Apache routing tests
-        run: make sample-photogen sample-build web-docker-build sample-test-apache
+      - name: Photogen and build
+        run: make sample-photogen sample-build
 
-      - name: Run Playwright e2e tests (all password variants, apache)
+      - name: Run Apache routing tests
+        run: make web-docker-build-apache sample-test-apache
+
+      - name: Run nginx routing tests
+        run: make web-docker-build-nginx sample-test-nginx
+
+      - name: Run Apache Playwright e2e tests (all password variants)
         run: bin/test-all.sh --mode apache
 
-      - name: Run Playwright e2e tests (all password variants, nginx)
+      - name: Run nginx Playwright e2e tests (all password variants)
         run: bin/test-all.sh --mode nginx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Run Apache routing tests
         run: make sample-photogen sample-build web-docker-build sample-test-apache
 
-      - name: Run Playwright e2e tests (all password variants)
+      - name: Run Playwright e2e tests (all password variants, apache)
         run: bin/test-all.sh --mode apache
+
+      - name: Run Playwright e2e tests (all password variants, nginx)
+        run: bin/test-all.sh --mode nginx

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ web-npm-run-dev-https:
 web-npm-build:
 	$(NODE_INIT) cd web && SITE_ENV=$(SITE_ENV) DDPHOTOS_ALBUMS_DIR=$(DDPHOTOS_ALBUMS_DIR) DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) npm run build
 
-.PHONY: web-docker-build
-## web-docker-build: build the photos Apache Docker image
-web-docker-build:
+.PHONY: web-docker-build-apache
+## web-docker-build-apache: build the photos Apache Docker image
+web-docker-build-apache:
 	bin/docker-check.sh --force
 
 .PHONY: web-docker-build-nginx
@@ -117,17 +117,17 @@ web-docker-build:
 web-docker-build-nginx:
 	bin/docker-check.sh --server nginx --force
 
-.PHONY: _check-docker-schema
-_check-docker-schema:
-	bin/docker-check.sh
+.PHONY: _check-docker-schema-apache
+_check-docker-schema-apache:
+	bin/docker-check.sh --server apache
 
 .PHONY: _check-docker-schema-nginx
 _check-docker-schema-nginx:
 	bin/docker-check.sh --server nginx
 
-.PHONY: web-docker-run
-## web-docker-run: run the photos Apache Docker container on port 8080
-web-docker-run: _check-docker-schema
+.PHONY: web-docker-run-apache
+## web-docker-run-apache: run the photos Apache Docker container on port 8080
+web-docker-run-apache: _check-docker-schema-apache
 	docker run --rm -p 8080:80 \
 		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
 		-v $(PWD)/build:/build:ro \
@@ -176,7 +176,7 @@ web-playwright-test-all:
 .PHONY: web-screenshots
 ## web-screenshots: capture screenshots and regenerate composite — requires a running server on port 8080
 web-screenshots:
-	# run `make sample-photogen sample-build web-docker-run` to start docker/apache for this script
+	# run `make sample-photogen sample-build web-docker-run-apache` to start docker/apache for this script
 	$(NODE_INIT) cd web && node scripts/screenshots.mjs --album antarctica --photo 4
 	.venv/bin/python3 bin/generate-screenshot-composite.py
 
@@ -217,7 +217,7 @@ sample-build:
 
 .PHONY: sample-test-apache
 ## sample-test-apache: run routing tests against local Apache Docker container on port 8082 (starts/stops Docker automatically)
-sample-test-apache: _check-docker-schema
+sample-test-apache: _check-docker-schema-apache
 	@test -d build/$(DDPHOTOS_SITE_ID) || { echo "Error: build/$(DDPHOTOS_SITE_ID) not found. Run 'make web-npm-build' first."; exit 1; }
 	docker run -d --rm --name sample-test-apache -p 8082:80 \
 		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,18 @@ web-npm-build:
 web-docker-build:
 	bin/docker-check.sh --force
 
+.PHONY: web-docker-build-nginx
+## web-docker-build-nginx: build the photos nginx Docker image
+web-docker-build-nginx:
+	bin/docker-check.sh --server nginx --force
+
 .PHONY: _check-docker-schema
 _check-docker-schema:
 	bin/docker-check.sh
+
+.PHONY: _check-docker-schema-nginx
+_check-docker-schema-nginx:
+	bin/docker-check.sh --server nginx
 
 .PHONY: web-docker-run
 ## web-docker-run: run the photos Apache Docker container on port 8080
@@ -125,20 +134,34 @@ web-docker-run: _check-docker-schema
 		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
 		photos-apache
 
+.PHONY: web-docker-run-nginx
+## web-docker-run-nginx: run the photos nginx Docker container on port 8080
+web-docker-run-nginx: _check-docker-schema-nginx
+	docker run --rm -p 8080:80 \
+		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
+		-v $(PWD)/build:/build:ro \
+		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
+		photos-nginx
+
 .PHONY: web-docker-stop
 ## web-docker-stop: stop the running photos Apache Docker container
 web-docker-stop:
 	docker stop $$(docker ps -q --filter publish=8080) 2>/dev/null || true
 
 .PHONY: web-docker-test
-## web-docker-test: run Apache routing tests against the local Docker container
+## web-docker-test: run server routing tests against the local Docker container
 web-docker-test:
-	bin/test-photos-apache.sh --local 8080
+	bin/test-photos-server.sh --local 8080
 
 .PHONY: web-playwright-test-apache
 ## web-playwright-test-apache: run Playwright e2e tests (no passwords) against Docker/Apache only
 web-playwright-test-apache:
 	bin/run-tests.sh --mode apache
+
+.PHONY: web-playwright-test-nginx
+## web-playwright-test-nginx: run Playwright e2e tests (no passwords) against Docker/nginx only
+web-playwright-test-nginx:
+	bin/run-tests.sh --mode nginx
 
 .PHONY: web-playwright-test-dev
 ## web-playwright-test-dev: run Playwright e2e tests (no passwords) against Vite dev server only
@@ -146,7 +169,7 @@ web-playwright-test-dev:
 	bin/run-tests.sh --mode dev
 
 .PHONY: web-playwright-test-all
-## web-playwright-test-all: run Playwright e2e tests against all password variants (dev + apache)
+## web-playwright-test-all: run Playwright e2e tests against all password variants (dev + apache + nginx)
 web-playwright-test-all:
 	bin/test-all.sh
 
@@ -193,7 +216,7 @@ sample-build:
 	SITE_ENV=sample/config/site.env $(MAKE) web-npm-build
 
 .PHONY: sample-test-apache
-## sample-test-apache: run test-photos-apache.sh tests against local Docker container on port 8082 (starts/stops Docker automatically)
+## sample-test-apache: run routing tests against local Apache Docker container on port 8082 (starts/stops Docker automatically)
 sample-test-apache: _check-docker-schema
 	@test -d build/$(DDPHOTOS_SITE_ID) || { echo "Error: build/$(DDPHOTOS_SITE_ID) not found. Run 'make web-npm-build' first."; exit 1; }
 	docker run -d --rm --name sample-test-apache -p 8082:80 \
@@ -203,8 +226,22 @@ sample-test-apache: _check-docker-schema
 		photos-apache
 	@echo "Waiting for Apache to be ready..."; \
 	until curl -s -o /dev/null http://localhost:8082; do sleep 1; done
-	bin/test-photos-apache.sh --config-dir sample/config --local 8082; \
+	bin/test-photos-server.sh --config-dir sample/config --local 8082; \
 	EXIT=$$?; docker stop sample-test-apache 2>/dev/null || true; exit $$EXIT
+
+.PHONY: sample-test-nginx
+## sample-test-nginx: run routing tests against local nginx Docker container on port 8082 (starts/stops Docker automatically)
+sample-test-nginx: _check-docker-schema-nginx
+	@test -d build/$(DDPHOTOS_SITE_ID) || { echo "Error: build/$(DDPHOTOS_SITE_ID) not found. Run 'make web-npm-build' first."; exit 1; }
+	docker run -d --rm --name sample-test-nginx -p 8082:80 \
+		-e DDPHOTOS_SITE_ID=$(DDPHOTOS_SITE_ID) \
+		-v $(PWD)/build:/build:ro \
+		-v $(DDPHOTOS_ALBUMS_DIR)/$(DDPHOTOS_SITE_ID):/albums:ro \
+		photos-nginx
+	@echo "Waiting for nginx to be ready..."; \
+	until curl -s -o /dev/null http://localhost:8082; do sleep 1; done
+	bin/test-photos-server.sh --config-dir sample/config --local 8082; \
+	EXIT=$$?; docker stop sample-test-nginx 2>/dev/null || true; exit $$EXIT
 
 .PHONY: sample-npm-run-dev
 ## sample-npm-run-dev: run npm dev server using sample config

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -106,9 +106,9 @@ The `site.env` variables are:
 | `VITE_COPYRIGHT_YEAR`   | Vite, Svelte                | Footer copyright start year                                                             |
 | `CLOUDFRONT_ID`         | `bin/deploy-photos.sh`      | CloudFront distribution ID for cache invalidation (deploy only)                         |
 | `RSYNC_DEST`            | `bin/deploy-photos.sh`      | Rsync destination path on the server (deploy only)                                      |
-| `TEST_ALBUM_LOCAL`      | `bin/test-photos-apache.sh` | Album slug used for local Apache tests                                                  |
-| `TEST_ALBUM_PROD`       | `bin/test-photos-apache.sh` | Album slug used for production tests                                                    |
-| `TEST_ALBUM_HYPHEN`     | `bin/test-photos-apache.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
+| `TEST_ALBUM_LOCAL`      | `bin/test-photos-server.sh` | Album slug used for local Apache tests                                                  |
+| `TEST_ALBUM_PROD`       | `bin/test-photos-server.sh` | Album slug used for production tests                                                    |
+| `TEST_ALBUM_HYPHEN`     | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
 
 The last five variables (`CLOUDFRONT_ID`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
 for deployment and Apache routing tests. For local development, only the `VITE_*` vars are required.
@@ -153,7 +153,7 @@ These variables are consumed by:
 - `vite.config.ts` — dev server middleware serves `/albums/**` from `<DDPHOTOS_ALBUMS_DIR>/<DDPHOTOS_SITE_ID>/`
 - `web/svelte.config.js` — build output goes to `build/<DDPHOTOS_SITE_ID>/`; album slugs are read for pre-rendered entries
 - `web/hooks.server.ts` — intercepts fetch calls to `/albums/**` during `npm run build`
-- `web/entrypoint.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the Apache document root at container startup
+- `web/apache-entrypoint.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the Apache document root at container startup
 
 ## Makefile Targets
 
@@ -172,11 +172,14 @@ Common tasks are available via `make` from the repo root:
 | `web-npm-run-dev`            | Start Vite dev server and open browser                                             |
 | `web-npm-build`              | Build the static site into `build/<site-id>/`                                      |
 | `web-docker-build`           | Build the `photos-apache` Docker image                                             |
+| `web-docker-build-nginx`     | Build the `photos-nginx` Docker image                                              |
 | `web-docker-run`             | Run Apache on port 8080 (mounts `build/` and `albums/<site-id>/`)                  |
+| `web-docker-run-nginx`       | Run nginx on port 8080 (mounts `build/` and `albums/<site-id>/`)                   |
 | `web-docker-stop`            | Stop the running `photos-apache` container                                         |
-| `web-docker-test`            | Run `bin/test-photos-apache.sh` against `localhost:8080`                           |
+| `web-docker-test`            | Run `bin/test-photos-server.sh` against `localhost:8080`                           |
 | `web-playwright-install`     | One-time setup: install `@playwright/test` and Chromium binary                     |
-| `web-playwright-test-apache` | Run Playwright e2e tests (starts Docker on port 8081, runs, stops)                 |
+| `web-playwright-test-apache` | Run Playwright e2e tests (starts Docker/Apache on port 8083, runs, stops)          |
+| `web-playwright-test-nginx`  | Run Playwright e2e tests (starts Docker/nginx on port 8084, runs, stops)           |
 | `web-playwright-test-dev`    | Run Playwright e2e tests (against Vite dev server)                                 |
 | `web-playwright-test-all`    | Run `bin/test-all.sh` across all password/CSS variants                             |
 | `sample-photogen`            | Run photogen using `sample/config/albums.yaml`                                     |
@@ -595,10 +598,10 @@ make web-docker-run
 
 You should be able to see the site at [localhost:8080](http://localhost:8080).
 
-### Automated Tests - Docker/Apache via Curl
+### Automated Tests - Docker via Curl
 
-If Docker/Apache is running, `make web-docker-test` runs 
-`bin/test-photos-apache.sh --local 8080`, which tests URL routing, redirects, 
+If Docker is running, `make web-docker-test` runs 
+`bin/test-photos-server.sh --local 8080`, which tests URL routing, redirects, 
 404 handling, photo permalink URLs, static asset accessibility,
 and verifies asset paths in HTML are absolute (required for photo permalink
 pages to render correctly).
@@ -610,9 +613,9 @@ make web-docker-test
 You can also run the script directly, against production or locally:
 
 ```bash
-bin/test-photos-apache.sh               # production ($VITE_SITE_URL)
-bin/test-photos-apache.sh --local       # local Docker on port 8080
-bin/test-photos-apache.sh --local 9090  # local Docker on custom port
+bin/test-photos-server.sh               # production ($VITE_SITE_URL)
+bin/test-photos-server.sh --local       # local Docker on port 8080
+bin/test-photos-server.sh --local 9090  # local Docker on custom port
 ```
 
 The deployment script runs this script automatically after deploying.
@@ -760,13 +763,13 @@ To deploy, I run `bin/deploy-photos.sh`, which:
 1. Runs `photogen` to resize images and generate JSON
 2. Builds the static site via `npm run build` into `build/<site-id>/`
 3. Starts the Docker/Apache container if not already running, runs
-   `bin/test-photos-apache.sh --local` to verify routing locally, then stops the container
+   `bin/test-photos-server.sh --local` to verify routing locally, then stops the container
 4. Runs Playwright tests against Docker/Apache
 5. Rsyncs `build/<site-id>/` to the `$RSYNC_DEST` directory on the EC2 server (`$AWS_APACHE`),
    using `--checksum` to reduce unnecessary re-copying since Vite resets timestamps.
    A second rsync pass syncs album data (`albums/<site-id>/`) independently.
 6. Invalidates the CloudFront cache (`$CLOUDFRONT_ID`)
-7. Runs `bin/test-photos-apache.sh` to verify the deployment against production
+7. Runs `bin/test-photos-server.sh` to verify the deployment against production
 8. Runs Playwright tests against production (`$VITE_SITE_URL`)
 
 The script uses `set -eo pipefail` — any failure (including local tests) aborts before rsync.

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -111,7 +111,7 @@ The `site.env` variables are:
 | `TEST_ALBUM_HYPHEN`     | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
 
 The last five variables (`CLOUDFRONT_ID`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
-for deployment and Apache routing tests. For local development, only the `VITE_*` vars are required.
+for deployment and server routing tests. For local development, only the `VITE_*` vars are required.
 
 In the web app, `vite.config.ts` reads `config/site.env` at startup and injects `VITE_*` keys into `process.env`
 before Vite runs, so the values are available as `import.meta.env.VITE_*` in Svelte components.
@@ -171,9 +171,9 @@ Common tasks are available via `make` from the repo root:
 | `web-npm-install`            | Install npm dependencies in `web/`                                                 |
 | `web-npm-run-dev`            | Start Vite dev server and open browser                                             |
 | `web-npm-build`              | Build the static site into `build/<site-id>/`                                      |
-| `web-docker-build`           | Build the `photos-apache` Docker image                                             |
+| `web-docker-build-apache`    | Build the `photos-apache` Docker image                                             |
 | `web-docker-build-nginx`     | Build the `photos-nginx` Docker image                                              |
-| `web-docker-run`             | Run Apache on port 8080 (mounts `build/` and `albums/<site-id>/`)                  |
+| `web-docker-run-apache`      | Run Apache on port 8080 (mounts `build/` and `albums/<site-id>/`)                  |
 | `web-docker-run-nginx`       | Run nginx on port 8080 (mounts `build/` and `albums/<site-id>/`)                   |
 | `web-docker-stop`            | Stop the running `photos-apache` container                                         |
 | `web-docker-test`            | Run `bin/test-photos-server.sh` against `localhost:8080`                           |
@@ -190,7 +190,8 @@ Common tasks are available via `make` from the repo root:
 | `sample-demo`                | One-step demo: photogen (CSS + passwords) and run dev server                       |
 | `sample-build`               | Build the static site using sample config                                          |
 | `sample-npm-run-dev`         | Run the Vite dev server using sample config                                        |
-| `sample-test-apache`         | Run Apache routing tests against Docker on port 8082                               |
+| `sample-test-apache`         | Run routing tests against Docker/Apache on port 8082                               |
+| `sample-test-nginx`          | Run routing tests against Docker/nginx on port 8082                                |
 | `web-screenshots`            | Capture screenshots (requires a running server on port 8080)                       |
 
 ## Generating Photos (`photogen`)
@@ -538,7 +539,7 @@ DDPHOTOS_SITE_ID=prod bin/search_cover.sh <url>
 
 There are three ways of testing the website:
 
-1. **Manual testing** in a browser, against the Vite dev server or a local static build (via Docker/Apache)
+1. **Manual testing** in a browser, against the Vite dev server or a local static build (via Docker)
 2. **Playwright e2e tests** that drive a headless Chromium browser to verify UI behavior
 3. **Apache routing tests** using `curl` to verify `.htaccess` URL routing, redirects, and 404 handling
 
@@ -578,22 +579,24 @@ make web-npm-build
 SITE_ENV=private/config/site.env make web-npm-build
 ```
 
-Once the site is built, you can serve it via Docker/Apache.
+Once the site is built, you can serve it via Docker (Apache/nginx).
 
-### Manual Testing - Build Served via Docker/Apache
+### Manual Testing - Build Served via Docker
 
-The Docker/Apache environment mirrors one possible production setup and applies
-`.htaccess` routing locally. The `build/` directory is mounted in the container (not
-`build/<site-id>/`) so that npm rebuilds (which delete and recreate `build/<site-id>/`)
-don't break the container's bind mount.
+The Docker environment mirrors one possible production setup and applies URL routing
+locally. The `build/` directory is mounted in the container (not `build/<site-id>/`)
+so that npm rebuilds (which delete and recreate `build/<site-id>/`) don't break the
+container's bind mount. Apache and nginx are both supported.
 
 ```bash
-# One-time: build the Docker image
-make web-docker-build
+# One-time: build the Docker image(s)
+make web-docker-build-apache # Apache
+make web-docker-build-nginx  # nginx
 
-# Start Apache on port 8080 (runs in foreground; Ctrl-C to stop) 
+# Start on port 8080 (runs in foreground; Ctrl-C to stop)
 # Site rebuilds do not require a restart
-make web-docker-run
+make web-docker-run-apache # Apache
+make web-docker-run-nginx  # nginx
 ```
 
 You should be able to see the site at [localhost:8080](http://localhost:8080).
@@ -622,17 +625,20 @@ The deployment script runs this script automatically after deploying.
 
 ### Automated Tests - Playwright E2E Tests
 
-Playwright runs a real headless Chromium browser against the Docker/Apache
-container, the dev server, or even a production server, testing JavaScript behavior 
-that static HTML checks can't cover - specifically lightbox caption rendering across 
+Playwright runs a real headless Chromium browser against a Docker container (Apache
+or nginx), the dev server, or even a production server, testing JavaScript behavior
+that static HTML checks can't cover - specifically lightbox caption rendering across
 the different open paths.
 
 ```bash
 # One-time setup (downloads ~100 MB Chromium binary)
 make web-playwright-install
 
-# starts a separate Docker/Apache on port 8081, runs tests, stops Docker
+# starts a separate Docker/Apache on port 8083, runs tests, stops Docker
 make web-playwright-test-apache
+
+# starts a separate Docker/nginx on port 8084, runs tests, stops Docker
+make web-playwright-test-nginx
 
 # runs against dev server (which must be running)
 make web-playwright-test-dev
@@ -672,14 +678,23 @@ Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants aut
 and `custom-css` (with `sample/config/custom.css` injected).
 
 ```bash
-# Run all 4 variants against Apache (recommended; mirrors CI)
+# Run all 4 variants against dev + Apache + nginx (default; recommended locally)
+bin/test-all.sh
+
+# Run all 4 variants against Apache only (mirrors CI)
 bin/test-all.sh --mode apache
 
-# Run all 4 variants against both dev server and Apache
-bin/test-all.sh --mode both
+# Run all 4 variants against nginx only
+bin/test-all.sh --mode nginx
+
+# Run all 4 variants against dev server, Apache, and nginx
+bin/test-all.sh --mode all
 
 # Run a single variant against Apache (no password)
 bin/run-tests.sh --mode apache
+
+# Run a single variant against nginx (no password)
+bin/run-tests.sh --mode nginx
 
 # Run pw-all variant against Apache
 bin/run-tests.sh --passwords sample/config/passwords-all.yaml --mode apache
@@ -798,15 +813,17 @@ bin/deploy-photos.sh --no-photogen --no-rsync # build + local test, skip both ph
 
 ## CI (GitHub Actions)
 
-The workflow in `.github/workflows/ci.yml` runs on every pull request to `main`. It:
+The workflow in `.github/workflows/ci.yml` runs on every push or pull request to `main`. It:
 
 1. Installs `libvips-dev` and `pkg-config` via `apt-get`
 2. Sets up Go (version from `go.mod`) and Node (version from `web/.nvmrc`); installs dependencies
 3. Runs `make build test vet`
 4. Installs Playwright Chromium and its system dependencies
-5. Runs `make sample-photogen sample-build web-docker-build sample-test-apache` — photogens
-   the sample site, builds the static site and Docker image, and runs Apache routing tests
-6. Runs `bin/test-all.sh --mode apache` — Playwright e2e tests across all password/CSS variants
+5. Runs `make sample-photogen sample-build` — photogens the sample site and builds the static site
+6. Runs `make web-docker-build-apache sample-test-apache` — builds the Apache Docker image and runs routing tests
+7. Runs `make web-docker-build-nginx sample-test-nginx` — builds the nginx Docker image and runs routing tests
+8. Runs `bin/test-all.sh --mode apache` — Playwright e2e tests across all password/CSS variants against Apache
+9. Runs `bin/test-all.sh --mode nginx` — Playwright e2e tests across all password/CSS variants against nginx
 
 ### Testing CI Locally with `act`
 
@@ -815,7 +832,7 @@ It requires Docker. Before running, there is one key prerequisite and one import
 
 ```bash
 # Prerequisite: generate and build sample site before running `act`
-make web-docker-build sample-photogen sample-build
+make web-docker-build-apache web-docker-build-nginx sample-photogen sample-build
 
 # Run act to simulate GitHub
 act --reuse --pull=false -W .github/workflows/ci.yml

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ These should pass against `sample`, but some will fail against your site,
 because values are hardcoded at the moment (i.e., the smoke/caption tests 
 reference specific album names - `antarctica` and `uganda`).
 
-You can also run some smoke tests as defined in `bin/test-photos-apache.sh`.
+You can also run some smoke tests as defined in `bin/test-photos-server.sh`.
 Assuming Docker/Apache is running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ make web-playwright-install  # installs Playwright + Chromium for e2e tests
 ```
 
 You may also want to install [Docker](https://www.docker.com/get-started/) if
-you don't have it, as it is required for testing site behavior using Apache.
+you don't have it, as it is required for testing site behavior using Apache or nginx.
 
 ## Sample App
 
@@ -178,13 +178,13 @@ assumes `photogen` has been run).
 
 ```bash
 # Build docker image (one time)
-make web-docker-build
+make web-docker-build-apache
 
 # Build sample site
 make sample-build
 
 # Run it in Docker/Apache
-make web-docker-run 
+make web-docker-run-apache 
 ```
 
 You should be able to see the site at [localhost:8080](http://localhost:8080).
@@ -248,7 +248,7 @@ dev server.
 make web-npm-run-dev
 ```
 
-### Build and Test Apache
+### Build and Test with Docker
 
 To test the build process:
 
@@ -259,10 +259,11 @@ make web-npm-build
 This deletes and recreates the `build/<site-id>` directory, which will have all
 the files needed to run the site, including copies of your resized photos.
 
-To run it using the Docker/Apache image:
+To run it using Docker, choose Apache or nginx:
 
 ```bash
-make web-docker-run
+make web-docker-run-apache # Apache
+make web-docker-run-nginx  # nginx
 ```
 
 You should be able to see the site at [localhost:8080](http://localhost:8080).
@@ -280,17 +281,18 @@ because values are hardcoded at the moment (i.e., the smoke/caption tests
 reference specific album names - `antarctica` and `uganda`).
 
 You can also run some smoke tests as defined in `bin/test-photos-server.sh`.
-Assuming Docker/Apache is running:
+Assuming Docker is running on port 8080:
 
 ```bash
 make web-docker-test
 ```
 
-If Docker/Apache isn't running, you can auto-start and stop it to
-run these tests against sample site:
+If Docker isn't running, you can auto-start and stop it to
+run these tests against the sample site:
 
 ```bash
-make sample-test-apache
+make sample-test-apache  # Apache
+make sample-test-nginx   # nginx
 ```
 
 ## Developer Information

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -122,7 +122,7 @@ else
     echo "Running local Apache tests..."
     TEST_ARGS=(--local 8080)
     [ -n "$CONFIG_DIR" ] && TEST_ARGS+=(--config-dir "$CONFIG_DIR")
-    "$SDIR/test-photos-apache.sh" "${TEST_ARGS[@]}"
+    "$SDIR/test-photos-server.sh" "${TEST_ARGS[@]}"
 fi
 
 if [ "$SKIP_PLAYWRIGHT" = true ]; then
@@ -175,7 +175,7 @@ else
         sleep 5
         PROD_ARGS=()
         [ -n "$CONFIG_DIR" ] && PROD_ARGS+=(--config-dir "$CONFIG_DIR")
-        "$SDIR/test-photos-apache.sh" "${PROD_ARGS[@]}"
+        "$SDIR/test-photos-server.sh" "${PROD_ARGS[@]}"
     fi
 
     if [ "$SKIP_PLAYWRIGHT" = true ]; then

--- a/bin/docker-check.sh
+++ b/bin/docker-check.sh
@@ -1,31 +1,57 @@
 #!/usr/bin/env bash
-# Verify (and optionally rebuild) the photos-apache Docker image.
+# Verify (and optionally rebuild) a photos Docker image (apache or nginx).
 #
 # Usage:
-#   bin/docker-check.sh          # check only; exit 1 if stale or missing
-#   bin/docker-check.sh --build  # rebuild if stale or missing, no-op if current
-#   bin/docker-check.sh --force  # always rebuild
+#   bin/docker-check.sh [--server apache|nginx] [--build|--force]
+#
+#   --server  Which server image to manage (default: apache)
+#   (no flag) check only; exit 1 if stale or missing
+#   --build   rebuild if stale or missing, no-op if current
+#   --force   always rebuild
 
 set -eo pipefail
 
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-case "${1:-}" in
-    "")       MODE=check ;;
-    --build)  MODE=build ;;
-    --force)  MODE=force ;;
-    *) echo "Usage: $0 [--build|--force]" >&2; exit 1 ;;
-esac
+SERVER="apache"
+MODE="check"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server)
+            SERVER="$2"
+            if [[ "$SERVER" != "apache" && "$SERVER" != "nginx" ]]; then
+                echo "Usage: $0 [--server apache|nginx] [--build|--force]" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --build)  MODE=build; shift ;;
+        --force)  MODE=force; shift ;;
+        *) echo "Usage: $0 [--server apache|nginx] [--build|--force]" >&2; exit 1 ;;
+    esac
+done
 
 if ! docker info >/dev/null 2>&1; then
     echo "ERROR: Docker daemon is not running."
     exit 1
 fi
 
-expected=$(cat "$SDIR/../web/Dockerfile" "$SDIR/../web/entrypoint.sh" | shasum -a 256 | cut -d' ' -f1)
+IMAGE="photos-$SERVER"
+WEB="$SDIR/../web"
+
+if [ "$SERVER" = "apache" ]; then
+    DOCKERFILE="$WEB/apache.dockerfile"
+    HASH_INPUTS="$WEB/apache.dockerfile $WEB/apache-entrypoint.sh $WEB/setup-htdocs.sh"
+else
+    DOCKERFILE="$WEB/nginx.dockerfile"
+    HASH_INPUTS="$WEB/nginx.dockerfile $WEB/nginx-entrypoint.sh $WEB/nginx.conf $WEB/setup-htdocs.sh"
+fi
+
+expected=$(cat $HASH_INPUTS | shasum -a 256 | cut -d' ' -f1)
 
 _build() {
-    docker build -t photos-apache --label "ddphotos.hash=$expected" "$SDIR/../web/"
+    docker build -t "$IMAGE" -f "$DOCKERFILE" --label "ddphotos.hash=$expected" "$WEB/"
 }
 
 if [ "$MODE" = force ]; then
@@ -33,17 +59,21 @@ if [ "$MODE" = force ]; then
     exit 0
 fi
 
-stored=$(docker image inspect photos-apache --format '{{index .Config.Labels "ddphotos.hash"}}' 2>/dev/null || true)
+stored=$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "ddphotos.hash"}}' 2>/dev/null || true)
 
 if [ "$stored" = "$expected" ]; then
     exit 0
 fi
 
 if [ "$MODE" = build ]; then
-    echo "=== Building Docker image (stale or missing) ==="
+    echo "=== Building Docker image $IMAGE (stale or missing) ==="
     _build
 else
-    echo "ERROR: photos-apache image is stale or missing."
-    echo "Run: make web-docker-build"
+    echo "ERROR: $IMAGE image is stale or missing."
+    if [ "$SERVER" = "apache" ]; then
+        echo "Run: make web-docker-build"
+    else
+        echo "Run: make web-docker-build-nginx"
+    fi
     exit 1
 fi

--- a/bin/docker-check.sh
+++ b/bin/docker-check.sh
@@ -71,7 +71,7 @@ if [ "$MODE" = build ]; then
 else
     echo "ERROR: $IMAGE image is stale or missing."
     if [ "$SERVER" = "apache" ]; then
-        echo "Run: make web-docker-build"
+        echo "Run: make web-docker-build-apache"
     else
         echo "Run: make web-docker-build-nginx"
     fi

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -112,9 +112,9 @@ DEV_PID=""
 # Cleanup: kill dev server and stop Docker container on exit
 # shellcheck disable=SC2317
 cleanup() {
-    if [ -n "$DEV_PID" ]; then kill "$DEV_PID" 2>/dev/null; fi
-    docker stop "$DOCKER_CONTAINER_APACHE" 2>/dev/null
-    docker stop "$DOCKER_CONTAINER_NGINX" 2>/dev/null
+    if [ -n "$DEV_PID" ]; then kill "$DEV_PID" 2>/dev/null || true; fi
+    docker stop "$DOCKER_CONTAINER_APACHE" 2>/dev/null || true
+    docker stop "$DOCKER_CONTAINER_NGINX" 2>/dev/null || true
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -2,16 +2,18 @@
 # Run Playwright tests against one variant of the sample site.
 #
 # Usage:
-#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|both]
+#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|both|all]
 #
 # --passwords  Path to a passwords file (e.g. sample/config/passwords-all.yaml).
 #              Omit for the no-password variant.
 # --css        Path to a custom CSS file (e.g. sample/config/custom.css).
 #              Omit for the no-CSS variant.
-# --mode       Which server to test against: dev, apache, or both (default: both).
-#              dev   — Vite dev server on port 5174
+# --mode       Which server to test against: dev, apache, nginx, both, or all (default: both).
+#              dev    — Vite dev server on port 5174
 #              apache — static build + Docker/Apache on port 8083
-#              both  — dev first, then apache
+#              nginx  — static build + Docker/nginx on port 8084
+#              both   — dev first, then apache
+#              all    — dev, apache, and nginx
 
 set -eo pipefail
 
@@ -27,10 +29,12 @@ usage() {
     echo "                      Omit for the no-password variant."
     echo "  --css <file>        Path to a custom CSS file (e.g. sample/config/custom.css)."
     echo "                      Omit for the no-CSS variant."
-    echo "  --mode <mode>       Server to test against: dev, apache, or both (default: both)."
+    echo "  --mode <mode>       Server to test against: dev, apache, nginx, both, or all (default: both)."
     echo "                        dev    — Vite dev server on port 5174"
     echo "                        apache — static build + Docker/Apache on port 8083"
+    echo "                        nginx  — static build + Docker/nginx on port 8084"
     echo "                        both   — dev first, then apache"
+    echo "                        all    — dev, apache, and nginx"
     echo "  --help, -?          Show this help message and exit."
 }
 
@@ -100,13 +104,17 @@ ALBUMS_DIR="$(pwd)/albums"
 SITE_ENV="$(pwd)/sample/config/site.env"
 DEV_PORT=5174
 DOCKER_PORT=8083
-DOCKER_CONTAINER="ddphotos-playwright-test"
+DOCKER_PORT_NGINX=8084
+DOCKER_CONTAINER_APACHE="ddphotos-playwright-test-apache"
+DOCKER_CONTAINER_NGINX="ddphotos-playwright-test-nginx"
 DEV_PID=""
 
 # Cleanup: kill dev server and stop Docker container on exit
+# shellcheck disable=SC2317
 cleanup() {
-    [ -n "$DEV_PID" ] && kill "$DEV_PID" 2>/dev/null || true
-    docker stop "$DOCKER_CONTAINER" 2>/dev/null || true
+    if [ -n "$DEV_PID" ]; then kill "$DEV_PID" 2>/dev/null; fi
+    docker stop "$DOCKER_CONTAINER_APACHE" 2>/dev/null
+    docker stop "$DOCKER_CONTAINER_NGINX" 2>/dev/null
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -176,7 +184,7 @@ run_apache() {
     "$SDIR/docker-check.sh" --build || return 1
 
     echo "=== [apache] Starting Apache on port $DOCKER_PORT ==="
-    docker run -d --rm --name "$DOCKER_CONTAINER" -p "$DOCKER_PORT:80" \
+    docker run -d --rm --name "$DOCKER_CONTAINER_APACHE" -p "$DOCKER_PORT:80" \
         -e DDPHOTOS_SITE_ID="$SITE_ID" \
         -v "$(pwd)/build":/build:ro \
         -v "$ALBUMS_DIR/$SITE_ID":/albums:ro \
@@ -187,7 +195,33 @@ run_apache() {
     local exit_code=0
     run_playwright "http://localhost:$DOCKER_PORT" || exit_code=$?
 
-    docker stop "$DOCKER_CONTAINER" 2>/dev/null || true
+    docker stop "$DOCKER_CONTAINER_APACHE" 2>/dev/null || true
+
+    return $exit_code
+}
+
+# --- nginx mode ---
+run_nginx() {
+    echo ""
+    echo "=== [nginx] Building static site ==="
+    (cd web && SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
+
+    # Build Docker image if missing or stale
+    "$SDIR/docker-check.sh" --server nginx --build || return 1
+
+    echo "=== [nginx] Starting nginx on port $DOCKER_PORT_NGINX ==="
+    docker run -d --rm --name "$DOCKER_CONTAINER_NGINX" -p "$DOCKER_PORT_NGINX:80" \
+        -e DDPHOTOS_SITE_ID="$SITE_ID" \
+        -v "$(pwd)/build":/build:ro \
+        -v "$ALBUMS_DIR/$SITE_ID":/albums:ro \
+        photos-nginx
+
+    wait_for_http "http://localhost:$DOCKER_PORT_NGINX" "nginx"
+
+    local exit_code=0
+    run_playwright "http://localhost:$DOCKER_PORT_NGINX" || exit_code=$?
+
+    docker stop "$DOCKER_CONTAINER_NGINX" 2>/dev/null || true
 
     return $exit_code
 }
@@ -195,12 +229,16 @@ run_apache() {
 # --- run selected modes ---
 OVERALL_EXIT=0
 
-if [[ "$MODE" == "dev" || "$MODE" == "both" ]]; then
+if [[ "$MODE" == "dev" || "$MODE" == "both" || "$MODE" == "all" ]]; then
     run_dev || OVERALL_EXIT=$?
 fi
 
-if [[ "$MODE" == "apache" || "$MODE" == "both" ]]; then
+if [[ "$MODE" == "apache" || "$MODE" == "both" || "$MODE" == "all" ]]; then
     run_apache || OVERALL_EXIT=$?
+fi
+
+if [[ "$MODE" == "nginx" || "$MODE" == "all" ]]; then
+    run_nginx || OVERALL_EXIT=$?
 fi
 
 exit $OVERALL_EXIT

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -2,38 +2,36 @@
 # Run Playwright tests against one variant of the sample site.
 #
 # Usage:
-#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|both|all]
+#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|all]
 #
 # --passwords  Path to a passwords file (e.g. sample/config/passwords-all.yaml).
 #              Omit for the no-password variant.
 # --css        Path to a custom CSS file (e.g. sample/config/custom.css).
 #              Omit for the no-CSS variant.
-# --mode       Which server to test against: dev, apache, nginx, both, or all (default: both).
+# --mode       Which server to test against: dev, apache, nginx, or all (default: all).
 #              dev    — Vite dev server on port 5174
 #              apache — static build + Docker/Apache on port 8083
 #              nginx  — static build + Docker/nginx on port 8084
-#              both   — dev first, then apache
 #              all    — dev, apache, and nginx
 
 set -eo pipefail
 
 PASSWORDS_FILE=""
 CSS_FILE=""
-MODE="both"
+MODE="all"
 
 usage() {
-    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|both]"
+    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|all]"
     echo ""
     echo "Options:"
     echo "  --passwords <file>  Path to a passwords file (e.g. sample/config/passwords-all.yaml)."
     echo "                      Omit for the no-password variant."
     echo "  --css <file>        Path to a custom CSS file (e.g. sample/config/custom.css)."
     echo "                      Omit for the no-CSS variant."
-    echo "  --mode <mode>       Server to test against: dev, apache, nginx, both, or all (default: both)."
+    echo "  --mode <mode>       Server to test against: dev, apache, nginx, or all (default: all)."
     echo "                        dev    — Vite dev server on port 5174"
     echo "                        apache — static build + Docker/Apache on port 8083"
     echo "                        nginx  — static build + Docker/nginx on port 8084"
-    echo "                        both   — dev first, then apache"
     echo "                        all    — dev, apache, and nginx"
     echo "  --help, -?          Show this help message and exit."
 }
@@ -119,7 +117,7 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT TERM
 
-# --- photogen + symlink (done once, shared by both dev and apache runs) ---
+# --- photogen + symlink (done once, shared across all modes) ---
 echo ""
 echo "=== Generating sample data (site-id: $SITE_ID) ==="
 # shellcheck disable=SC2086
@@ -229,11 +227,11 @@ run_nginx() {
 # --- run selected modes ---
 OVERALL_EXIT=0
 
-if [[ "$MODE" == "dev" || "$MODE" == "both" || "$MODE" == "all" ]]; then
+if [[ "$MODE" == "dev" || "$MODE" == "all" ]]; then
     run_dev || OVERALL_EXIT=$?
 fi
 
-if [[ "$MODE" == "apache" || "$MODE" == "both" || "$MODE" == "all" ]]; then
+if [[ "$MODE" == "apache" || "$MODE" == "all" ]]; then
     run_apache || OVERALL_EXIT=$?
 fi
 

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -6,7 +6,7 @@
 #   4. custom-css (sample/config/custom.css injected)
 #
 # Usage:
-#   bin/test-all.sh [--mode dev|apache|nginx|both|all]
+#   bin/test-all.sh [--mode dev|apache|nginx|all]
 #
 # Passes --mode through to bin/run-tests.sh (default: all).
 
@@ -15,7 +15,7 @@ set -eo pipefail
 MODE="all"
 
 usage() {
-    echo "Usage: bin/test-all.sh [--mode dev|apache|nginx|both|all]"
+    echo "Usage: bin/test-all.sh [--mode dev|apache|nginx|all]"
     echo ""
     echo "Runs Playwright tests against all sample site variants:"
     echo "  1. No passwords (plain site)"
@@ -24,11 +24,10 @@ usage() {
     echo "  4. custom-css (sample/config/custom.css injected)"
     echo ""
     echo "Options:"
-    echo "  --mode <mode>  Server to test against: dev, apache, nginx, both, or all (default: all)."
+    echo "  --mode <mode>  Server to test against: dev, apache, nginx, or all (default: all)."
     echo "                   dev    — Vite dev server on port 5174"
     echo "                   apache — static build + Docker/Apache on port 8083"
     echo "                   nginx  — static build + Docker/nginx on port 8084"
-    echo "                   both   — dev first, then apache"
     echo "                   all    — dev, apache, and nginx"
     echo "  --help, -?     Show this help message and exit."
 }

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -6,16 +6,16 @@
 #   4. custom-css (sample/config/custom.css injected)
 #
 # Usage:
-#   bin/test-all.sh [--mode dev|apache|both]
+#   bin/test-all.sh [--mode dev|apache|nginx|both|all]
 #
-# Passes --mode through to bin/run-tests.sh (default: both).
+# Passes --mode through to bin/run-tests.sh (default: all).
 
 set -eo pipefail
 
-MODE="both"
+MODE="all"
 
 usage() {
-    echo "Usage: bin/test-all.sh [--mode dev|apache|both]"
+    echo "Usage: bin/test-all.sh [--mode dev|apache|nginx|both|all]"
     echo ""
     echo "Runs Playwright tests against all sample site variants:"
     echo "  1. No passwords (plain site)"
@@ -24,10 +24,12 @@ usage() {
     echo "  4. custom-css (sample/config/custom.css injected)"
     echo ""
     echo "Options:"
-    echo "  --mode <mode>  Server to test against: dev, apache, or both (default: both)."
+    echo "  --mode <mode>  Server to test against: dev, apache, nginx, both, or all (default: all)."
     echo "                   dev    — Vite dev server on port 5174"
     echo "                   apache — static build + Docker/Apache on port 8083"
+    echo "                   nginx  — static build + Docker/nginx on port 8084"
     echo "                   both   — dev first, then apache"
+    echo "                   all    — dev, apache, and nginx"
     echo "  --help, -?     Show this help message and exit."
 }
 

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
 #
-# Verify Apache is serving the photos site correctly.
+# Verify the photos site is being served correctly.
 # Tests URL routing, redirects, and error handling.
+# Works against any web server (Apache or nginx).
 #
 # Usage:
-#   bin/test-photos-apache.sh                  # test production ($VITE_SITE_URL)
-#   bin/test-photos-apache.sh --local          # test local Docker on port 8080
-#   bin/test-photos-apache.sh --local 9090     # test local Docker on port 9090
+#   bin/test-photos-server.sh                  # test production ($VITE_SITE_URL)
+#   bin/test-photos-server.sh --local          # test local Docker on port 8080
+#   bin/test-photos-server.sh --local 9090     # test local Docker on port 9090
 #
 # Note: In production, Apache is behind CloudFront, so:
 #   - Redirect locations use http:// (Apache sees HTTP from CloudFront)

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1044,3 +1044,50 @@ Added a `default_theme` setting to `albums.yaml` that controls the site's initia
 **Theme store**: `theme.ts` previously hardcoded `'dark'` as the fallback when localStorage has no stored value. It now reads `document.documentElement.getAttribute('data-theme')` — the value already applied by the inline script — so the Svelte store initialises to match what's on screen. This prevents a flash on first visit when the configured default is `'light'`.
 
 **`?clear` improvement**: The `?clear` URL parameter (developer/testing tool that wipes stored passwords) now also removes the `'theme'` key from localStorage. The `logout()` function in `+layout.svelte` is intentionally left unchanged — it clears auth state only.
+
+### 56. nginx Docker POC
+
+Added nginx as an alternative to Apache for serving the static site, mirroring the existing Docker setup exactly. Also took the opportunity to clean up Dockerfile naming conventions.
+
+#### Dockerfile Renaming
+
+Renamed existing files to use a consistent `server-name.*` convention that JetBrains IDEs recognize via the `.dockerfile` extension:
+
+- `web/Dockerfile` → `web/apache.dockerfile`
+- `web/entrypoint.sh` → `web/apache-entrypoint.sh`
+- `bin/test-photos-apache.sh` → `bin/test-photos-server.sh` (server-agnostic routing tests)
+
+#### Shared Entrypoint Logic
+
+Extracted the common symlink setup logic from both entrypoints into a shared helper:
+
+- **`web/setup-htdocs.sh`** — takes `<htdocs-dir>` as an argument; symlinks everything from `/build/<site-id>/` into the document root (using `find` to include dotfiles like `.htaccess`), then populates `<htdocs>/albums/` with symlinks to pre-rendered HTML pages and photogen output.
+- **`web/apache-entrypoint.sh`** — sets `HTDOCS=/usr/local/apache2/htdocs`, calls `setup-htdocs.sh`, execs `httpd-foreground`.
+- **`web/nginx-entrypoint.sh`** — sets `HTDOCS=/usr/share/nginx/html`, calls `setup-htdocs.sh`, execs `nginx -g 'daemon off;'`.
+
+#### nginx Config
+
+**`web/nginx.conf`** replicates the `.htaccess` URL routing rules:
+
+- **Trailing slash removal** — `rewrite ^(.+)/$ $1 permanent` (301)
+- **Photo permalink** — `location ~ ^/albums/([^/]+)/\d+$` serves `/albums/$1.html` via `try_files`
+- **HTML extension mapping** — `try_files $uri $uri.html @spa_fallback` serves `/albums/slug` from `albums/slug.html`
+- **SPA fallback** — `location @spa_fallback` serves `index.html` for root-level single-segment paths; returns 404 for nested paths (e.g. `/albums/doesnotexist`)
+
+#### nginx Dockerfile
+
+**`web/nginx.dockerfile`** uses `nginx:alpine` as the base image, replaces `/etc/nginx/conf.d/default.conf` with the custom routing config, and copies both `setup-htdocs.sh` and `nginx-entrypoint.sh` into the image.
+
+#### `bin/docker-check.sh` Generalization
+
+Added `--server apache|nginx` flag (default: `apache`). All existing calls remain unchanged. Per-server differences:
+
+- Image tag: `photos-apache` vs `photos-nginx`
+- Dockerfile: `web/apache.dockerfile` vs `web/nginx.dockerfile`
+- Hash inputs: the relevant dockerfile + entrypoint(s) + `setup-htdocs.sh` (+ `nginx.conf` for nginx)
+
+#### Test Infrastructure
+
+- **`bin/run-tests.sh`** — added `--mode nginx` (port 8084) and `--mode all` (dev + apache + nginx). `both` retains its original meaning (dev + apache).
+- **`bin/test-all.sh`** — default mode changed from `both` to `all`, so CI-like runs now cover all three servers.
+- **Makefile** — added `web-docker-build-nginx`, `web-docker-run-nginx`, `web-playwright-test-nginx`, `sample-test-nginx`.

--- a/web/apache-entrypoint.sh
+++ b/web/apache-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+HTDOCS="/usr/local/apache2/htdocs"
+
+/setup-htdocs.sh "$HTDOCS"
+
+exec httpd-foreground

--- a/web/apache.dockerfile
+++ b/web/apache.dockerfile
@@ -1,4 +1,5 @@
 FROM httpd:2.4
+
 # Enable mod_rewrite, AllowOverride for .htaccess, FollowSymLinks for entrypoint symlinks.
 RUN sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/apache2/conf/httpd.conf \
     && sed -i 's/AllowOverride None/AllowOverride All/g' /usr/local/apache2/conf/httpd.conf \

--- a/web/apache.dockerfile
+++ b/web/apache.dockerfile
@@ -5,9 +5,11 @@ RUN sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/' /usr/local/
     && echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf \
     && printf '\n<Directory "/usr/local/apache2/htdocs">\n    Options +FollowSymLinks\n</Directory>\n' >> /usr/local/apache2/conf/httpd.conf
 
-# entrypoint.sh populates /usr/local/apache2/htdocs with symlinks into /build/<site-id>
-# and /albums at container startup, then hands off to httpd-foreground.
-COPY entrypoint.sh /entrypoint.sh
+# apache-entrypoint.sh calls setup-htdocs.sh to populate the document root with symlinks,
+# then hands off to httpd-foreground.
+COPY setup-htdocs.sh /setup-htdocs.sh
+COPY apache-entrypoint.sh /entrypoint.sh
+RUN chmod +x /setup-htdocs.sh /entrypoint.sh
 CMD ["/entrypoint.sh"]
 
 # Mounts at runtime:

--- a/web/nginx-entrypoint.sh
+++ b/web/nginx-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+HTDOCS="/usr/share/nginx/html"
+
+/setup-htdocs.sh "$HTDOCS"
+
+exec nginx -g 'daemon off;'

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -4,8 +4,11 @@ server {
 
     error_page 404 /404.html;
 
-    # Remove trailing slash (301), except root
-    rewrite ^(.+)/$ $1 permanent;
+    # Remove trailing slash (301), except root.
+    # Use $http_host (not $host) so the port is preserved in the Location header.
+    location ~ ^(.+)/$ {
+        return 301 $scheme://$http_host$1;
+    }
 
     # Photo permalink: /albums/slug/N -> serve /albums/slug.html
     location ~ ^/albums/([^/]+)/\d+$ {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+
+    error_page 404 /404.html;
+
+    # Remove trailing slash (301), except root
+    rewrite ^(.+)/$ $1 permanent;
+
+    # Photo permalink: /albums/slug/N -> serve /albums/slug.html
+    location ~ ^/albums/([^/]+)/\d+$ {
+        try_files /albums/$1.html =404;
+    }
+
+    # Serve exact file, or try .html extension; fall back to SPA check
+    location / {
+        try_files $uri $uri.html @spa_fallback;
+    }
+
+    # SPA fallback: root-level single-segment paths -> index.html; deeper paths -> 404
+    location @spa_fallback {
+        if ($uri ~ ^/[^/]*$) {
+            rewrite ^ /index.html last;
+        }
+        return 404;
+    }
+}

--- a/web/nginx.dockerfile
+++ b/web/nginx.dockerfile
@@ -1,6 +1,8 @@
 FROM nginx:alpine
+
 # Replace the default config with our routing rules.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # nginx-entrypoint.sh calls setup-htdocs.sh to populate the document root with symlinks,
 # then hands off to nginx.
 COPY setup-htdocs.sh /setup-htdocs.sh

--- a/web/nginx.dockerfile
+++ b/web/nginx.dockerfile
@@ -1,0 +1,14 @@
+FROM nginx:alpine
+# Replace the default config with our routing rules.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+# nginx-entrypoint.sh calls setup-htdocs.sh to populate the document root with symlinks,
+# then hands off to nginx.
+COPY setup-htdocs.sh /setup-htdocs.sh
+COPY nginx-entrypoint.sh /entrypoint.sh
+RUN chmod +x /setup-htdocs.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]
+
+# Mounts at runtime:
+#   -v <root>/build:/build:ro
+#   -v <root>/albums/<site-id>:/albums:ro
+#   -e DDPHOTOS_SITE_ID=<site-id>

--- a/web/setup-htdocs.sh
+++ b/web/setup-htdocs.sh
@@ -1,25 +1,32 @@
 #!/bin/sh
-set -e
-
-# Populate /usr/local/apache2/htdocs with symlinks so Apache can serve the site.
+# Populate a document root with symlinks so a web server can serve the site.
+#
+# Usage: setup-htdocs.sh <htdocs-dir>
 #
 # Mounts:
 #   /build        — <root>/build  (all site builds)
 #   /albums       — <root>/albums/<site-id>  (photogen output: image dirs + JSON)
 #
 # Strategy:
-#   1. Symlink everything from /build/<site-id>/ into htdocs/, except albums/.
-#   2. Create htdocs/albums/ as a real directory, then populate it with:
+#   1. Symlink everything from /build/<site-id>/ into <htdocs>/, except albums/.
+#   2. Create <htdocs>/albums/ as a real directory, then populate it with:
 #        - symlinks to *.html files from /build/<site-id>/albums/  (pre-rendered pages)
 #        - symlinks to everything in /albums/                       (image dirs, JSON, etc.)
 #
 # All symlinks live inside the container — nothing dangling is left on the host.
 
+set -e
+
+HTDOCS="$1"
+if [ -z "$HTDOCS" ]; then
+    echo "Usage: setup-htdocs.sh <htdocs-dir>" >&2
+    exit 1
+fi
+
 SITE_ID="${DDPHOTOS_SITE_ID:-sample}"
 BUILD_SITE="/build/$SITE_ID"
-HTDOCS="/usr/local/apache2/htdocs"
 
-# 1. Symlink build output into htdocs (skip albums/ — handled separately below).
+# 1. Symlink build output into htdocs/ (skip albums/ — handled separately below).
 # Use find rather than glob so dotfiles like .htaccess are included.
 find "$BUILD_SITE" -maxdepth 1 -mindepth 1 | while IFS= read -r item; do
     name=$(basename "$item")
@@ -41,5 +48,3 @@ for item in /albums/*; do
     [ -e "$item" ] || continue
     ln -sf "$item" "$HTDOCS/albums/$(basename "$item")"
 done
-
-exec httpd-foreground


### PR DESCRIPTION
## Summary

Adds nginx as an alternative to Apache for serving the static site, mirrors the existing Docker setup exactly, and cleans up several related files.

### Dockerfile renaming

- `web/Dockerfile` → `web/apache.dockerfile`
- `web/entrypoint.sh` → `web/apache-entrypoint.sh`

### Shared entrypoint helper

Extracted the symlink-population logic common to both servers into `web/setup-htdocs.sh`. Both `apache-entrypoint.sh` and `nginx-entrypoint.sh` call it, passing their respective document-root paths.

### nginx support

- `web/nginx.dockerfile` — `nginx:alpine`-based image
- `web/nginx-entrypoint.sh` — calls `setup-htdocs.sh`, then execs `nginx -g 'daemon off;'`
- `web/nginx.conf` — routing rules equivalent to `.htaccess`: trailing-slash 301 redirect (using `$http_host` to preserve port), photo permalink rewrite (`/albums/slug/N` → `slug.html`), HTML-extension mapping, and SPA fallback for root-level paths

### bin/docker-check.sh

Added `--server apache|nginx` flag (default: `apache`). Selects the correct Dockerfile, entrypoint, image tag (`photos-apache` / `photos-nginx`), and hash inputs for cache invalidation.

### Test infrastructure

- `bin/test-photos-apache.sh` → `bin/test-photos-server.sh` (server-agnostic)
- `bin/run-tests.sh` — added `--mode nginx`; removed redundant `both` mode; default is now `all` (dev + apache + nginx)
- `bin/test-all.sh` — same mode cleanup
- New Makefile targets: `web-docker-build-nginx`, `web-docker-run-nginx`, `web-docker-stop-nginx`, `web-playwright-test-nginx`, `sample-test-nginx`

### CI

Both Apache and nginx routing tests and Playwright e2e suites now run in CI.

### Docs

- `README.md` and `README-DEV.md` updated to document nginx options alongside Apache
- `docs/HISTORY.md` — Session 56 added

## Test plan

- [x] `make sample-test-apache` — Apache routing tests pass
- [x] `make sample-test-nginx` — nginx routing tests pass
- [x] `bin/test-all.sh --mode apache` — all 4 variants pass against Apache
- [x] `bin/test-all.sh --mode nginx` — all 4 variants pass against nginx