### PR TITLE
Fix S3 sync, browser cache headers, and key-rotation cover invalidation

### DIFF
--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -160,12 +160,27 @@ elif [ "$S3_MODE" = true ]; then
     aws s3 sync "$REPO_ROOT/build/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/" \
         $S3_SYNC_OPTS --exclude "albums/*" --include "albums/*.html"
 
-    # Deploy album data (images + JSON) independently.
+    # Deploy album data — two passes to set different Cache-Control headers.
     # --size-only: photogen preserves timestamps, so size alone is a reliable change signal.
+    #
+    # Pass 2a: JSON, XML, JPEG covers — must revalidate on every request (content can change
+    #   in-place, e.g. cover.jpg or index.enc.json when the encryption key changes).
+    # No --size-only: JSON files always get a fresh timestamp when photogen runs, so
+    #   default size+timestamp comparison reliably detects changes. --size-only would
+    #   silently skip re-encrypted JSON files since AES-GCM output size is key-independent.
     # --exclude=*.html: don't delete pre-rendered .html pages synced above.
     # shellcheck disable=SC2086
     aws s3 sync "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/albums/" \
-        $S3_SYNC_OPTS --size-only --exclude "*.html"
+        $S3_SYNC_OPTS --exclude "*.html" --exclude "*.webp" \
+        --cache-control "no-cache"
+
+    # Pass 2b: WebP photos — immutable; photogen gives them a content-derived UUID name,
+    #   so a changed photo gets a new name rather than overwriting the old file.
+    # shellcheck disable=SC2086
+    aws s3 sync "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/albums/" \
+        $S3_SYNC_OPTS --size-only \
+        --exclude "*" --include "*.webp" \
+        --cache-control "max-age=31536000,immutable"
 
     # Clear cache (skipped in dry-run mode)
     if [ "$DRY_RUN" = true ]; then

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -174,11 +174,13 @@ elif [ "$S3_MODE" = true ]; then
         $S3_SYNC_OPTS --exclude "*.html" --exclude "*.webp" \
         --cache-control "no-cache"
 
-    # Pass 2b: WebP photos — immutable; photogen gives them a content-derived UUID name,
-    #   so a changed photo gets a new name rather than overwriting the old file.
+    # Pass 2b: WebP photos — immutable; photogen gives them a deterministic UUID name
+    #   derived from HMAC(key, filename), so key rotation renames all files.
+    #   photogen skips existing WebP files (preserving timestamp), so unchanged files are
+    #   never re-uploaded. Regenerated files (after manual delete) get a new timestamp.
     # shellcheck disable=SC2086
     aws s3 sync "$DDPHOTOS_ALBUMS_DIR/$DDPHOTOS_SITE_ID/" "s3://$S3_BUCKET/albums/" \
-        $S3_SYNC_OPTS --size-only \
+        $S3_SYNC_OPTS \
         --exclude "*" --include "*.webp" \
         --cache-control "max-age=31536000,immutable"
 

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -2,6 +2,8 @@ package photogen
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -282,12 +284,21 @@ type SiteConfig struct {
 	CopyrightOwner  string            `json:"copyrightOwner"`
 	CopyrightYear   int               `json:"copyrightYear"`
 	AllowCrawling   bool              `json:"allowCrawling,omitempty"`
+	KeyID           string            `json:"keyId,omitempty"` // short fingerprint of the HMAC key; changes when the key changes
 	SiteHint        string            `json:"siteHint,omitempty"`
 	AlbumHints      map[string]string `json:"albumHints,omitempty"`
 	Encrypted       bool              `json:"encrypted,omitempty"`    // true if any encryption is configured
 	HeroImage       string            `json:"heroImage,omitempty"`    // "hero.jpg" if a hero image is configured
 	CustomCSS       string            `json:"customCss,omitempty"`    // "custom.css" if a CSS override is configured
 	DefaultTheme    string            `json:"defaultTheme,omitempty"` // "light" or "dark"; omitted when dark (the built-in default)
+}
+
+// hmacKeyID returns an 8-hex-char fingerprint of the HMAC key.
+// Used in config.json so the frontend can detect when the key (and therefore all image
+// filenames) has changed, and clear stale cover URLs from localStorage.
+func hmacKeyID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])[:8]
 }
 
 // WriteConfigJSON writes config.json indicating which albums file to load.
@@ -318,6 +329,9 @@ func (c *Config) WriteConfigJSON() error {
 		cfg.SiteHint = c.Encrypt.SiteHint
 		if len(c.Encrypt.AlbumHints) > 0 {
 			cfg.AlbumHints = c.Encrypt.AlbumHints
+		}
+		if c.Encrypt.HMACKey != "" {
+			cfg.KeyID = hmacKeyID(c.Encrypt.HMACKey)
 		}
 	}
 	if c.Hero != nil {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -4,6 +4,17 @@ server {
 
     error_page 404 /404.html;
 
+    # JSON data files must revalidate on every request (content can change in-place).
+    # WebP photos are content-addressed (UUID filenames), so they are immutable.
+    location ~* \.json$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+    location ~* \.webp$ {
+        add_header Cache-Control "max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     # Remove trailing slash (301), except root.
     # Use $http_host (not $host) so the port is preserved in the Location header.
     location ~ ^(.+)/$ {

--- a/web/src/lib/crypto.ts
+++ b/web/src/lib/crypto.ts
@@ -115,13 +115,15 @@ export function getAlbumCover(siteId: string, slug: string): string | null {
 	}
 }
 
-// Call once per page load with the siteId from config.json. If the siteId has changed
-// (i.e. the user switched to a different build), clears all stale per-site entries
-// (covers, passwords) so they don't leak across builds.
-export function syncSiteId(siteId: string): void {
+// Call once per page load with the siteId and optional keyId from config.json.
+// Clears all stale per-site entries (covers, passwords) when either value changes:
+// siteId change = user switched to a different build; keyId change = HMAC key rotated,
+// which renames all image files and makes cached cover URLs invalid.
+export function syncSiteId(siteId: string, keyId?: string): void {
 	try {
+		const token = keyId ? `${siteId}:${keyId}` : siteId;
 		const stored = localStorage.getItem(SITE_ID_KEY);
-		if (stored === siteId) return;
+		if (stored === token) return;
 		const toRemove: string[] = [];
 		for (let i = 0; i < localStorage.length; i++) {
 			const k = localStorage.key(i);
@@ -130,7 +132,7 @@ export function syncSiteId(siteId: string): void {
 			}
 		}
 		toRemove.forEach((k) => localStorage.removeItem(k));
-		localStorage.setItem(SITE_ID_KEY, siteId);
+		localStorage.setItem(SITE_ID_KEY, token);
 	} catch {
 		// localStorage not available
 	}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface SiteConfig {
 	copyrightOwner: string;
 	copyrightYear: number;
 	allowCrawling?: boolean;
+	keyId?: string;
 	siteHint?: string;
 	albumHints?: Record<string, string>;
 	encrypted?: boolean;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -155,8 +155,8 @@
 		}
 
 
-		// Clear stale cover cache if the siteId changed (e.g. switching between dev builds).
-		syncSiteId(data.siteId);
+		// Clear stale cover cache if the siteId or keyId changed (key rotation renames all image files).
+		syncSiteId(data.siteId, data.siteConfig?.keyId);
 
 		// ?clear removes all stored ddp_* passwords and reloads the page without the param.
 		if (new URLSearchParams(window.location.search).has('clear')) {

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -451,7 +451,7 @@
 	});
 
 	onMount(() => {
-		syncSiteId(data.siteId);
+		syncSiteId(data.siteId, data.siteConfig?.keyId);
 
 		const updateWidth = () => {
 			if (container) {

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -34,6 +34,7 @@
 	// (needed for site-encrypted sites where albums.enc.json is not fetched server-side).
 	let albumTitle = $derived(album?.title ?? data.albumTitle);
 	let description = $derived(data.description || album?.description || '');
+	let plainDescription = $derived(description.replace(/<[^>]*>/g, ''));
 	let dateSpan = $derived(data.dateSpan || album?.dateSpan || '');
 	// True while we're silently trying stored passwords so we don't flash the prompt.
 	// $effect.pre runs synchronously before Svelte's first DOM commit in the browser,
@@ -500,7 +501,7 @@
 
 <OpenGraph
 	title={albumTitle}
-	description={description ||
+	description={plainDescription ||
 		(album
 			? `${album.photos.length} photos from the '${albumTitle}' album`
 			: albumTitle)}

--- a/web/static/.htaccess
+++ b/web/static/.htaccess
@@ -5,6 +5,15 @@
 
 ErrorDocument 404 /404.html
 
+# JSON data files must revalidate on every request (content can change in-place).
+# WebP photos are content-addressed (UUID filenames), so they are immutable.
+<FilesMatch "\.json$">
+    Header set Cache-Control "no-cache"
+</FilesMatch>
+<FilesMatch "\.webp$">
+    Header set Cache-Control "max-age=31536000, immutable"
+</FilesMatch>
+
 DirectorySlash Off
 RewriteEngine On
 


### PR DESCRIPTION
## Summary

- **S3 Pass 2 split**: Separated album data sync into two passes — Pass 2a syncs JSON/XML/cover JPEGs with `Cache-Control: no-cache` (no `--size-only`, since AES-GCM re-encryption always produces a new timestamp); Pass 2b syncs WebP photos with `Cache-Control: max-age=31536000, immutable` using default size+timestamp comparison (dropped `--size-only` — photogen preserves timestamps on existing files so unchanged WebPs are never re-uploaded, and regenerated files get a new timestamp naturally)
- **Cache headers for Apache and nginx**: Added `Cache-Control: no-cache` for `.json` files and `max-age=31536000, immutable` for `.webp` files in `.htaccess` and `nginx.conf`, matching the S3 headers and preventing browser heuristic caching of stale JSON
- **Key-rotation cover invalidation**: Added `keyId` (8-char SHA-256 fingerprint of the HMAC key) to `config.json` via `pkg/photogen/json.go`; updated `syncSiteId` in `crypto.ts` to accept `keyId` and combine it with `siteId` as the localStorage token — so rotating `passwords.yaml key:` (which renames all WebP files) automatically clears stale cover URLs cached in localStorage
- **Strip HTML from OG description**: Album descriptions can contain HTML (rendered via `{@html}`); strip tags before passing to `<OpenGraph>` so `<meta name="description">` contains plain text

## Test plan

- [x] Deploy with new HMAC key; verify cover photos update without manual cache clear
- [x] Confirm `Cache-Control: no-cache` header on JSON files in S3 and Apache/nginx
- [x] Confirm `Cache-Control: max-age=31536000, immutable` on WebP files
- [x] Verify OG description tag contains plain text when album description includes HTML
- [x] Run `bin/test-all.sh --mode apache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)