### PR TITLE
Add support for AWS S3 deployment

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -107,7 +107,7 @@ The `site.env` variables are:
 | `CLOUDFRONT_ID`         | `bin/deploy-photos.sh`      | CloudFront distribution ID for cache invalidation (deploy only)                         |
 | `S3_BUCKET`             | `bin/deploy-photos.sh`      | S3 bucket name for deployment (S3 mode only; requires `--s3` flag)                      |
 | `RSYNC_DEST`            | `bin/deploy-photos.sh`      | Rsync destination path on the server (EC2/rsync mode only)                              |
-| `TEST_ALBUM_LOCAL`      | `bin/test-photos-server.sh` | Album slug used for local Apache tests                                                  |
+| `TEST_ALBUM_LOCAL`      | `bin/test-photos-server.sh` | Album slug used for local server tests                                                  |
 | `TEST_ALBUM_PROD`       | `bin/test-photos-server.sh` | Album slug used for production tests                                                    |
 | `TEST_ALBUM_HYPHEN`     | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
 
@@ -881,7 +881,7 @@ The script uses `set -eo pipefail` — any failure aborts before deployment.
 | `--dry-run`        | Pass `--dry-run`/`--dryrun` to rsync or `aws s3 sync`; skips CloudFront invalidation and post-deploy tests                      |
 | `--no-photogen`    | Skip photo generation step                                                                                                      |
 | `--no-rsync`       | Skip deploy, CloudFront invalidation, and post-deploy tests (build + local test only)                                           |
-| `--no-apache-test` | Skip both the local and post-deploy Apache routing tests                                                                        |
+| `--no-server-test` | Skip both the local and post-deploy server routing tests                                                                        |
 | `--no-playwright`  | Skip Playwright tests (both local and production)                                                                               |
 | `--config-dir`     | Directory containing `albums.yaml`, `descriptions.txt`, and (by default) `site.env`                                             |
 | `--site-env`       | Path to `site.env` — overrides `--config-dir/site.env` when the two live in different locations                                 |

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -105,12 +105,13 @@ The `site.env` variables are:
 | `VITE_COPYRIGHT_OWNER`  | Vite, Svelte                | Footer copyright name                                                                   |
 | `VITE_COPYRIGHT_YEAR`   | Vite, Svelte                | Footer copyright start year                                                             |
 | `CLOUDFRONT_ID`         | `bin/deploy-photos.sh`      | CloudFront distribution ID for cache invalidation (deploy only)                         |
-| `RSYNC_DEST`            | `bin/deploy-photos.sh`      | Rsync destination path on the server (deploy only)                                      |
+| `S3_BUCKET`             | `bin/deploy-photos.sh`      | S3 bucket name for deployment (S3 mode only; requires `--s3` flag)                      |
+| `RSYNC_DEST`            | `bin/deploy-photos.sh`      | Rsync destination path on the server (EC2/rsync mode only)                              |
 | `TEST_ALBUM_LOCAL`      | `bin/test-photos-server.sh` | Album slug used for local Apache tests                                                  |
 | `TEST_ALBUM_PROD`       | `bin/test-photos-server.sh` | Album slug used for production tests                                                    |
 | `TEST_ALBUM_HYPHEN`     | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
 
-The last five variables (`CLOUDFRONT_ID`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
+The last six variables (`CLOUDFRONT_ID`, `S3_BUCKET`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
 for deployment and server routing tests. For local development, only the `VITE_*` vars are required.
 
 In the web app, `vite.config.ts` reads `config/site.env` at startup and injects `VITE_*` keys into `process.env`
@@ -738,12 +739,14 @@ The `.htaccess` file (`web/static/.htaccess`) configures URL routing:
 
 ## Deployment
 
-DD Photos was originally built to serve my personal photo albums.  I happened
-to have my own EC2 instance with Apache for my other websites, so it was easy
-to add another one.
+DD Photos was originally built to serve my personal photo albums.  My first deployment
+re-used an existing EC2 instance with Apache which served my other websites.  The
+second (and current) deployment uses S3 as the backing store.  Both are described below.
 
-Traffic to [photos.donohoe.info](https://photos.donohoe.info) is handled by CloudFront, which filters 
-requests through a WAFv2 web ACL before forwarding clean traffic to the Apache 
+### EC2/Apache
+
+In this scenario, traffic is handled by CloudFront, which filters 
+requests through a WAFv2 web ACL before forwarding clean traffic to an Apache 
 origin on EC2.
 
 ```mermaid
@@ -757,7 +760,7 @@ The WAF (Web Application Firewall) inspects every incoming request and blocks
 suspicious or malicious traffic (things like bots or known bad IP addresses)
 before it ever reaches my server.
 
-The CDN (Content Delivery Network) caches my content at edge locations around 
+The CDN (Content Delivery Network) caches content at edge locations around 
 the world so visitors get fast load times regardless of where they are,
 and my origin server handles far less traffic.
 
@@ -766,49 +769,137 @@ my EC2 instance behind CloudFront.  It is specific to my setup, but it is
 parameterized via `site.env` so that others with a similar setup can re-use it.
 It can also be extended or changed to suit your needs.
 
+### S3 + CloudFront
+
+An alternative to EC2 is to serve the site entirely from S3 and CloudFront — no server
+required. Site files live in a private S3 bucket; CloudFront serves them using a
+signed-request mechanism called OAC (Origin Access Control).
+
+```mermaid
+flowchart LR
+    User -->|HTTPS| WAF["WAFv2 Web ACL (optional)"]
+    WAF --> CF["CloudFront CDN\n+ CloudFront Function"]
+    CF -->|SigV4| S3["S3 Bucket (private)"]
+```
+
+#### AWS Components
+
+Several AWS components are needed to serve an S3-based site:
+
+| Component                       | Purpose                                                                                                                               |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| **S3 bucket**                   | Stores all site files. Must be private — no public access block overrides.                                                            |
+| **Origin Access Control (OAC)** | Lets CloudFront sign requests to S3 using SigV4. Required because the bucket is private.                                              |
+| **S3 bucket policy**            | Grants the OAC principal `s3:GetObject` on the bucket. Without this, CloudFront gets a `403` even with OAC.                           |
+| **ACM certificate**             | TLS certificate for your domain. Must be provisioned in `us-east-1` — CloudFront requires this regardless of where your bucket lives. |
+| **CloudFront distribution**     | CDN that serves from S3 via OAC. Requires custom error responses (see below).                                                         |
+| **CloudFront Function**         | Lightweight JavaScript function (viewer-request stage) that handles URL routing. See below.                                           |
+| **DNS**                         | CNAME or alias record pointing your domain to the CloudFront distribution domain name.                                                |
+| **WAFv2 Web ACL**               | *(optional)* Blocks bots and malicious traffic before requests reach CloudFront.                                                      |
+
+**Custom error responses:** A private S3 bucket returns `403 Forbidden` (not `404`) for keys that
+don't exist — returning `404` would confirm the key's absence and enable bucket enumeration.
+Your CloudFront distribution must map both `403` and `404` to `/404.html` with a `404` response code,
+or users will see a raw XML error from S3 instead of your custom 404 page.
+
+#### CloudFront Function
+
+CloudFront Functions are lightweight JavaScript functions that run at the edge on every request.
+Attaching one at the **viewer-request** stage lets you rewrite and redirect URLs before S3 is ever
+contacted — no round-trip cost.
+
+For a SvelteKit `adapter-static` site like DD Photos, a function is **required** to handle:
+
+- **URL routing** — extensionless paths like `/albums/patagonia` map to `patagonia.html`; the root
+  `/` maps to `index.html`; unknown root-level paths fall back to `index.html` (SPA fallback)
+- **Photo permalinks** — `/albums/slug/42` maps to `/albums/slug.html` so the album page can open
+  the lightbox to photo 42 via the URL hash
+- **Domain redirects** — apex-to-www (`example.com` → `www.example.com`) and any other domain consolidation
+
+The function effectively replicates the Apache `.htaccess` rules. 
+Here is a minimal function for a SvelteKit-based photo site:
+
+```javascript
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // Root
+    if (uri === '/') {
+        request.uri = '/index.html';
+        return request;
+    }
+
+    // Photo permalink: /albums/slug/42 → /albums/slug.html
+    var photoPermalink = uri.match(/^\/albums\/([^\/]+)\/\d+$/);
+    if (photoPermalink) {
+        request.uri = '/albums/' + photoPermalink[1] + '.html';
+        return request;
+    }
+
+    // Extensionless paths
+    if (!uri.includes('.')) {
+        if (uri.indexOf('/', 1) === -1) {
+            // Root-level single-segment (/about, /unknown-page) → SPA fallback
+            request.uri = '/index.html';
+        } else {
+            // Deeper path (/albums/slug) → pre-rendered .html page
+            request.uri = uri + '.html';
+        }
+        return request;
+    }
+
+    return request;
+}
+```
+
 ### Deploy Script
 
-The included deployment script assumes the site is running from an EC2
-server with `ssh` access and is using a CloudFront CDN.  It uses the `CLOUDFRONT_ID`,
-`RSYNC_DEST` and `VITE_SITE_URL` variables from `site.env`.  It also
-assumes `AWS_APACHE` is in the environment and specifies an accessible IP to your EC2 instance.
-
-To deploy, I run `bin/deploy-photos.sh`, which:
+`bin/deploy-photos.sh` handles both S3 and EC2/rsync modes. Add `--s3` for S3 mode.
 
 1. Runs `photogen` to resize images and generate JSON
 2. Builds the static site via `npm run build` into `build/<site-id>/`
-3. Starts the Docker/Apache container if not already running, runs
-   `bin/test-photos-server.sh --local` to verify routing locally, then stops the container
-4. Runs Playwright tests against Docker/Apache
-5. Rsyncs `build/<site-id>/` to the `$RSYNC_DEST` directory on the EC2 server (`$AWS_APACHE`),
-   using `--checksum` to reduce unnecessary re-copying since Vite resets timestamps.
-   A second rsync pass syncs album data (`albums/<site-id>/`) independently.
-6. Invalidates the CloudFront cache (`$CLOUDFRONT_ID`)
-7. Runs `bin/test-photos-server.sh` to verify the deployment against production
-8. Runs Playwright tests against production (`$VITE_SITE_URL`)
+3. *(EC2 only)* Starts Docker/Apache, runs `bin/test-photos-server.sh --local` to verify routing
+   locally, runs Playwright tests against Docker/Apache, then stops the container
+4. Deploys the site:
+   - **S3**: two-pass `aws s3 sync` — pass 1 syncs the build output (excluding `albums/*` but
+     re-including `albums/*.html`); pass 2 syncs album images and JSON (`--size-only`, excluding
+     `*.html`). The two-pass approach keeps app files and photo data independent.
+   - **EC2**: two-pass `rsync` — pass 1 uses `--checksum` (Vite resets timestamps on every build);
+     pass 2 syncs album data independently.
+5. Invalidates the CloudFront cache (`$CLOUDFRONT_ID`)
+6. Runs `bin/test-photos-server.sh` to verify the deployment against production
+7. Runs Playwright tests against production (`$VITE_SITE_URL`)
 
-The script uses `set -eo pipefail` — any failure (including local tests) aborts before rsync.
+The script uses `set -eo pipefail` — any failure aborts before deployment.
 
 ### Flags
 
-| Flag               | Description                                                                                                                                       |
-|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--dry-run`        | Pass `--dry-run` to both rsync calls (shows what would transfer without touching the server); skips CloudFront invalidation and post-deploy tests |
-| `--no-photogen`    | Skip photo generation step                                                                                                                        |
-| `--no-rsync`       | Skip rsync, CloudFront invalidation, and post-deploy tests (build + local test only)                                                              |
-| `--no-apache-test` | Skip both the local and post-deploy Apache routing tests                                                                                          |
-| `--no-playwright`  | Skip Playwright tests (both local and production)                                                                                                 |
-| `--config-dir`     | Directory containing `albums.yaml`, `descriptions.txt`, and (by default) `site.env`                                                               |
-| `--site-env`       | Path to `site.env` — overrides `--config-dir/site.env` when the two live in different locations                                                   |
+| Flag               | Description                                                                                                                     |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `--s3`             | Deploy to S3 instead of EC2 via rsync (requires `S3_BUCKET` in `site.env`; skips pre-deploy Docker/Apache and Playwright tests) |
+| `--dry-run`        | Pass `--dry-run`/`--dryrun` to rsync or `aws s3 sync`; skips CloudFront invalidation and post-deploy tests                      |
+| `--no-photogen`    | Skip photo generation step                                                                                                      |
+| `--no-rsync`       | Skip deploy, CloudFront invalidation, and post-deploy tests (build + local test only)                                           |
+| `--no-apache-test` | Skip both the local and post-deploy Apache routing tests                                                                        |
+| `--no-playwright`  | Skip Playwright tests (both local and production)                                                                               |
+| `--config-dir`     | Directory containing `albums.yaml`, `descriptions.txt`, and (by default) `site.env`                                             |
+| `--site-env`       | Path to `site.env` — overrides `--config-dir/site.env` when the two live in different locations                                 |
 
 Examples:
 
 ```bash
-bin/deploy-photos.sh                          # full deploy
-bin/deploy-photos.sh --dry-run                # preview what rsync would transfer, no changes made
-bin/deploy-photos.sh --no-photogen            # skip photo generation
-bin/deploy-photos.sh --no-rsync               # build + local test only (safe on a dev machine)
-bin/deploy-photos.sh --no-photogen --no-rsync # build + local test, skip both photogen and rsync
+# S3 mode
+bin/deploy-photos.sh --s3                          # full S3 deploy
+bin/deploy-photos.sh --s3 --dry-run                # preview what s3 sync would transfer, no changes made
+bin/deploy-photos.sh --s3 --no-photogen            # skip photo generation
+
+# EC2/rsync mode
+bin/deploy-photos.sh                               # full deploy
+bin/deploy-photos.sh --dry-run                     # preview what rsync would transfer, no changes made
+bin/deploy-photos.sh --no-photogen                 # skip photo generation
+bin/deploy-photos.sh --no-rsync                    # build + local test only (safe on a dev machine)
+bin/deploy-photos.sh --no-photogen --no-rsync      # build + local test, skip both photogen and rsync
 ```
 
 ## CI (GitHub Actions)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ the web app uses.
 That's it.  Now, you can easily view your photo albums on your machine using the dev server.
 
 Finally, there is a build step which creates a static site that can easily be
-deployed to a machine that has a web server (like Apache) or theoretically
-something like AWS S3.  No code runs on a server.  No database is needed.
+deployed to a machine that has a web server (like Apache) or to AWS S3.
+No code runs on a server.  No database is needed.
 It's just HTML, CSS, JavaScript and your (resized) photos.
 
 ## Key Features
@@ -109,12 +109,11 @@ There are many ways to deploy a static site like this. It is somewhat outside th
 of this project to tackle all the various deployment strategies, but I may add more
 options in the future if there is interest.
 
-That said, I happen to already run an Apache server on an AWS EC2 instance that is fronted 
-by CloudFront.  Deployment for me is an `rsync` to this server, and I've included the 
-script which does this.  My actual AWS setup is maintained in Terraform files in a
-private repo, but I provide some details in the [README-DEV](README-DEV.md)
-for those that are curious.  Part of what makes my photos site fast is the use of the CDN
-and the fact that the site is entirely static.
+That said, I provide two deployment options out of the box: EC2/Apache via `rsync`, and
+S3+CloudFront using `aws s3 sync`. Both use the same `bin/deploy-photos.sh` script, with
+`--s3` selecting S3 mode. My personal site ([photos.donohoe.info](https://photos.donohoe.info))
+runs on S3+CloudFront. Part of what makes the site fast is the CDN and the fact that
+the site is entirely static. See [README-DEV](README-DEV.md) for AWS setup details.
 
 ## Prerequisites
 

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 SKIP_PHOTOGEN=${NO_PHOTOGEN:+true}; SKIP_PHOTOGEN=${SKIP_PHOTOGEN:-false}
 SKIP_RSYNC=false
 SKIP_PLAYWRIGHT=false
-SKIP_APACHE_TEST=false
+SKIP_SERVER_TEST=false
 DRY_RUN=false
 S3_MODE=false
 CONFIG_DIR=""
@@ -16,7 +16,7 @@ while [[ $# -gt 0 ]]; do
         --no-photogen)  SKIP_PHOTOGEN=true; shift ;;
         --no-rsync)     SKIP_RSYNC=true; shift ;;
         --no-playwright) SKIP_PLAYWRIGHT=true; shift ;;
-        --no-apache-test) SKIP_APACHE_TEST=true; shift ;;
+        --no-server-test) SKIP_SERVER_TEST=true; shift ;;
         --dry-run)      DRY_RUN=true; shift ;;
         --s3)           S3_MODE=true; shift ;;
         --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
@@ -95,7 +95,7 @@ cd web
 source "$HOME/.nvm/nvm.sh"
 SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$DDPHOTOS_ALBUMS_DIR" DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" npm run build
 
-# Local Apache test before deploying (rsync mode only — not applicable for S3).
+# Local server test before deploying (rsync mode only — not applicable for S3).
 DOCKER_STARTED=false
 _docker_cleanup() {
     if [ "$DOCKER_STARTED" = true ]; then
@@ -106,8 +106,8 @@ _docker_cleanup() {
 trap _docker_cleanup EXIT
 if [ "$S3_MODE" = true ]; then
     echo "Skipping pre-deploy local tests (--s3 mode)"
-elif [ "$SKIP_APACHE_TEST" = true ]; then
-    echo "Skipping local Apache tests (--no-apache-test)"
+elif [ "$SKIP_SERVER_TEST" = true ]; then
+    echo "Skipping local server tests (--no-server-test)"
 else
     # Verify Docker image is current before running
     "$SDIR/docker-check.sh"
@@ -126,7 +126,7 @@ else
         sleep 1
     fi
 
-    echo "Running local Apache tests..."
+    echo "Running local server tests..."
     TEST_ARGS=(--local 8080)
     [ -n "$CONFIG_DIR" ] && TEST_ARGS+=(--config-dir "$CONFIG_DIR")
     "$SDIR/test-photos-server.sh" "${TEST_ARGS[@]}"
@@ -170,8 +170,8 @@ elif [ "$S3_MODE" = true ]; then
             --query 'Invalidation.Id' --output text
     fi
 
-    if [ "$SKIP_APACHE_TEST" = true ]; then
-        echo "Skipping post-deploy server tests (--no-apache-test)"
+    if [ "$SKIP_SERVER_TEST" = true ]; then
+        echo "Skipping post-deploy server tests (--no-server-test)"
     elif [ "$DRY_RUN" = true ]; then
         echo "DRY RUN: skipping post-deploy server tests"
     else
@@ -226,10 +226,10 @@ else
         aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/*"
     fi
 
-    if [ "$SKIP_APACHE_TEST" = true ]; then
-        echo "Skipping post-deploy Apache tests (--no-apache-test)"
+    if [ "$SKIP_SERVER_TEST" = true ]; then
+        echo "Skipping post-deploy server tests (--no-server-test)"
     elif [ "$DRY_RUN" = true ]; then
-        echo "DRY RUN: skipping post-deploy Apache tests"
+        echo "DRY RUN: skipping post-deploy server tests"
     else
         # Wait, run test
         echo "Sleeping 5 to allow cache to clear..."

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -8,6 +8,7 @@ SKIP_RSYNC=false
 SKIP_PLAYWRIGHT=false
 SKIP_APACHE_TEST=false
 DRY_RUN=false
+S3_MODE=false
 CONFIG_DIR=""
 SITE_ENV_ARG=""
 while [[ $# -gt 0 ]]; do
@@ -17,6 +18,7 @@ while [[ $# -gt 0 ]]; do
         --no-playwright) SKIP_PLAYWRIGHT=true; shift ;;
         --no-apache-test) SKIP_APACHE_TEST=true; shift ;;
         --dry-run)      DRY_RUN=true; shift ;;
+        --s3)           S3_MODE=true; shift ;;
         --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
         --config-dir=*) CONFIG_DIR="${1#*=}"; shift ;;
         --site-env)     SITE_ENV_ARG="$2"; shift 2 ;;
@@ -62,14 +64,18 @@ fi
 
 # These must be set in site.env — guard early so a missing value can't
 # cause rsync --delete to target the wrong (or empty) remote path.
-[ -n "$AWS_APACHE" ]      || { echo "Error: AWS_APACHE not set in $SITE_ENV"; exit 1; }
-[ -n "$RSYNC_DEST" ]      || { echo "Error: RSYNC_DEST not set in $SITE_ENV"; exit 1; }
 [ -n "$CLOUDFRONT_ID" ]   || { echo "Error: CLOUDFRONT_ID not set in $SITE_ENV"; exit 1; }
 [ -n "$VITE_SITE_URL" ]   || { echo "Error: VITE_SITE_URL not set in $SITE_ENV"; exit 1; }
 
-# Ensure RSYNC_DEST ends with / so rsync targets an explicit directory path,
-# never a bare or empty string that could default to the remote home directory.
-[[ "$RSYNC_DEST" == */ ]] || RSYNC_DEST="${RSYNC_DEST}/"
+if [ "$S3_MODE" = true ]; then
+    [ -n "$S3_BUCKET" ] || { echo "Error: S3_BUCKET not set in $SITE_ENV"; exit 1; }
+else
+    [ -n "$AWS_APACHE" ]  || { echo "Error: AWS_APACHE not set in $SITE_ENV"; exit 1; }
+    [ -n "$RSYNC_DEST" ]  || { echo "Error: RSYNC_DEST not set in $SITE_ENV"; exit 1; }
+    # Ensure RSYNC_DEST ends with / so rsync targets an explicit directory path,
+    # never a bare or empty string that could default to the remote home directory.
+    [[ "$RSYNC_DEST" == */ ]] || RSYNC_DEST="${RSYNC_DEST}/"
+fi
 
 # Resolve DDPHOTOS_ALBUMS_DIR to absolute path
 DDPHOTOS_ALBUMS_DIR="$(cd "$DDPHOTOS_ALBUMS_DIR" && pwd)"
@@ -89,8 +95,7 @@ cd web
 source "$HOME/.nvm/nvm.sh"
 SITE_ENV="$SITE_ENV" DDPHOTOS_ALBUMS_DIR="$DDPHOTOS_ALBUMS_DIR" DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" npm run build
 
-# Local Apache test before deploying.
-# Start Docker container if not already running on port 8080, and stop it on exit.
+# Local Apache test before deploying (rsync mode only — not applicable for S3).
 DOCKER_STARTED=false
 _docker_cleanup() {
     if [ "$DOCKER_STARTED" = true ]; then
@@ -99,7 +104,9 @@ _docker_cleanup() {
     fi
 }
 trap _docker_cleanup EXIT
-if [ "$SKIP_APACHE_TEST" = true ]; then
+if [ "$S3_MODE" = true ]; then
+    echo "Skipping pre-deploy local tests (--s3 mode)"
+elif [ "$SKIP_APACHE_TEST" = true ]; then
     echo "Skipping local Apache tests (--no-apache-test)"
 else
     # Verify Docker image is current before running
@@ -123,23 +130,72 @@ else
     TEST_ARGS=(--local 8080)
     [ -n "$CONFIG_DIR" ] && TEST_ARGS+=(--config-dir "$CONFIG_DIR")
     "$SDIR/test-photos-server.sh" "${TEST_ARGS[@]}"
-fi
 
-if [ "$SKIP_PLAYWRIGHT" = true ]; then
-    echo "Skipping Playwright tests (--no-playwright)"
-else
-    echo "Running Playwright e2e tests..."
-    npx playwright test
+    if [ "$SKIP_PLAYWRIGHT" = true ]; then
+        echo "Skipping pre-deploy Playwright tests (--no-playwright)"
+    else
+        echo "Running pre-deploy Playwright e2e tests..."
+        npx playwright test
+    fi
 fi
-
-RSYNC_OPTS="-avz --checksum --delete"
-RSYNC_OPTS_ALBUMS="-avz --delete"
-[ "$DRY_RUN" = true ] && RSYNC_OPTS="$RSYNC_OPTS --dry-run"
-[ "$DRY_RUN" = true ] && RSYNC_OPTS_ALBUMS="$RSYNC_OPTS_ALBUMS --dry-run"
 
 if [ "$SKIP_RSYNC" = true ]; then
-    echo "Skipping rsync, CloudFront invalidation, and post-deploy test (--no-rsync)"
+    echo "Skipping deploy, CloudFront invalidation, and post-deploy tests (--no-rsync)"
+elif [ "$S3_MODE" = true ]; then
+    [ "$DRY_RUN" = true ] && echo "=== DRY RUN: aws s3 sync will not transfer any files ==="
+
+    S3_SYNC_OPTS="--delete"
+    [ "$DRY_RUN" = true ] && S3_SYNC_OPTS="$S3_SYNC_OPTS --dryrun"
+
+    # Deploy app files + pre-rendered album HTML/JSON.
+    # Pass 1: sync web build, protecting albums/ image/JSON data (managed by Pass 2 below).
+    # --exclude "albums/*" prevents uploading or deleting album images/JSON from S3.
+    # --include "albums/*.html" re-includes pre-rendered SvelteKit album pages (last rule wins).
+    # shellcheck disable=SC2086
+    aws s3 sync "$REPO_ROOT/build/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/" \
+        $S3_SYNC_OPTS --exclude "albums/*" --include "albums/*.html"
+
+    # Deploy album data (images + JSON) independently.
+    # --size-only: photogen preserves timestamps, so size alone is a reliable change signal.
+    # --exclude=*.html: don't delete pre-rendered .html pages synced above.
+    # shellcheck disable=SC2086
+    aws s3 sync "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/albums/" \
+        $S3_SYNC_OPTS --size-only --exclude "*.html"
+
+    # Clear cache (skipped in dry-run mode)
+    if [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping CloudFront invalidation"
+    else
+        aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/*" \
+            --query 'Invalidation.Id' --output text
+    fi
+
+    if [ "$SKIP_APACHE_TEST" = true ]; then
+        echo "Skipping post-deploy server tests (--no-apache-test)"
+    elif [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping post-deploy server tests"
+    else
+        echo "Sleeping 5 to allow cache to clear..."
+        sleep 5
+        PROD_ARGS=(--s3)
+        [ -n "$CONFIG_DIR" ] && PROD_ARGS+=(--config-dir "$CONFIG_DIR")
+        "$SDIR/test-photos-server.sh" "${PROD_ARGS[@]}"
+    fi
+
+    if [ "$SKIP_PLAYWRIGHT" = true ]; then
+        echo "Skipping Playwright tests against production (--no-playwright)"
+    elif [ "$DRY_RUN" = true ]; then
+        echo "DRY RUN: skipping Playwright tests against production"
+    else
+        echo "Running Playwright e2e tests against production..."
+        PLAYWRIGHT_BASE_URL="$VITE_SITE_URL" npx playwright test
+    fi
 else
+    RSYNC_OPTS="-avz --checksum --delete"
+    RSYNC_OPTS_ALBUMS="-avz --delete"
+    [ "$DRY_RUN" = true ] && RSYNC_OPTS="$RSYNC_OPTS --dry-run"
+    [ "$DRY_RUN" = true ] && RSYNC_OPTS_ALBUMS="$RSYNC_OPTS_ALBUMS --dry-run"
+
     [ "$DRY_RUN" = true ] && echo "=== DRY RUN: rsync will not transfer any files ==="
 
     # Deploy app files + pre-rendered album HTML/JSON.

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -23,6 +23,7 @@ SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 LOCAL=0
 PORT=8080
 CONFIG_DIR=""
+S3_MODE=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -36,6 +37,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
         --config-dir=*) CONFIG_DIR="${1#*=}"; shift ;;
+        --s3)           S3_MODE=1; shift ;;
         *) shift ;;
     esac
 done
@@ -54,9 +56,13 @@ if [ "$LOCAL" -eq 1 ]; then
     ALBUM="${TEST_ALBUM_LOCAL:-antarctica}"
 else
     BASE="$VITE_SITE_URL"
-    # Apache returns http:// in redirect Location headers since CloudFront
-    # terminates SSL and forwards HTTP to the origin.
-    REDIRECT_BASE="$(echo "$VITE_SITE_URL" | sed 's|^https://|http://|')"
+    if [ "$S3_MODE" -eq 1 ]; then
+        # S3+CloudFront: redirects come from CloudFront Functions and use https://
+        REDIRECT_BASE="$VITE_SITE_URL"
+    else
+        # Apache behind CloudFront: Apache sees HTTP and returns http:// in Location headers
+        REDIRECT_BASE="$(echo "$VITE_SITE_URL" | sed 's|^https://|http://|')"
+    fi
     ALBUM="${TEST_ALBUM_PROD:-patagonia}"
 fi
 
@@ -154,7 +160,7 @@ echo "Static assets (expect 200):"
 check_status "$BASE/favicon.ico"                  200 "Favicon"
 check_status "$BASE/robots.txt"                   200 "Robots.txt"
 check_status "$BASE/albums/config.json"           200 "Config JSON"
-check_status "$BASE/sitemap.xml"                  200 "Sitemap"
+check_status "$BASE/albums/sitemap.xml"            200 "Sitemap"
 
 echo ""
 echo "Trailing slash redirects (expect 301 -> no slash):"


### PR DESCRIPTION
## Summary

Adds S3 deployment support to `bin/deploy-photos.sh` alongside the existing EC2/rsync mode.

### `bin/deploy-photos.sh`
- New `--s3` flag selects S3 mode (default remains EC2/rsync)
- S3 mode uses a two-pass `aws s3 sync`: pass 1 syncs the SvelteKit build output (excluding `albums/*` but re-including pre-rendered `albums/*.html`); pass 2 syncs album images and JSON (`--size-only`, excluding `*.html`) — keeps app files and photo data independent
- Pre-deploy Docker/Apache and Playwright tests are skipped in S3 mode (no local equivalent of the S3+CloudFront stack); post-deploy routing tests and Playwright run against production as usual
- Guards for `S3_BUCKET`, `AWS_APACHE`, and `RSYNC_DEST` are now mode-specific

### `bin/test-photos-server.sh`
- New `--s3` flag: in S3+CloudFront mode, redirect `Location` headers use `https://` (CloudFront Functions redirect); EC2/Apache mode continues to use `http://` (Apache sees HTTP behind CloudFront)
- Fixed sitemap test path: `sitemap.xml` is served at `/albums/sitemap.xml`, not `/sitemap.xml`

### Docs
- `README.md`: updated Tech Details to describe both EC2 and S3+CloudFront deployment options
- `README-DEV.md`: added S3+CloudFront section (AWS components, CloudFront Function sample, deploy steps); updated env vars table (`S3_BUCKET`); consolidated deploy script docs; updated flags table