### PR TITLE
Encrypt custom HTML fields via html.json / html.enc.json

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -108,17 +108,17 @@ Site identity settings live in the `settings:` block of `albums.yaml` and are wr
 into `config.json` by `photogen`. The frontend reads them at runtime via `fetch('/albums/config.json')` —
 no build-time injection needed.
 
-| Setting              | Required | Description                                                                                                    |
-|----------------------|----------|----------------------------------------------------------------------------------------------------------------|
-| `site_name`          | yes      | Site title shown in the browser tab and OG tags                                                                |
-| `site_url`           | yes      | Canonical base URL (e.g. `https://photos.example.com`); used in sitemap and OG tags                            |
-| `site_description`   | yes      | Meta description and OG description for the home page                                                          |
-| `copyright_owner`    | yes      | Name shown in the footer copyright line                                                                        |
-| `copyright_year`     | yes      | Start year shown in the footer copyright line                                                                  |
-| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`)              |
-| `site_title_html`    | no       | HTML for the site title on the home page; falls back to `site_name` when omitted. Allows links, emphasis, etc. |
-| `site_subtitle_html` | no       | HTML rendered below the site title in a smaller font                                                           |
-| `site_overview_html` | no       | HTML rendered above the album cards (slightly larger than album descriptions)                                  |
+| Setting              | Required | Description                                                                                                                                                                 |
+|----------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `site_name`          | yes      | Site title shown in the browser tab and OG tags                                                                                                                             |
+| `site_url`           | yes      | Canonical base URL (e.g. `https://photos.example.com`); used in sitemap and OG tags                                                                                         |
+| `site_description`   | yes      | Meta description and OG description for the home page                                                                                                                       |
+| `copyright_owner`    | yes      | Name shown in the footer copyright line                                                                                                                                     |
+| `copyright_year`     | yes      | Start year shown in the footer copyright line                                                                                                                               |
+| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`)                                                                           |
+| `site_title_html`    | no       | HTML for the site title on the home page; falls back to `site_name` when omitted. Allows links, emphasis, etc. Written to `html.json` / `html.enc.json`, not `config.json`. |
+| `site_subtitle_html` | no       | HTML rendered below the site title in a smaller font. Written to `html.json` / `html.enc.json`.                                                                             |
+| `site_overview_html` | no       | HTML rendered above the album cards (slightly larger than album descriptions). Written to `html.json` / `html.enc.json`.                                                    |
 
 `photogen`'s `Config.Validate()` enforces all required fields before any files are written.
 
@@ -414,6 +414,14 @@ are written as `.enc.json` alongside their plaintext counterparts. `config.json`
 always written in plaintext — it contains only non-sensitive metadata (site ID, hints,
 hero/CSS filenames) needed to bootstrap the frontend before any password is entered.
 
+Custom HTML fields (`site_title_html`, `site_subtitle_html`, `site_overview_html`) can
+contain private information such as links to private documents or contact details. When
+a site password is configured, these fields are written to `html.enc.json` (encrypted)
+rather than `config.json`. On unencrypted sites they are written to `html.json`
+(plaintext). If none of the three fields are set, neither file is written. The frontend
+fetches and decrypts `html.enc.json` as part of the same unlock step as `albums.enc.json`,
+so there is no additional password prompt.
+
 Decryption happens entirely in-browser using the Web Crypto API. Passwords are never
 sent to a server.
 
@@ -463,12 +471,15 @@ git-ignored directory (e.g. `.secrets/`).
 When the frontend loads an encrypted page, it:
 
 1. Reads `config.json` (always plaintext) to get the `siteId`, hints, and which albums
-   file to load (`albums.json` vs `albums.enc.json`).
+   file to load (`albums.json` vs `albums.enc.json`). If `htmlFile` is set, also fetches
+   `html.json` (plaintext) or holds `html.enc.json` as a raw blob for later decryption.
 2. Checks localStorage for a stored password scoped to the current `siteId`.
-3. If a stored password decrypts successfully, the page renders normally with no prompt.
+3. If a stored password decrypts successfully, both `albums.enc.json` and `html.enc.json`
+   are decrypted in parallel — the page renders with all content in a single DOM update,
+   with no flash.
 4. If no stored password works, a full-screen `PasswordPrompt` overlay appears with a
    lock icon, a password input, and an optional hint. A wrong password triggers a shake
-   animation; a correct one stores the password in localStorage and decrypts the content.
+   animation; a correct one stores the password in localStorage and decrypts all content.
 
 **Stored passwords and auto-unlock:** After a successful unlock, the password is saved
 to localStorage so subsequent visits auto-decrypt without prompting. Append `?clear` to
@@ -528,6 +539,7 @@ The correct password is selected automatically from the filename:
 | File              | Password used                                    |
 |-------------------|--------------------------------------------------|
 | `albums.enc.json` | Site-wide password (`site.password`)             |
+| `html.enc.json`   | Site-wide password (`site.password`)             |
 | `index.enc.json`  | Per-album password for the parent directory slug |
 
 ## Finding a Cover Photo (`search_cover.sh`)

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -261,6 +261,9 @@ func main() {
 		if err := cfg.WriteConfigJSON(); err != nil {
 			fmt.Printf("Error writing config.json: %s\n", err)
 		}
+		if err := cfg.WriteHTMLFile(); err != nil {
+			fmt.Printf("Error writing html file: %s\n", err)
+		}
 		if err := cfg.WriteSitemap(summaries); err != nil {
 			fmt.Printf("Error writing sitemap.xml: %s\n", err)
 		}

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1208,3 +1208,37 @@ Built with joy by DD Photos on {date}  ⓘ
 - The info icon uses the same blue as the "DD Photos" link (`#5a8ec0` dark / `--link-color` light), with opacity fade on hover.
 - `margin-left: 0.5rem` on the icon button separates it visually from the date.
 - Space bar now activates album cards (keyboard accessibility): `onkeydown` handler on each `<a>` card calls `e.preventDefault()` + `e.currentTarget.click()` when Space is pressed.
+
+### 60. Encrypt Custom HTML Fields via `html.json` / `html.enc.json`
+
+#### Motivation
+
+The three home page HTML fields (`site_title_html`, `site_subtitle_html`, `site_overview_html`) can contain private information — links to private spreadsheets, email addresses, internal notes. Previously they were written into `config.json`, which is always served publicly. This change moves them out of `config.json` into a dedicated file that is encrypted when a site password is configured.
+
+#### New File: `html.json` / `html.enc.json`
+
+Follows the exact same pattern as `albums.json` / `albums.enc.json`:
+
+- **No site password**: `html.json` (plaintext JSON) is written; `config.json` includes `"htmlFile": "html.json"`.
+- **Site password**: `html.enc.json` (AES-256-GCM encrypted, same key derivation as albums) is written; `config.json` includes `"htmlFile": "html.enc.json"`.
+- **No HTML fields configured**: neither file is written; `htmlFile` is omitted from `config.json`.
+
+`photogen` writes the file in `WriteHTMLFile()` (called alongside `WriteConfigJSON()` in the index phase). The three HTML fields were removed from `SiteConfig` / `config.json`; the new `SiteHTMLContent` Go struct holds them.
+
+#### Go changes
+
+- `pkg/photogen/json.go`: removed `SiteTitleHTML`, `SiteSubtitleHTML`, `SiteOverviewHTML` from `SiteConfig`; added `HTMLFile string`; added `SiteHTMLContent` struct; added `WriteHTMLFile()` method.
+- `cmd/photogen/photogen.go`: added `cfg.WriteHTMLFile()` call in the index phase.
+- `pkg/photogen/json_test.go`: updated `TestWriteConfigJSON` for the new `htmlFile` behavior; added `TestWriteHTMLFile` covering no-op, plaintext, encrypted, and stale-file-removal cases.
+
+#### Frontend changes
+
+- `web/src/lib/types.ts`: removed HTML fields from `SiteConfig`; added `htmlFile?`; added `SiteHtmlContent` interface.
+- `web/src/routes/+page.ts`: fetches `html.json` or `html.enc.json` when `htmlFile` is set; returns `siteHtml` (plaintext) or `encryptedHtmlBlob` (raw text for later decryption).
+- `web/src/routes/+page.svelte`:
+  - Added `decryptedSiteHtml` state; derives `effectiveSiteHtml`, `siteTitleHtml`, `siteSubtitleHtml`, `siteOverviewHtml` from decrypted or static content.
+  - All three decryption paths (`handleUnlock`, stored site password, stored album password fallback) use `Promise.all` to decrypt `albums.enc.json` and `html.enc.json` in parallel, then assign `decryptedSiteHtml` before `decryptedAlbums` in a single synchronous block. Svelte 5 batches both state assignments into one DOM commit, preventing any flash of missing HTML content over the hero image.
+
+#### Documentation
+
+`README-DEV.md` updated: passwords section explains the new `html.json`/`html.enc.json` files; site settings table annotates the three HTML fields; frontend behavior section describes the parallel decryption; decode table adds `html.enc.json`.

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -276,24 +276,29 @@ func (c *Config) WriteAlbumsIndex(summaries []AlbumSummary) error {
 
 // SiteConfig is the structure for config.json (always unencrypted).
 type SiteConfig struct {
-	SiteID           string            `json:"siteId"`
-	AlbumsFile       string            `json:"albumsFile"`
-	SiteName         string            `json:"siteName"`
-	SiteURL          string            `json:"siteUrl"`
-	SiteDescription  string            `json:"siteDescription"`
-	CopyrightOwner   string            `json:"copyrightOwner"`
-	CopyrightYear    int               `json:"copyrightYear"`
-	AllowCrawling    bool              `json:"allowCrawling,omitempty"`
-	KeyID            string            `json:"keyId,omitempty"` // short fingerprint of the HMAC key; changes when the key changes
-	SiteHint         string            `json:"siteHint,omitempty"`
-	AlbumHints       map[string]string `json:"albumHints,omitempty"`
-	Encrypted        bool              `json:"encrypted,omitempty"`        // true if any encryption is configured
-	HeroImage        string            `json:"heroImage,omitempty"`        // "hero.jpg" if a hero image is configured
-	CustomCSS        string            `json:"customCss,omitempty"`        // "custom.css" if a CSS override is configured
-	DefaultTheme     string            `json:"defaultTheme,omitempty"`     // "light" or "dark"; omitted when dark (the built-in default)
-	SiteTitleHTML    string            `json:"siteTitleHtml,omitempty"`    // HTML for site title; falls back to siteName
-	SiteSubtitleHTML string            `json:"siteSubtitleHtml,omitempty"` // HTML shown below site title
-	SiteOverviewHTML string            `json:"siteOverviewHtml,omitempty"` // HTML shown above album cards
+	SiteID          string            `json:"siteId"`
+	AlbumsFile      string            `json:"albumsFile"`
+	SiteName        string            `json:"siteName"`
+	SiteURL         string            `json:"siteUrl"`
+	SiteDescription string            `json:"siteDescription"`
+	CopyrightOwner  string            `json:"copyrightOwner"`
+	CopyrightYear   int               `json:"copyrightYear"`
+	AllowCrawling   bool              `json:"allowCrawling,omitempty"`
+	KeyID           string            `json:"keyId,omitempty"` // short fingerprint of the HMAC key; changes when the key changes
+	SiteHint        string            `json:"siteHint,omitempty"`
+	AlbumHints      map[string]string `json:"albumHints,omitempty"`
+	Encrypted       bool              `json:"encrypted,omitempty"`    // true if any encryption is configured
+	HeroImage       string            `json:"heroImage,omitempty"`    // "hero.jpg" if a hero image is configured
+	CustomCSS       string            `json:"customCss,omitempty"`    // "custom.css" if a CSS override is configured
+	DefaultTheme    string            `json:"defaultTheme,omitempty"` // "light" or "dark"; omitted when dark (the built-in default)
+	HTMLFile        string            `json:"htmlFile,omitempty"`     // "html.json" or "html.enc.json" when HTML fields are configured
+}
+
+// SiteHTMLContent is the structure for html.json / html.enc.json.
+type SiteHTMLContent struct {
+	SiteTitleHTML    string `json:"siteTitleHtml,omitempty"`    // HTML for site title; falls back to siteName
+	SiteSubtitleHTML string `json:"siteSubtitleHtml,omitempty"` // HTML shown below site title
+	SiteOverviewHTML string `json:"siteOverviewHtml,omitempty"` // HTML shown above album cards
 }
 
 // hmacKeyID returns an 8-hex-char fingerprint of the HMAC key.
@@ -344,12 +349,67 @@ func (c *Config) WriteConfigJSON() error {
 		cfg.CustomCSS = "custom.css"
 	}
 	cfg.DefaultTheme = c.DefaultTheme
-	cfg.SiteTitleHTML = c.SiteTitleHTML
-	cfg.SiteSubtitleHTML = c.SiteSubtitleHTML
-	cfg.SiteOverviewHTML = c.SiteOverviewHTML
+	if c.SiteTitleHTML != "" || c.SiteSubtitleHTML != "" || c.SiteOverviewHTML != "" {
+		if siteEncrypted {
+			cfg.HTMLFile = "html.enc.json"
+		} else {
+			cfg.HTMLFile = "html.json"
+		}
+	}
 	if err := writeJSON(outputPath, cfg); err != nil {
 		return err
 	}
+	c.TrackFile(outputPath)
+	return nil
+}
+
+// WriteHTMLFile writes html.json (or html.enc.json if the site is encrypted) into the site output dir.
+// No-op if all three HTML fields are empty.
+func (c *Config) WriteHTMLFile() error {
+	if c.SiteTitleHTML == "" && c.SiteSubtitleHTML == "" && c.SiteOverviewHTML == "" {
+		return nil
+	}
+	siteEncrypted := c.Encrypt != nil && c.Encrypt.IsSiteEncrypted()
+	outputName := "html.json"
+	counterpart := "html.enc.json"
+	if siteEncrypted {
+		outputName = "html.enc.json"
+		counterpart = "html.json"
+	}
+	outputPath := c.SiteOutputPath(outputName)
+
+	if c.DryRun {
+		action := "write"
+		if siteEncrypted {
+			action = "encrypt+write"
+		}
+		fmt.Printf("DRYRUN: would %s %s\n", action, outputPath)
+		c.TrackFile(outputPath)
+		return nil
+	}
+
+	content := SiteHTMLContent{
+		SiteTitleHTML:    c.SiteTitleHTML,
+		SiteSubtitleHTML: c.SiteSubtitleHTML,
+		SiteOverviewHTML: c.SiteOverviewHTML,
+	}
+	b, err := json.MarshalIndent(content, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal html content: %w", err)
+	}
+	b = append(b, '\n')
+
+	if siteEncrypted {
+		b, err = EncryptJSON(b, c.Encrypt.SitePassword, c.Encrypt.PwFile)
+		if err != nil {
+			return fmt.Errorf("encrypt html content: %w", err)
+		}
+	}
+
+	if err := writeBytes(outputPath, b); err != nil {
+		return err
+	}
+	removeIfExists(c.SiteOutputPath(counterpart))
 	c.TrackFile(outputPath)
 	return nil
 }

--- a/pkg/photogen/json_test.go
+++ b/pkg/photogen/json_test.go
@@ -245,10 +245,22 @@ func TestWriteAlbumsIndex(t *testing.T) {
 	})
 }
 
+func makeSiteCfgWithHTML(dir string, encrypt *EncryptConfig) *Config {
+	return &Config{
+		OutputRoot:       dir,
+		SiteID:           "testsite",
+		Encrypt:          encrypt,
+		Warn:             &WarnCollector{},
+		SiteTitleHTML:    "<b>Title</b>",
+		SiteSubtitleHTML: "<i>Subtitle</i>",
+		SiteOverviewHTML: "<p>Overview</p>",
+	}
+}
+
 func TestWriteConfigJSON(t *testing.T) {
 	t.Parallel()
 
-	t.Run("unencrypted references albums.json", func(t *testing.T) {
+	t.Run("unencrypted references albums.json, no htmlFile when no HTML fields", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		require.NoError(t, makeSiteCfg(dir, nil).WriteConfigJSON())
@@ -257,9 +269,10 @@ func TestWriteConfigJSON(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"siteId": "testsite"`)
 		assert.Contains(t, string(data), `"albumsFile": "albums.json"`)
+		assert.NotContains(t, string(data), `"htmlFile"`)
 	})
 
-	t.Run("encrypted references albums.enc.json", func(t *testing.T) {
+	t.Run("encrypted references albums.enc.json, no htmlFile when no HTML fields", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		encrypt := &EncryptConfig{SitePassword: "passw0rd"}
@@ -269,6 +282,87 @@ func TestWriteConfigJSON(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"siteId": "testsite"`)
 		assert.Contains(t, string(data), `"albumsFile": "albums.enc.json"`)
+		assert.NotContains(t, string(data), `"htmlFile"`)
+	})
+
+	t.Run("unencrypted with HTML fields references html.json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, makeSiteCfgWithHTML(dir, nil).WriteConfigJSON())
+
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"htmlFile": "html.json"`)
+		assert.NotContains(t, string(data), `"siteTitleHtml"`, "HTML fields must not appear in config.json")
+	})
+
+	t.Run("encrypted with HTML fields references html.enc.json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		encrypt := &EncryptConfig{SitePassword: "passw0rd"}
+		require.NoError(t, makeSiteCfgWithHTML(dir, encrypt).WriteConfigJSON())
+
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"htmlFile": "html.enc.json"`)
+		assert.NotContains(t, string(data), `"siteTitleHtml"`, "HTML fields must not appear in config.json")
+	})
+}
+
+func TestWriteHTMLFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op when no HTML fields set", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, makeSiteCfg(dir, nil).WriteHTMLFile())
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "html.json"))
+	})
+
+	t.Run("unencrypted writes html.json with plaintext content", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, makeSiteCfgWithHTML(dir, nil).WriteHTMLFile())
+
+		outPath := filepath.Join(dir, "testsite", "html.json")
+		assert.FileExists(t, outPath)
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "html.enc.json"))
+
+		data, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"siteTitleHtml"`)
+		assert.Contains(t, string(data), "Title") // HTML is JSON-escaped (\u003cb\u003e) but content is present
+	})
+
+	t.Run("encrypted writes html.enc.json with unreadable content", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		encrypt := &EncryptConfig{SitePassword: "passw0rd"}
+		require.NoError(t, makeSiteCfgWithHTML(dir, encrypt).WriteHTMLFile())
+
+		encPath := filepath.Join(dir, "testsite", "html.enc.json")
+		assert.FileExists(t, encPath)
+		assert.NoFileExists(t, filepath.Join(dir, "testsite", "html.json"))
+
+		data, err := os.ReadFile(encPath)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "siteTitleHtml", "encrypted file must not contain plaintext field name")
+		assert.NotContains(t, string(data), "Title", "encrypted file must not contain plaintext content")
+	})
+
+	t.Run("switching to unencrypted removes stale html.enc.json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		siteDir := filepath.Join(dir, "testsite")
+		require.NoError(t, os.MkdirAll(siteDir, 0o755))
+
+		staleEnc := filepath.Join(siteDir, "html.enc.json")
+		require.NoError(t, os.WriteFile(staleEnc, []byte("stale"), 0o644))
+
+		require.NoError(t, makeSiteCfgWithHTML(dir, nil).WriteHTMLFile())
+
+		assert.FileExists(t, filepath.Join(siteDir, "html.json"))
+		assert.NoFileExists(t, staleEnc)
 	})
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -55,6 +55,11 @@ export interface SiteConfig {
 	heroImage?: string;
 	customCss?: string;
 	defaultTheme?: string;
+	htmlFile?: string; // "html.json" or "html.enc.json" when HTML fields are configured
+}
+
+// Mirrors Go's SiteHTMLContent in pkg/photogen/json.go.
+export interface SiteHtmlContent {
 	siteTitleHtml?: string;
 	siteSubtitleHtml?: string;
 	siteOverviewHtml?: string;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 	import BackToTop from '$lib/components/BackToTop.svelte';
 	import OpenGraph from '$lib/components/OpenGraph.svelte';
 	import PasswordPrompt from '$lib/components/PasswordPrompt.svelte';
-	import type { AlbumSummary } from '$lib/types';
+	import type { AlbumSummary, SiteHtmlContent } from '$lib/types';
 	import {
 		siteKey,
 		getStoredPassword,
@@ -75,9 +75,16 @@
 	});
 
 	const siteName = $derived(data.siteConfig.siteName);
-	const siteTitleHtml = $derived(data.siteConfig.siteTitleHtml ?? siteName);
 	const siteUrl = $derived(data.siteConfig.siteUrl);
 	const siteDesc = $derived(data.siteConfig.siteDescription);
+
+	// HTML content from html.json or html.enc.json; null until decrypted (encrypted sites).
+	let decryptedSiteHtml = $state<SiteHtmlContent | null>(null);
+	// Effective HTML content: decrypted takes precedence over statically loaded (unencrypted sites).
+	const effectiveSiteHtml = $derived(decryptedSiteHtml ?? data.siteHtml);
+	const siteTitleHtml = $derived(effectiveSiteHtml?.siteTitleHtml ?? siteName);
+	const siteSubtitleHtml = $derived(effectiveSiteHtml?.siteSubtitleHtml);
+	const siteOverviewHtml = $derived(effectiveSiteHtml?.siteOverviewHtml);
 
 	// Client-decrypted albums list (null until decryption succeeds).
 	let decryptedAlbums = $state<AlbumSummary[] | null>(null);
@@ -185,9 +192,14 @@
 		// Try the site-wide stored password first.
 		const sitePw = getStoredPassword(siteKey(data.siteId));
 		if (sitePw) {
-			const result = await tryDecrypt(data.encryptedBlob, sitePw);
-			if (result) {
-				decryptedAlbums = result as AlbumSummary[];
+			const [albumResult, htmlResult] = await Promise.all([
+				tryDecrypt(data.encryptedBlob, sitePw),
+				data.encryptedHtmlBlob ? tryDecrypt(data.encryptedHtmlBlob, sitePw) : Promise.resolve(null)
+			]);
+			if (albumResult) {
+				// Set siteHtml before albums so both are ready in the same Svelte DOM commit.
+				if (htmlResult) decryptedSiteHtml = htmlResult as SiteHtmlContent;
+				decryptedAlbums = albumResult as AlbumSummary[];
 				unlocking = false;
 				return;
 			}
@@ -196,6 +208,11 @@
 		// Fall back to any stored per-album password (user may have visited an album first).
 		const match = await tryStoredAlbumPasswords(data.encryptedBlob, data.siteId);
 		if (match) {
+			const htmlResult = data.encryptedHtmlBlob
+				? await tryDecrypt(data.encryptedHtmlBlob, match.password)
+				: null;
+			// Set siteHtml before albums so both are ready in the same Svelte DOM commit.
+			if (htmlResult) decryptedSiteHtml = htmlResult as SiteHtmlContent;
 			decryptedAlbums = match.result as AlbumSummary[];
 			storePassword(siteKey(data.siteId), match.password);
 			unlocking = false;
@@ -207,9 +224,14 @@
 
 	async function handleUnlock(password: string) {
 		if (!data.encryptedBlob) return;
-		const result = await tryDecrypt(data.encryptedBlob, password);
-		if (result) {
-			decryptedAlbums = result as AlbumSummary[];
+		const [albumResult, htmlResult] = await Promise.all([
+			tryDecrypt(data.encryptedBlob, password),
+			data.encryptedHtmlBlob ? tryDecrypt(data.encryptedHtmlBlob, password) : Promise.resolve(null)
+		]);
+		if (albumResult) {
+			// Set siteHtml before albums so both are ready in the same Svelte DOM commit.
+			if (htmlResult) decryptedSiteHtml = htmlResult as SiteHtmlContent;
+			decryptedAlbums = albumResult as AlbumSummary[];
 			storePassword(siteKey(data.siteId), password);
 		} else {
 			shakeCount++;
@@ -225,16 +247,16 @@
 			<img src="/albums/{data.siteConfig.heroImage}" alt={siteName} />
 			<div class="hero-overlay">
 				<h1>{@html siteTitleHtml}</h1>
-				{#if data.siteConfig.siteSubtitleHtml}
-					<p class="site-subtitle">{@html data.siteConfig.siteSubtitleHtml}</p>
+				{#if siteSubtitleHtml}
+					<p class="site-subtitle">{@html siteSubtitleHtml}</p>
 				{/if}
 			</div>
 		</div>
 	{:else}
 		<header>
 			<h1>{@html siteTitleHtml}</h1>
-			{#if data.siteConfig.siteSubtitleHtml}
-				<p class="site-subtitle">{@html data.siteConfig.siteSubtitleHtml}</p>
+			{#if siteSubtitleHtml}
+				<p class="site-subtitle">{@html siteSubtitleHtml}</p>
 			{/if}
 		</header>
 	{/if}
@@ -242,8 +264,8 @@
 
 {#if albums}
 	<main class:fade-in={decryptedAlbums !== null}>
-		{#if data.siteConfig.siteOverviewHtml}
-			<div class="site-overview">{@html data.siteConfig.siteOverviewHtml}</div>
+		{#if siteOverviewHtml}
+			<div class="site-overview">{@html siteOverviewHtml}</div>
 		{/if}
 		<div class="albums">
 			{#each albums as album (album.slug)}

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import type { AlbumSummary } from '$lib/types';
+import type { AlbumSummary, SiteHtmlContent } from '$lib/types';
 
 export async function load({ fetch, parent }) {
 	const { siteConfig } = await parent();
@@ -12,11 +12,25 @@ export async function load({ fetch, parent }) {
 	const siteId = siteConfig.siteId;
 	const siteHint = siteConfig.siteHint;
 
+	// Load the HTML content file (html.json or html.enc.json) if configured.
+	let siteHtml: SiteHtmlContent | null = null;
+	let encryptedHtmlBlob: string | null = null;
+	if (siteConfig.htmlFile) {
+		const htmlRes = await fetch(`/albums/${siteConfig.htmlFile}`);
+		if (htmlRes.ok) {
+			if (siteConfig.htmlFile.endsWith('.enc.json')) {
+				encryptedHtmlBlob = await htmlRes.text();
+			} else {
+				siteHtml = await htmlRes.json();
+			}
+		}
+	}
+
 	if (siteConfig.albumsFile.endsWith('.enc.json')) {
 		const encryptedBlob = await albumsRes.text();
-		return { albums: null as AlbumSummary[] | null, encryptedBlob, siteId, siteHint };
+		return { albums: null as AlbumSummary[] | null, encryptedBlob, siteId, siteHint, siteHtml, encryptedHtmlBlob };
 	}
 
 	const albums: AlbumSummary[] = await albumsRes.json();
-	return { albums, encryptedBlob: null as string | null, siteId, siteHint };
+	return { albums, encryptedBlob: null as string | null, siteId, siteHint, siteHtml, encryptedHtmlBlob };
 }


### PR DESCRIPTION
## Summary

Custom HTML fields (`site_title_html`, `site_subtitle_html`, `site_overview_html`) can contain private information — links to private documents, email addresses, etc. Previously these were written into `config.json`, which is always public. This PR moves them into a dedicated file that follows the same encrypted/plaintext pattern as `albums.json`.

- `html.json` — written when no site password is configured (plaintext)
- `html.enc.json` — written when a site password is configured (AES-256-GCM, same key derivation as albums)
- `config.json` gains an `htmlFile` field (`"html.json"` or `"html.enc.json"`); omitted when no HTML fields are set
- The three HTML fields are removed from `config.json` entirely

The frontend fetches `html.enc.json` alongside `albums.enc.json` and decrypts both in parallel using `Promise.all`. Both state assignments happen synchronously in one Svelte DOM commit, preventing any flash of missing HTML content over the hero image on unlock.

## Changes

**Go**
- `pkg/photogen/json.go`: new `SiteHTMLContent` struct; new `WriteHTMLFile()` method; `HTMLFile` field added to `SiteConfig`; three HTML fields removed from `SiteConfig`
- `cmd/photogen/photogen.go`: call `WriteHTMLFile()` in the index phase
- `pkg/photogen/json_test.go`: updated `TestWriteConfigJSON`; new `TestWriteHTMLFile`

**TypeScript / Svelte**
- `web/src/lib/types.ts`: new `SiteHtmlContent` interface; `htmlFile?` on `SiteConfig`; HTML fields removed from `SiteConfig`
- `web/src/routes/+page.ts`: fetch `html.json` or `html.enc.json` when `htmlFile` is present
- `web/src/routes/+page.svelte`: decrypt both blobs in parallel on unlock; derive HTML fields reactively; single DOM commit prevents hero flash

**Docs**
- `README-DEV.md`: updated passwords section, site settings table, frontend behavior section, and decode table
- `docs/HISTORY.md`: session 60 entry