### PR TITLE
Migrate VITE_* to albums.yaml

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -102,31 +102,39 @@ LOG_REQUESTS=1 make sample-npm-run-dev
 
 ## Environment Variables
 
-The `site.env` variables are:
+### Site Identity (`albums.yaml`)
 
-| Variable                | Used by                     | Description                                                                             |
-|-------------------------|-----------------------------|-----------------------------------------------------------------------------------------|
-| `VITE_ALLOW_CRAWLING`   | Vite, Svelte                | Set to `true` to allow crawling and include `Sitemap:` in robots.txt (default: `false`) |
-| `VITE_SITE_NAME`        | Vite, Svelte                | Site title shown in browser and OG tags                                                 |
-| `VITE_SITE_URL`         | Vite, Svelte, bin/          | Canonical base URL (e.g. `https://photos.example.com`)                                  |
-| `VITE_SITE_DESCRIPTION` | Vite, Svelte                | Meta description and OG description                                                     |
-| `VITE_COPYRIGHT_OWNER`  | Vite, Svelte                | Footer copyright name                                                                   |
-| `VITE_COPYRIGHT_YEAR`   | Vite, Svelte                | Footer copyright start year                                                             |
-| `CLOUDFRONT_ID`         | `bin/deploy-photos.sh`      | CloudFront distribution ID for cache invalidation (deploy only)                         |
-| `S3_BUCKET`             | `bin/deploy-photos.sh`      | S3 bucket name for deployment (S3 mode only; requires `--s3` flag)                      |
-| `RSYNC_DEST`            | `bin/deploy-photos.sh`      | Rsync destination path on the server (EC2/rsync mode only)                              |
-| `TEST_ALBUM_LOCAL`      | `bin/test-photos-server.sh` | Album slug used for local server tests                                                  |
-| `TEST_ALBUM_PROD`       | `bin/test-photos-server.sh` | Album slug used for production tests                                                    |
-| `TEST_ALBUM_HYPHEN`     | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)                                  |
+Site identity settings live in the `settings:` block of `albums.yaml` and are written
+into `config.json` by `photogen`. The frontend reads them at runtime via `fetch('/albums/config.json')` —
+no build-time injection needed.
 
-The last six variables (`CLOUDFRONT_ID`, `S3_BUCKET`, `RSYNC_DEST`, `TEST_ALBUM_*`) are only needed
-for deployment and server routing tests. For local development, only the `VITE_*` vars are required.
+| Setting            | Required | Description                                                                                       |
+|--------------------|----------|---------------------------------------------------------------------------------------------------|
+| `site_name`        | yes      | Site title shown in the browser tab and OG tags                                                   |
+| `site_url`         | yes      | Canonical base URL (e.g. `https://photos.example.com`); used in sitemap and OG tags               |
+| `site_description` | yes      | Meta description and OG description for the home page                                             |
+| `copyright_owner`  | yes      | Name shown in the footer copyright line                                                           |
+| `copyright_year`   | yes      | Start year shown in the footer copyright line                                                     |
+| `allow_crawling`   | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`) |
 
-In the web app, `vite.config.ts` reads `config/site.env` at startup and injects `VITE_*` keys into `process.env`
-before Vite runs, so the values are available as `import.meta.env.VITE_*` in Svelte components.
-Multi-word values must be quoted (e.g. `VITE_SITE_NAME="My Photo Albums"`).
+`photogen`'s `Config.Validate()` enforces all required fields before any files are written.
 
-The `bin` scripts `source` the file directly.
+### Deploy and Test Variables (`site.env`)
+
+The `site.env` file holds variables used only by deployment scripts and tests — nothing
+that affects the built site itself.
+
+| Variable            | Used by                     | Description                                                     |
+|---------------------|-----------------------------|-----------------------------------------------------------------|
+| `CLOUDFRONT_ID`     | `bin/deploy-photos.sh`      | CloudFront distribution ID for cache invalidation (deploy only) |
+| `S3_BUCKET`         | `bin/deploy-photos.sh`      | S3 bucket name for deployment (S3 mode only; requires `--s3`)   |
+| `RSYNC_DEST`        | `bin/deploy-photos.sh`      | Rsync destination path on the server (EC2/rsync mode only)      |
+| `TEST_ALBUM_LOCAL`  | `bin/test-photos-server.sh` | Album slug used for local server tests                          |
+| `TEST_ALBUM_PROD`   | `bin/test-photos-server.sh` | Album slug used for production tests                            |
+| `TEST_ALBUM_HYPHEN` | `bin/test-photos-server.sh` | Album slug with a hyphen (tests URL routing edge case)          |
+
+The `bin` scripts `source` this file directly. For local development, these variables
+are not needed — only `albums.yaml` settings are required.
 
 The `SITE_ENV` environment variable overrides which `site.env` file is loaded. This is useful
 when your config lives outside the repo (e.g. in a private config repo):
@@ -207,7 +215,21 @@ Common tasks are available via `make` from the repo root:
 
 To resize photos and generate the JSON indexes, run `photogen`. Albums are
 defined in a YAML config file (default: `config/albums.yaml`). See
-[config/albums.example.yaml](config/albums.example.yaml) for the format.  
+[config/albums.example.yaml](config/albums.example.yaml) for the full format.
+
+The `settings:` block at the top of `albums.yaml` has several required fields that are
+validated before any files are written:
+
+```yaml
+settings:
+  id: my-site                                    # required; names the output directory
+  site_name: "My Photo Albums"                   # required
+  site_url: https://photos.example.com           # required
+  site_description: "A collection of photos"     # required
+  copyright_owner: "Your Name"                   # required
+  copyright_year: 2020                           # required
+  # allow_crawling: false                        # optional; default false
+```
 
 Album descriptions are in a TXT file (default: `config/descriptions.txt`).
 See [config/descriptions.example.txt](config/descriptions.example.txt)
@@ -625,9 +647,9 @@ make web-docker-test
 You can also run the script directly, against production or locally:
 
 ```bash
-bin/test-photos-server.sh               # production ($VITE_SITE_URL)
-bin/test-photos-server.sh --local       # local Docker on port 8080
-bin/test-photos-server.sh --local 9090  # local Docker on custom port
+bin/test-photos-server.sh --remote https://photos.example.com   # remote site
+bin/test-photos-server.sh --local                               # local Docker on port 8080
+bin/test-photos-server.sh --local 9090                          # local Docker on custom port
 ```
 
 The deployment script runs this script automatically after deploying.
@@ -875,7 +897,7 @@ function handler(event) {
      pass 2 syncs album data independently.
 5. Invalidates the CloudFront cache (`$CLOUDFRONT_ID`)
 6. Runs `bin/test-photos-server.sh` to verify the deployment against production
-7. Runs Playwright tests against production (`$VITE_SITE_URL`)
+7. Runs Playwright tests against production (URL read from `config.json`)
 
 The script uses `set -eo pipefail` — any failure aborts before deployment.
 

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -65,7 +65,6 @@ fi
 # These must be set in site.env — guard early so a missing value can't
 # cause rsync --delete to target the wrong (or empty) remote path.
 [ -n "$CLOUDFRONT_ID" ]   || { echo "Error: CLOUDFRONT_ID not set in $SITE_ENV"; exit 1; }
-[ -n "$VITE_SITE_URL" ]   || { echo "Error: VITE_SITE_URL not set in $SITE_ENV"; exit 1; }
 
 if [ "$S3_MODE" = true ]; then
     [ -n "$S3_BUCKET" ] || { echo "Error: S3_BUCKET not set in $SITE_ENV"; exit 1; }
@@ -89,6 +88,12 @@ else
     # shellcheck disable=SC2086
     go run ./cmd/photogen $PHOTOGEN_ARGS
 fi
+
+# Read site URL from config.json (written by photogen)
+CONFIG_JSON="$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/config.json"
+[ -f "$CONFIG_JSON" ] || { echo "Error: $CONFIG_JSON not found — run photogen first"; exit 1; }
+SITE_URL=$(python3 -c "import json; print(json.load(open('$CONFIG_JSON'))['siteUrl'])")
+[ -n "$SITE_URL" ] || { echo "Error: siteUrl not found in $CONFIG_JSON"; exit 1; }
 
 # Build static site
 cd web
@@ -177,7 +182,7 @@ elif [ "$S3_MODE" = true ]; then
     else
         echo "Sleeping 5 to allow cache to clear..."
         sleep 5
-        PROD_ARGS=(--s3)
+        PROD_ARGS=(--s3 --remote "$SITE_URL")
         [ -n "$CONFIG_DIR" ] && PROD_ARGS+=(--config-dir "$CONFIG_DIR")
         "$SDIR/test-photos-server.sh" "${PROD_ARGS[@]}"
     fi
@@ -188,7 +193,7 @@ elif [ "$S3_MODE" = true ]; then
         echo "DRY RUN: skipping Playwright tests against production"
     else
         echo "Running Playwright e2e tests against production..."
-        PLAYWRIGHT_BASE_URL="$VITE_SITE_URL" npx playwright test
+        PLAYWRIGHT_BASE_URL="$SITE_URL" npx playwright test
     fi
 else
     RSYNC_OPTS="-avz --checksum --delete"
@@ -234,7 +239,7 @@ else
         # Wait, run test
         echo "Sleeping 5 to allow cache to clear..."
         sleep 5
-        PROD_ARGS=()
+        PROD_ARGS=(--remote "$SITE_URL")
         [ -n "$CONFIG_DIR" ] && PROD_ARGS+=(--config-dir "$CONFIG_DIR")
         "$SDIR/test-photos-server.sh" "${PROD_ARGS[@]}"
     fi
@@ -245,6 +250,6 @@ else
         echo "DRY RUN: skipping Playwright tests against production"
     else
         echo "Running Playwright e2e tests against production..."
-        PLAYWRIGHT_BASE_URL="$VITE_SITE_URL" npx playwright test
+        PLAYWRIGHT_BASE_URL="$SITE_URL" npx playwright test
     fi
 fi

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -6,9 +6,9 @@
 # Works against any web server (Apache or nginx).
 #
 # Usage:
-#   bin/test-photos-server.sh                  # test production ($VITE_SITE_URL)
-#   bin/test-photos-server.sh --local          # test local Docker on port 8080
-#   bin/test-photos-server.sh --local 9090     # test local Docker on port 9090
+#   bin/test-photos-server.sh --local              # test local Docker on port 8080
+#   bin/test-photos-server.sh --local 9090         # test local Docker on port 9090
+#   bin/test-photos-server.sh --remote URL         # test a remote site at URL
 #
 # Note: In production, Apache is behind CloudFront, so:
 #   - Redirect locations use http:// (Apache sees HTTP from CloudFront)
@@ -22,6 +22,7 @@ SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
 LOCAL=0
 PORT=8080
+REMOTE_URL=""
 CONFIG_DIR=""
 S3_MODE=0
 
@@ -35,6 +36,8 @@ while [[ $# -gt 0 ]]; do
             fi
             shift
             ;;
+        --remote)       REMOTE_URL="$2"; shift 2 ;;
+        --remote=*)     REMOTE_URL="${1#*=}"; shift ;;
         --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
         --config-dir=*) CONFIG_DIR="${1#*=}"; shift ;;
         --s3)           S3_MODE=1; shift ;;
@@ -55,13 +58,14 @@ if [ "$LOCAL" -eq 1 ]; then
     REDIRECT_BASE="http://localhost:$PORT"
     ALBUM="${TEST_ALBUM_LOCAL:-antarctica}"
 else
-    BASE="$VITE_SITE_URL"
+    [ -n "$REMOTE_URL" ] || { echo "Error: --remote URL is required when not using --local"; exit 1; }
+    BASE="$REMOTE_URL"
     if [ "$S3_MODE" -eq 1 ]; then
         # S3+CloudFront: redirects come from CloudFront Functions and use https://
-        REDIRECT_BASE="$VITE_SITE_URL"
+        REDIRECT_BASE="$REMOTE_URL"
     else
         # Apache behind CloudFront: Apache sees HTTP and returns http:// in Location headers
-        REDIRECT_BASE="$(echo "$VITE_SITE_URL" | sed 's|^https://|http://|')"
+        REDIRECT_BASE="$(echo "$REMOTE_URL" | sed 's|^https://|http://|')"
     fi
     ALBUM="${TEST_ALBUM_PROD:-patagonia}"
 fi

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -111,19 +111,24 @@ func main() {
 
 	warn := &photogen.WarnCollector{}
 	cfg := &photogen.Config{
-		OutputRoot:   filepath.Clean(resolvedAlbumsDir),
-		SiteID:       resolvedSiteID,
-		DryRun:       !(*doit),
-		SkipVariant:  true,
-		Limit:        *limit,
-		Force:        *force,
-		Resize:       *resize,
-		Index:        *index,
-		SiteURL:      resolvedSiteURL,
-		NumWorkers:   *numWorkers,
-		Warn:         warn,
-		CustomCSS:    resolvedCSSPath,
-		DefaultTheme: settings.DefaultTheme,
+		OutputRoot:      filepath.Clean(resolvedAlbumsDir),
+		SiteID:          resolvedSiteID,
+		DryRun:          !(*doit),
+		SkipVariant:     true,
+		Limit:           *limit,
+		Force:           *force,
+		Resize:          *resize,
+		Index:           *index,
+		SiteName:        settings.SiteName,
+		SiteURL:         resolvedSiteURL,
+		SiteDescription: settings.SiteDescription,
+		CopyrightOwner:  settings.CopyrightOwner,
+		CopyrightYear:   settings.CopyrightYear,
+		AllowCrawling:   settings.AllowCrawling,
+		NumWorkers:      *numWorkers,
+		Warn:            warn,
+		CustomCSS:       resolvedCSSPath,
+		DefaultTheme:    settings.DefaultTheme,
 	}
 
 	// -passwords overrides settings.passwords; fall back to YAML setting if flag not provided

--- a/config/albums.example.yaml
+++ b/config/albums.example.yaml
@@ -16,8 +16,22 @@ settings:
   # Lowercase letters, digits, and hyphens only (e.g. "prod", "my-site").
   id: my-site
 
-  # Base URL used when generating sitemap.xml
+  # Site title displayed in the browser tab and social sharing cards
+  site_name: "Your Photo Albums"
+
+  # Base URL used when generating sitemap.xml, OG/social sharing tags, and canonical links
   site_url: https://photos.example.com
+
+  # Site description shown in search results and social sharing cards
+  site_description: "A collection of photo albums"
+
+  # Footer copyright line: "Copyright © {copyright_year}-{current_year}. {copyright_owner}."
+  copyright_owner: "Your Name"
+  copyright_year: 2000
+
+  # Allow search engine crawling (default: false).
+  # When true, robots.txt allows all bots and includes the sitemap URL.
+  # allow_crawling: false
 
   # Descriptions file (relative to this config dir). Each line:
   #   slug<whitespace>description

--- a/config/site.example.env
+++ b/config/site.example.env
@@ -1,11 +1,3 @@
-# Site identity — consumed by Vite (VITE_* prefix) and bin/ scripts
-VITE_ALLOW_CRAWLING=false
-VITE_SITE_NAME="Your Photo Albums"
-VITE_SITE_URL=https://photos.example.com
-VITE_SITE_DESCRIPTION="A collection of photo albums"
-VITE_COPYRIGHT_OWNER="Your Name"
-VITE_COPYRIGHT_YEAR=2000
-
 # Deploy infrastructure — consumed by bin/deploy-photos.sh
 CLOUDFRONT_ID=YOUR_CLOUDFRONT_DISTRIBUTION_ID
 RSYNC_DEST=/path/to/your/web/root/

--- a/pkg/photogen/albums_config.go
+++ b/pkg/photogen/albums_config.go
@@ -18,13 +18,18 @@ type AlbumsFile struct {
 
 // AlbumsSettings holds site-level configuration from the YAML settings block.
 type AlbumsSettings struct {
-	ID           string     `yaml:"id"` // site identifier; output goes to {DDPHOTOS_ALBUMS_DIR}/{id}/
-	SiteURL      string     `yaml:"site_url"`
-	Descriptions string     `yaml:"descriptions"`  // filename relative to config dir
-	Passwords    string     `yaml:"passwords"`     // filename relative to config dir; enables encryption
-	CustomCSS    string     `yaml:"css"`           // filename relative to config dir; copied to output
-	DefaultTheme string     `yaml:"default_theme"` // "light" or "dark" (default: "dark")
-	Hero         *HeroEntry `yaml:"hero"`
+	ID              string     `yaml:"id"`               // site identifier; output goes to {DDPHOTOS_ALBUMS_DIR}/{id}/
+	SiteName        string     `yaml:"site_name"`        // displayed in page title and OG tags
+	SiteURL         string     `yaml:"site_url"`         // base URL for sitemap and OG tags
+	SiteDescription string     `yaml:"site_description"` // meta description and OG description
+	CopyrightOwner  string     `yaml:"copyright_owner"`  // name shown in footer copyright
+	CopyrightYear   int        `yaml:"copyright_year"`   // start year shown in footer copyright
+	AllowCrawling   bool       `yaml:"allow_crawling"`   // controls robots.txt (default: false)
+	Descriptions    string     `yaml:"descriptions"`     // filename relative to config dir
+	Passwords       string     `yaml:"passwords"`        // filename relative to config dir; enables encryption
+	CustomCSS       string     `yaml:"css"`              // filename relative to config dir; copied to output
+	DefaultTheme    string     `yaml:"default_theme"`    // "light" or "dark" (default: "dark")
+	Hero            *HeroEntry `yaml:"hero"`
 
 	// Resolved paths (populated by ToAlbumConfigs; not from YAML).
 	HeroImagePath string `yaml:"-"`

--- a/pkg/photogen/config.go
+++ b/pkg/photogen/config.go
@@ -34,8 +34,18 @@ type Config struct {
 	Resize bool
 	// Index enables generating JSON index files (albums.json and per-album index.json).
 	Index bool
-	// SiteURL is the base URL for sitemap generation (e.g., "https://photos.example.com").
+	// SiteName is the site title displayed in the browser and OG tags.
+	SiteName string
+	// SiteURL is the base URL for sitemap and OG tag generation (e.g., "https://photos.example.com").
 	SiteURL string
+	// SiteDescription is the meta description and OG description for the home page.
+	SiteDescription string
+	// CopyrightOwner is the name shown in the footer copyright line.
+	CopyrightOwner string
+	// CopyrightYear is the start year shown in the footer copyright line.
+	CopyrightYear int
+	// AllowCrawling controls robots.txt: true = allow all; false = disallow all.
+	AllowCrawling bool
 	// NumWorkers is the number of concurrent resize workers (0 = auto-detect based on CPU count).
 	NumWorkers int
 	// Warn collects warnings for re-display at the end of the run.
@@ -84,6 +94,18 @@ func (c *Config) Validate() error {
 	}
 	if !validSiteID.MatchString(c.SiteID) {
 		return fmt.Errorf("settings.id %q must contain only lowercase letters, digits, and hyphens", c.SiteID)
+	}
+	if c.SiteName == "" {
+		return fmt.Errorf("settings.site_name is required")
+	}
+	if c.SiteDescription == "" {
+		return fmt.Errorf("settings.site_description is required")
+	}
+	if c.CopyrightOwner == "" {
+		return fmt.Errorf("settings.copyright_owner is required")
+	}
+	if c.CopyrightYear == 0 {
+		return fmt.Errorf("settings.copyright_year is required")
 	}
 	if c.Encrypt != nil {
 		if err := c.Encrypt.Validate(); err != nil {

--- a/pkg/photogen/config_test.go
+++ b/pkg/photogen/config_test.go
@@ -59,12 +59,32 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: "settings.id",
 		},
 		{
+			name:    "missing site name",
+			config:  Config{OutputRoot: "/tmp/out", SiteID: "my-site"},
+			wantErr: "settings.site_name",
+		},
+		{
+			name:    "missing site description",
+			config:  Config{OutputRoot: "/tmp/out", SiteID: "my-site", SiteName: "My Site"},
+			wantErr: "settings.site_description",
+		},
+		{
+			name:    "missing copyright owner",
+			config:  Config{OutputRoot: "/tmp/out", SiteID: "my-site", SiteName: "My Site", SiteDescription: "Desc"},
+			wantErr: "settings.copyright_owner",
+		},
+		{
+			name:    "missing copyright year",
+			config:  Config{OutputRoot: "/tmp/out", SiteID: "my-site", SiteName: "My Site", SiteDescription: "Desc", CopyrightOwner: "Me"},
+			wantErr: "settings.copyright_year",
+		},
+		{
 			name:   "valid config",
-			config: Config{OutputRoot: "/tmp/out", SiteID: "my-site"},
+			config: Config{OutputRoot: "/tmp/out", SiteID: "my-site", SiteName: "My Site", SiteDescription: "Desc", CopyrightOwner: "Me", CopyrightYear: 2020},
 		},
 		{
 			name:   "valid config single char id",
-			config: Config{OutputRoot: "/tmp/out", SiteID: "x"},
+			config: Config{OutputRoot: "/tmp/out", SiteID: "x", SiteName: "My Site", SiteDescription: "Desc", CopyrightOwner: "Me", CopyrightYear: 2020},
 		},
 	}
 

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -274,14 +274,20 @@ func (c *Config) WriteAlbumsIndex(summaries []AlbumSummary) error {
 
 // SiteConfig is the structure for config.json (always unencrypted).
 type SiteConfig struct {
-	SiteID       string            `json:"siteId"`
-	AlbumsFile   string            `json:"albumsFile"`
-	SiteHint     string            `json:"siteHint,omitempty"`
-	AlbumHints   map[string]string `json:"albumHints,omitempty"`
-	Encrypted    bool              `json:"encrypted,omitempty"`    // true if any encryption is configured
-	HeroImage    string            `json:"heroImage,omitempty"`    // "hero.jpg" if a hero image is configured
-	CustomCSS    string            `json:"customCss,omitempty"`    // "custom.css" if a CSS override is configured
-	DefaultTheme string            `json:"defaultTheme,omitempty"` // "light" or "dark"; omitted when dark (the built-in default)
+	SiteID          string            `json:"siteId"`
+	AlbumsFile      string            `json:"albumsFile"`
+	SiteName        string            `json:"siteName"`
+	SiteURL         string            `json:"siteUrl"`
+	SiteDescription string            `json:"siteDescription"`
+	CopyrightOwner  string            `json:"copyrightOwner"`
+	CopyrightYear   int               `json:"copyrightYear"`
+	AllowCrawling   bool              `json:"allowCrawling,omitempty"`
+	SiteHint        string            `json:"siteHint,omitempty"`
+	AlbumHints      map[string]string `json:"albumHints,omitempty"`
+	Encrypted       bool              `json:"encrypted,omitempty"`    // true if any encryption is configured
+	HeroImage       string            `json:"heroImage,omitempty"`    // "hero.jpg" if a hero image is configured
+	CustomCSS       string            `json:"customCss,omitempty"`    // "custom.css" if a CSS override is configured
+	DefaultTheme    string            `json:"defaultTheme,omitempty"` // "light" or "dark"; omitted when dark (the built-in default)
 }
 
 // WriteConfigJSON writes config.json indicating which albums file to load.
@@ -297,7 +303,16 @@ func (c *Config) WriteConfigJSON() error {
 		c.TrackFile(outputPath)
 		return nil
 	}
-	cfg := SiteConfig{SiteID: c.SiteID, AlbumsFile: albumsFile}
+	cfg := SiteConfig{
+		SiteID:          c.SiteID,
+		AlbumsFile:      albumsFile,
+		SiteName:        c.SiteName,
+		SiteURL:         c.SiteURL,
+		SiteDescription: c.SiteDescription,
+		CopyrightOwner:  c.CopyrightOwner,
+		CopyrightYear:   c.CopyrightYear,
+		AllowCrawling:   c.AllowCrawling,
+	}
 	if c.Encrypt != nil {
 		cfg.Encrypted = true
 		cfg.SiteHint = c.Encrypt.SiteHint

--- a/sample/config/albums.yaml
+++ b/sample/config/albums.yaml
@@ -1,6 +1,11 @@
 settings:
   id: sample
+  site_name: "Sample Photo Albums"
   site_url: https://sample.donohoe.info
+  site_description: "Photo albums from our travels and adventures"
+  copyright_owner: "Doug and Cindy Donohoe"
+  copyright_year: 2001
+  allow_crawling: true
   descriptions: descriptions.txt
   hero:
     image: theway/2024-The-Way-13.jpg

--- a/sample/config/site.env
+++ b/sample/config/site.env
@@ -1,10 +1,3 @@
-# Site identity — consumed by Vite (VITE_* prefix) and bin/ scripts
-VITE_SITE_NAME="Sample Photo Albums"
-VITE_SITE_URL=https://sample.donohoe.info
-VITE_SITE_DESCRIPTION="Photo albums from our travels and adventures"
-VITE_COPYRIGHT_OWNER="Doug and Cindy Donohoe"
-VITE_COPYRIGHT_YEAR=2001
-
 # Test album slugs — consumed by bin/test-photos-apache.sh
 TEST_ALBUM_LOCAL=antarctica
 TEST_ALBUM_PROD=antarctica

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -11,13 +11,7 @@ declare global {
 }
 
 interface ImportMetaEnv {
-	readonly VITE_SITE_NAME: string;
-	readonly VITE_SITE_URL: string;
-	readonly VITE_SITE_DESCRIPTION: string;
-	readonly VITE_COPYRIGHT_OWNER: string;
-	readonly VITE_COPYRIGHT_YEAR: string;
 	readonly VITE_BUILD_TIME: string;
-	readonly VITE_ALLOW_CRAWLING: string;
 }
 
 // Augments Vite's built-in ImportMeta interface to add type-safe access to

--- a/web/src/lib/components/OpenGraph.svelte
+++ b/web/src/lib/components/OpenGraph.svelte
@@ -3,10 +3,11 @@
 		title: string;
 		description: string;
 		url: string;
+		siteName: string;
 		image?: string;
 	}
 
-	let { title, description, url, image }: Props = $props();
+	let { title, description, url, siteName, image }: Props = $props();
 </script>
 
 <svelte:head>
@@ -22,6 +23,6 @@
 	{:else}
 		<meta name="twitter:card" content="summary" />
 	{/if}
-	<meta property="og:site_name" content={import.meta.env.VITE_SITE_NAME} />
+	<meta property="og:site_name" content={siteName} />
 	<link rel="canonical" href={url} />
 </svelte:head>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,12 @@ export interface AlbumSummary {
 export interface SiteConfig {
 	siteId: string;
 	albumsFile: string;
+	siteName: string;
+	siteUrl: string;
+	siteDescription: string;
+	copyrightOwner: string;
+	copyrightYear: number;
+	allowCrawling?: boolean;
 	siteHint?: string;
 	albumHints?: Record<string, string>;
 	encrypted?: boolean;

--- a/web/src/routes/+error.svelte
+++ b/web/src/routes/+error.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<title>Error - {import.meta.env.VITE_SITE_NAME}</title>
+	<title>Error - DD Photos</title>
 </svelte:head>
 
 <main>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -103,7 +103,7 @@
 	</div>
 	{@render children()}
 	<footer class:ready={!page.data.encryptedBlob || $footerReady}>
-		<div>Copyright © {import.meta.env.VITE_COPYRIGHT_YEAR}-{new Date().getFullYear()}. {import.meta.env.VITE_COPYRIGHT_OWNER}.</div>
+		<div>Copyright © {data.siteConfig?.copyrightYear}-{new Date().getFullYear()}. {data.siteConfig?.copyrightOwner}.</div>
 		<div class="built-with">Built {builtOn} with <button class="about-btn" onclick={openAbout}>DD Photos</button>.</div>
 	</footer>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -71,9 +71,9 @@
 		}
 	});
 
-	const siteName = import.meta.env.VITE_SITE_NAME;
-	const siteUrl = import.meta.env.VITE_SITE_URL;
-	const siteDesc = import.meta.env.VITE_SITE_DESCRIPTION;
+	const siteName = $derived(data.siteConfig.siteName);
+	const siteUrl = $derived(data.siteConfig.siteUrl);
+	const siteDesc = $derived(data.siteConfig.siteDescription);
 
 	// Client-decrypted albums list (null until decryption succeeds).
 	let decryptedAlbums = $state<AlbumSummary[] | null>(null);
@@ -213,7 +213,7 @@
 	}
 </script>
 
-<OpenGraph title={siteName} description={siteDesc} url={siteUrl} image={ogImage} />
+<OpenGraph title={siteName} description={siteDesc} url={siteUrl} {siteName} image={ogImage} />
 
 {#if !data.encryptedBlob || albums}
 	{#if data.siteConfig?.heroImage}

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -504,8 +504,9 @@
 		(album
 			? `${album.photos.length} photos from the '${albumTitle}' album`
 			: albumTitle)}
-	url="{import.meta.env.VITE_SITE_URL}/albums/{data.slug}"
-	image={album ? `${import.meta.env.VITE_SITE_URL}/albums/${data.slug}/cover.jpg` : undefined}
+	url="{data.siteConfig.siteUrl}/albums/{data.slug}"
+	siteName={data.siteConfig.siteName}
+	image={album ? `${data.siteConfig.siteUrl}/albums/${data.slug}/cover.jpg` : undefined}
 />
 
 {#if album}

--- a/web/src/routes/robots.txt/+server.ts
+++ b/web/src/routes/robots.txt/+server.ts
@@ -1,9 +1,14 @@
 export const prerender = true;
 
-export function GET() {
-	const allow = import.meta.env.VITE_ALLOW_CRAWLING === 'true';
+import type { RequestHandler } from '@sveltejs/kit';
+import type { SiteConfig } from '$lib/types';
+
+export const GET: RequestHandler = async ({ fetch }) => {
+	const res = await fetch('/albums/config.json');
+	const config: SiteConfig = await res.json();
+	const allow = config.allowCrawling === true;
 	const body = allow
-		? `User-agent: *\nAllow: /\nSitemap: ${import.meta.env.VITE_SITE_URL}/albums/sitemap.xml\n`
+		? `User-agent: *\nAllow: /\nSitemap: ${config.siteUrl}/albums/sitemap.xml\n`
 		: `User-agent: *\nDisallow: /\n`;
 
 	return new Response(body, {

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -45,6 +45,20 @@ test('album page has correct Open Graph tags', async ({ page }) => {
 	await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /antarctica\/cover\.jpg$/);
 });
 
+test('home page og:site_name matches siteName from config.json', async ({ page }) => {
+	const config = await page.request.get('/albums/config.json').then((r) => r.json());
+	await page.goto('/');
+	await unlockSiteIfNeeded(page, pw);
+	await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', config.siteName);
+});
+
+test('album page og:site_name matches siteName from config.json', async ({ page }) => {
+	const config = await page.request.get('/albums/config.json').then((r) => r.json());
+	await page.goto('/albums/antarctica');
+	await unlockAlbumIfNeeded(page, 'antarctica', pw);
+	await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', config.siteName);
+});
+
 test('home page has Open Graph image tag pointing to a JPEG', async ({ page }) => {
 	// In the pw-all variant every album is encrypted, so the home page derives no OG
 	// cover image (it only uses non-encrypted albums). Skip rather than expect a tag

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,7 +25,7 @@ function loadEnvFile(path: string) {
 	}
 }
 
-// Load the site-specific env file containing VITE_* variables (site URL, IDs, etc.).
+// Load the site-specific env file containing deploy and test variables.
 // Resolution order:
 //   1. $SITE_ENV (explicit override)
 //   2. config/site.env (real config, not committed)


### PR DESCRIPTION
## Migration Guide

If you have an existing `site.env`, move these values into the `settings:` block of your `albums.yaml` and remove them from `site.env`:

| `site.env` variable       | `albums.yaml` setting  |
|---------------------------|------------------------|
| `VITE_SITE_NAME`          | `site_name`            |
| `VITE_SITE_URL`           | `site_url` *(already existed — no change needed)* |
| `VITE_SITE_DESCRIPTION`   | `site_description`     |
| `VITE_COPYRIGHT_OWNER`    | `copyright_owner`      |
| `VITE_COPYRIGHT_YEAR`     | `copyright_year`       |
| `VITE_ALLOW_CRAWLING`     | `allow_crawling`       |

Example — before (`site.env`):
```
VITE_SITE_NAME="My Photo Albums"
VITE_SITE_URL=https://photos.example.com
VITE_SITE_DESCRIPTION="A collection of photo albums"
VITE_COPYRIGHT_OWNER="Your Name"
VITE_COPYRIGHT_YEAR=2020
VITE_ALLOW_CRAWLING=false
```

Example — after (`albums.yaml`):
```yaml
settings:
  id: my-site
  site_name: "My Photo Albums"
  site_url: https://photos.example.com
  site_description: "A collection of photo albums"
  copyright_owner: "Your Name"
  copyright_year: 2020
  # allow_crawling: false   # omit or set to false to block crawlers (default)
```

After updating `albums.yaml`, re-run `photogen -index -doit` to regenerate `config.json` with the new fields, then rebuild the site.

---

## Summary

- Moves all six `VITE_SITE_*` / `VITE_COPYRIGHT_*` / `VITE_ALLOW_CRAWLING` variables from `site.env` into `albums.yaml`'s `settings:` block
- `photogen` writes them into `config.json`; the frontend reads them at runtime via `fetch('/albums/config.json')` — no build-time injection needed
- `site.env` now holds only deploy infrastructure and test variables (`CLOUDFRONT_ID`, `S3_BUCKET`, `RSYNC_DEST`, `TEST_ALBUM_*`)
- `bin/test-photos-server.sh` drops `$VITE_SITE_URL` in favour of an explicit `--remote URL` flag (required when not using `--local`)
- `bin/deploy-photos.sh` reads the production URL from `config.json` (`siteUrl` field) and passes it via `--remote` to the server test and as `PLAYWRIGHT_BASE_URL`

## Changes

**Go (`pkg/photogen/`)**
- Added `SiteName`, `SiteDescription`, `CopyrightOwner`, `CopyrightYear`, `AllowCrawling` to `AlbumsSettings`, `Config`, and `SiteConfig`
- `Config.Validate()` enforces all five required fields before any files are written
- `WriteConfigJSON()` writes all fields into `config.json`

**Frontend (`web/src/`)**
- `SiteConfig` TypeScript interface extended with the new fields
- `+page.svelte`, `+layout.svelte`: read site identity from `data.siteConfig.*`
- `+error.svelte`: hardcoded to "DD Photos" (error pages don't load config)
- `OpenGraph.svelte`: replaced `import.meta.env.VITE_SITE_NAME` with a `siteName` prop; both callers updated
- `robots.txt/+server.ts`: fetches `config.json` for `allowCrawling` and `siteUrl`
- `app.d.ts`: removed the six `VITE_*` declarations (only `VITE_BUILD_TIME` remains)

**Tests**
- Added two Playwright smoke tests: `og:site_name` on home page and album page both match `siteName` from `config.json`
- Added four Go unit tests for the new `Config.Validate()` required-field checks

**Docs / Config**
- `README-DEV.md`: Environment Variables section rewritten; deploy script docs updated
- `config/albums.example.yaml`: new settings fields documented with comments
- `config/site.example.env` / `sample/config/site.env`: `VITE_*` lines removed