### PR TITLE
Sync grid with lightbox

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1091,3 +1091,45 @@ Added `--server apache|nginx` flag (default: `apache`). All existing calls remai
 - **`bin/run-tests.sh`** — added `--mode nginx` (port 8084) and `--mode all` (dev + apache + nginx). `both` retains its original meaning (dev + apache).
 - **`bin/test-all.sh`** — default mode changed from `both` to `all`, so CI-like runs now cover all three servers.
 - **Makefile** — added `web-docker-build-nginx`, `web-docker-run-nginx`, `web-playwright-test-nginx`, `sample-test-nginx`.
+
+### 57. Lightbox Grid Scroll Tracking
+
+When navigating photos in the PhotoSwipe lightbox, closing it always returned the user to wherever the grid happened to be scrolled — typically the photo they originally clicked on, not the one they last viewed. The goal: when the lightbox closes, the underlying grid should be scrolled so the current photo is vertically centered on screen.
+
+#### Why This Was Tricky
+
+Three compounding problems, each hiding the next:
+
+**1. Two separate scroll resets, not one.**
+`history.go(-1)` (called on close to pop the pushState photo-URL entry) triggers SvelteKit's popstate handler, which resets scroll synchronously within ~2 frames to the position saved when `pushState` was called. A double-`requestAnimationFrame` handles that. But SvelteKit *also* re-runs the album page's load function (a network fetch) and restores scroll again when it completes — ~300–500ms later. This second reset was invisible in early debugging because probes only went to 200ms.
+
+**2. `afterNavigate` doesn't fire for shallow pushState pops.**
+SvelteKit's `pushState` creates a "shallow" history entry. When popped via `history.go(-1)`, SvelteKit processes it without firing full navigation lifecycle hooks — so `afterNavigate` (the idiomatic SvelteKit override point) never fires. This burned two rounds of investigation before console logging confirmed it.
+
+**3. Live scrolling during the lightbox caused mobile glitches.**
+An early iteration also scrolled the grid *live* while navigating (in the `change` event handler), so the close animation could animate back to a visible thumbnail. On desktop this was invisible under the opaque overlay. On iOS Safari, calling `scrollTo` while a `position: fixed` element is on screen causes the fixed element to momentarily mis-render — a visible flash. Removing the live scroll and relying purely on the on-close guard fixed both platforms.
+
+#### Solution
+
+On the PhotoSwipe `change` event, compute and store the target scroll position (`pendingScrollY`) that would vertically center the current photo:
+
+```js
+const galleryTop = container.getBoundingClientRect().top + window.scrollY;
+const photoCenterY = galleryTop + box.top + box.height / 2;
+pendingScrollY = photoCenterY - window.innerHeight / 2;
+```
+
+On `close`, capture the target and start a `requestAnimationFrame` guard loop that runs every frame for 700ms, re-applying the target whenever SvelteKit resets it:
+
+```js
+const deadline = performance.now() + 700;
+const guard = () => {
+    if (Math.abs(window.scrollY - target) > 1) {
+        window.scrollTo({ top: target, behavior: 'instant' });
+    }
+    if (performance.now() < deadline) requestAnimationFrame(guard);
+};
+requestAnimationFrame(guard);
+```
+
+Any individual flash caused by a SvelteKit reset is at most one frame (~16ms) — imperceptible at 60fps. The guard covers both the immediate synchronous reset and the async one at ~400ms. All changes are in `web/src/routes/albums/[slug]/[[index]]/+page.svelte`.

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -67,6 +67,9 @@
 	// Stored so onMount cleanup can remove it when navigating away via a link while the
 	// lightbox is open (component unmounts before the close event fires).
 	let activePopstateHandler: (() => void) | null = null;
+	// Scroll target set as user navigates in the lightbox; applied on close.
+	let pendingScrollY: number | null = null;
+
 	// Image fade-in state. Populated by the $effect below, which re-runs on album change.
 	let imageSrcs = $state<string[]>([]); // src per image; empty string = not yet assigned
 	let imageLoaded = $state<boolean[]>([]); // true once the browser fires the load event
@@ -205,16 +208,29 @@
 			lightboxOpen = false;
 			lightboxClosedAt = Date.now();
 			if (!closedByBackNav) {
+				const target = pendingScrollY !== null ? Math.max(0, pendingScrollY) : null;
+				pendingScrollY = null;
+
 				if (pushedHistoryEntry) {
-					// Pop our native push entry so the album URL is restored and history
-					// is clean (subsequent back goes to the page before the album, not
-					// back to the photo URL).  Fires a popstate that SvelteKit handles
-					// as a normal navigation to /albums/slug.
 					history.go(-1);
 				} else {
-					// Permalink open (animate=false, no native push): update URL from
-					// /albums/slug/N back to /albums/slug via SvelteKit's shallow replace.
 					replaceState(`/albums/${data.slug}`, {});
+				}
+
+				if (target !== null) {
+					// SvelteKit resets scroll twice after history.go(-1):
+					//   1. Synchronous (~2 frames): handled by the first rAF iteration
+					//   2. Async (~300-500ms, after load fn completes): handled by subsequent iterations
+					// Run every frame for 700ms; re-apply target whenever a reset is detected.
+					// Any visible flash is at most one frame (~16ms).
+					const deadline = performance.now() + 700;
+					const guard = () => {
+						if (Math.abs(window.scrollY - target) > 1) {
+								window.scrollTo({ top: target, behavior: 'instant' });
+						}
+						if (performance.now() < deadline) requestAnimationFrame(guard);
+					};
+					requestAnimationFrame(guard);
 				}
 			}
 			// closedByBackNav: back button already navigated to the correct URL; nothing to do.
@@ -243,6 +259,16 @@
 			// Uses replaceState (not pushState) so every photo doesn't add a history entry
 			// — back always jumps directly to the album rather than stepping photo-by-photo.
 			replaceState(`/albums/${data.slug}/${pswp.currIndex + 1}`, {});
+			// Store the target scroll so the current photo will be centered when the
+			// lightbox closes. Applied via afterNavigate (history.go(-1) case) or directly
+			// in the close handler (replaceState case) — both fire after SvelteKit's own
+			// scroll restoration, ensuring we override it.
+			if (container) {
+				const box = layout().boxes[pswp.currIndex];
+				const galleryTop = container.getBoundingClientRect().top + window.scrollY;
+				const photoCenterY = galleryTop + box.top + box.height / 2;
+				pendingScrollY = photoCenterY - window.innerHeight / 2;
+			}
 		});
 
 		// Inject a copy-link button into PhotoSwipe's top bar (left of the close button).


### PR DESCRIPTION
After swiping to different photos in lightbox, when closing it, the grid should show the last photo seen.