### PR TITLE
Docker and docs fine tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,18 +136,26 @@ See [Deployment](docs/DEPLOY.md) for setup details.
 
 ## Documentation
 
+These documents are primarily meant for users of DD Photos:
+
 | Document                                               | Description                                                                        |
 |--------------------------------------------------------|------------------------------------------------------------------------------------|
 | [Docker](docs/DOCKER.md)                               | Docker workflow: init, photogen, run, build, serve, deploy, upgrade                |
-| [Non-Docker Setup](docs/INSTALL.md)                    | Prerequisites, sample app, commands (developer mode)                               |
 | [Configuration](docs/CONFIGURATION.md)                 | `albums.yaml`, `descriptions.txt`, `site.env`, and how config reaches the frontend |
 | [Photogen](docs/PHOTOGEN.md)                           | `photogen` CLI: flags, photo descriptions, recursive albums                        |
 | [Deployment](docs/DEPLOY.md)                           | Deployment via rsync and S3+CloudFront                                             |
 | [Web Server Configuration](docs/DEPLOYMENT-SERVERS.md) | Apache, nginx, and CloudFront URL routing rules                                    |
-| [Environment Variables](docs/ENV.md)                   | Deploy and album location variables                                                |
-| [Development](docs/DEV.md)                             | SvelteKit details, LAN access, debugging                                           |
-| [Testing](docs/TESTING.md)                             | Manual testing, Playwright e2e tests, CI                                           |
-| [Makefile Targets](docs/MAKEFILE.md)                   | All `make` targets                                                                 |
+| [Environment Variables](docs/ENV.md)                   | Deployment variables                                                               |
+
+These documents are primarily meant for developers of DD Photos:
+
+| Document                             | Description                                          |
+|--------------------------------------|------------------------------------------------------|
+| [Developer Setup](docs/INSTALL.md)   | Prerequisites, sample app, commands (developer mode) |
+| [Development Notes](docs/DEV.md)     | SvelteKit details, LAN access, debugging             |
+| [Testing](docs/TESTING.md)           | Manual testing, Playwright e2e tests, CI             |
+| [Makefile Targets](docs/MAKEFILE.md) | All `make` targets                                   |
+| [Environment Variables](docs/ENV.md) | Deploy and album location variables                  |
 
 ## Contributing
 

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# https://github.com/dougdonohoe/ddphotos
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -4,12 +4,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="ddphotos"
 
-# Parse --albums-dir, --site-id, --config-dir, --site-env flags before the command
+# Parse --dir, --site-id, --config-dir, --site-env flags before the command
 OPT_CONFIG_DIR=""
 OPT_SITE_ENV=""
 while [[ "${1:-}" == --?* ]]; do
     case "$1" in
-        --albums-dir) DDPHOTOS_ALBUMS_DIR="$2"; shift 2 ;;
+        --dir) DDPHOTOS_DIR="$2"; shift 2 ;;
         --site-id)    DDPHOTOS_SITE_ID="$2";    shift 2 ;;
         --config-dir) OPT_CONFIG_DIR="$2";      shift 2 ;;
         --site-env)   OPT_SITE_ENV="$2";        shift 2 ;;
@@ -20,14 +20,14 @@ done
 cmd="${1:-help}"
 shift 2>/dev/null || true
 
-# DDPHOTOS_ALBUMS_DIR: directory mounted as /ddphotos; defaults to script location
-DDPHOTOS_ALBUMS_DIR="${DDPHOTOS_ALBUMS_DIR:-$SCRIPT_DIR}"
+# DDPHOTOS_DIR: directory mounted as /ddphotos; defaults to script location
+DDPHOTOS_DIR="${DDPHOTOS_DIR:-$SCRIPT_DIR}"
 
 # CONFIG_HOST_DIR: host path to config directory (normalized)
 if [ -n "$OPT_CONFIG_DIR" ]; then
     CONFIG_HOST_DIR="$(cd "$OPT_CONFIG_DIR" && pwd)"
 else
-    CONFIG_HOST_DIR="$DDPHOTOS_ALBUMS_DIR/config"
+    CONFIG_HOST_DIR="$DDPHOTOS_DIR/config"
 fi
 
 # DDPHOTOS_SITE_ID: read from config dir's albums.yaml settings.id if not set via env or flag
@@ -40,13 +40,13 @@ fi
 DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 
 # Resolve --config-dir to a container path.
-# If inside DDPHOTOS_ALBUMS_DIR, translate directly; otherwise mount as /ddphotos-config.
+# If inside DDPHOTOS_DIR, translate directly; otherwise mount as /ddphotos-config.
 EXTRA_MOUNT_ARGS=()
 DDPHOTOS_CONFIG_DIR=""
 CONFIG_DIR_EXTRA_SRC=""  # set only when an extra mount is needed (for display)
 if [ -n "$OPT_CONFIG_DIR" ]; then
-    if [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_ALBUMS_DIR"/* ]] || [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_ALBUMS_DIR" ]]; then
-        DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#$DDPHOTOS_ALBUMS_DIR}"
+    if [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR"/* ]] || [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR" ]]; then
+        DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#$DDPHOTOS_DIR}"
     else
         EXTRA_MOUNT_ARGS+=(-v "$CONFIG_HOST_DIR":/ddphotos-config:ro)
         DDPHOTOS_CONFIG_DIR="/ddphotos-config"
@@ -63,7 +63,7 @@ if [ -n "$OPT_SITE_ENV" ]; then
 fi
 
 # Parse bases: section from albums.yaml and emit -v flags for external photo dirs.
-# Paths already inside DDPHOTOS_ALBUMS_DIR are skipped (covered by the main /ddphotos mount).
+# Paths already inside DDPHOTOS_DIR are skipped (covered by the main /ddphotos mount).
 # Populates MOUNT_ARGS (for docker run), MOUNT_PATHS and MOUNT_DESTS (for display).
 build_mount_args() {
     local config="$CONFIG_HOST_DIR/albums.yaml"
@@ -80,7 +80,7 @@ build_mount_args() {
             local path
             path=$(echo "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//')
             path="${path/#\~/$HOME}"
-            if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_ALBUMS_DIR"* ]]; then
+            if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
                 MOUNT_ARGS+=(-v "$path:$path:ro")
                 MOUNT_PATHS+=("$path")
                 MOUNT_DESTS+=("$path")
@@ -93,7 +93,7 @@ build_mount_args() {
 print_mounts() {
     echo "Mounting:"
     echo "  $SCRIPT_DIR -> /ddphotos-script-dir"
-    echo "  $DDPHOTOS_ALBUMS_DIR -> /ddphotos"
+    echo "  $DDPHOTOS_DIR -> /ddphotos"
     local i=0
     while [ $i -lt ${#MOUNT_PATHS[@]} ]; do
         echo "  ${MOUNT_PATHS[$i]} -> ${MOUNT_DESTS[$i]} (read-only)"
@@ -106,7 +106,7 @@ SERVE_PORT="${SERVE_PORT:-8000}"
 RUN_PORT="${RUN_PORT:-5173}"
 
 # Always mount SCRIPT_DIR at a fixed path so the container can verify/upgrade the script
-# regardless of what DDPHOTOS_ALBUMS_DIR points to.
+# regardless of what DDPHOTOS_DIR points to.
 SCRIPT_MOUNT=(-v "$SCRIPT_DIR":/ddphotos-script-dir)
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
@@ -115,9 +115,9 @@ case "$cmd" in
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
-            if [ "$DDPHOTOS_ALBUMS_DIR" = "$SCRIPT_DIR" ]; then
+            if [ "$DDPHOTOS_DIR" = "$SCRIPT_DIR" ]; then
                 echo "If ddphotos is installed in your PATH, specify your album directory:"
-                echo "  ddphotos --albums-dir ~/my-ddphotos $cmd"
+                echo "  ddphotos --dir ~/my-ddphotos $cmd"
             else
                 echo "Run 'ddphotos init' to initialize the album directory."
             fi
@@ -129,7 +129,7 @@ esac
 case "$cmd" in
     init)
         docker run --rm \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             "$IMAGE" init "$@"
         ;;
@@ -147,7 +147,7 @@ case "$cmd" in
         [ -n "$DDPHOTOS_CONFIG_DIR" ] && PHOTOGEN_ARGS+=(-e "DDPHOTOS_CONFIG_DIR=$DDPHOTOS_CONFIG_DIR")
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             "${PHOTOGEN_ARGS[@]}" \
             "$IMAGE" photogen "$@"
@@ -158,7 +158,7 @@ case "$cmd" in
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             "$IMAGE" build "$@"
         ;;
@@ -169,7 +169,7 @@ case "$cmd" in
         docker run --rm -it \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e SERVE_PORT="$SERVE_PORT" \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             -p "$SERVE_PORT":80 \
             "$IMAGE" serve "$@"
@@ -181,7 +181,7 @@ case "$cmd" in
         docker run --rm -it \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e RUN_PORT="$RUN_PORT" \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             -p "$RUN_PORT":5173 \
             "$IMAGE" run "$@"
@@ -217,14 +217,14 @@ case "$cmd" in
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             "${DEPLOY_ARGS[@]}" \
             "$IMAGE" deploy "$@"
         ;;
     upgrade)
         docker run --rm \
-            -v "$DDPHOTOS_ALBUMS_DIR":/ddphotos \
+            -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
             "$IMAGE" upgrade
         ;;
@@ -236,15 +236,15 @@ case "$cmd" in
         else
             echo "Image:       $IMAGE"
         fi
-        echo "Albums dir:  $DDPHOTOS_ALBUMS_DIR"
-        echo "Config dir:  $CONFIG_HOST_DIR"
-        echo "Site ID:     $DDPHOTOS_SITE_ID"
+        echo "DD Photos dir:  $DDPHOTOS_DIR"
+        echo "Config dir:     $CONFIG_HOST_DIR"
+        echo "Site ID:        $DDPHOTOS_SITE_ID"
         ;;
     *)
         echo "Usage: ddphotos [OPTIONS] {init|photogen|build|serve|run|deploy|upgrade} [args]"
         echo ""
         echo "Options (before command):"
-        echo "  --albums-dir DIR   Album directory to mount as /ddphotos (default: script location)"
+        echo "  --dir DIR         Directory to mount as /ddphotos (default: script location)"
         echo "  --site-id ID      Site ID override (default: settings.id from albums.yaml)"
         echo "  --config-dir DIR  Config directory override (default: albums-dir/config)"
         echo "  --site-env FILE   Path to site.env for deploy (default: config-dir/site.env)"

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -15,5 +15,7 @@ mkdir -p /ddphotos/build
 # svelte.config.js writes to ../build/$SITE_ID relative to web/; redirect to /ddphotos/build
 ln -sfn /ddphotos/build /app/build
 
+echo "Building $DDPHOTOS_SITE_ID ..."
+
 cd /app/web
 exec npm run build

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -16,7 +16,7 @@ if [ "${1:-}" = "--script-only" ]; then
     echo
     echo "Usage with a separate albums directory:"
     echo
-    echo "  ddphotos --albums-dir ~/my-ddphotos photogen|run|build|serve|upgrade|version"
+    echo "  ddphotos --dir ~/my-ddphotos photogen|run|build|serve|upgrade|version"
     echo
     exit 0
 fi

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -148,6 +148,15 @@ for the function code.
 A `config/site.env` with your rsync or S3 credentials is required before deploying in
 either mode — see [site.env](CONFIGURATION.md#siteenv) for examples.
 
+**Rsync mode** also requires a valid SSH key in `~/.ssh` with access to the target host.
+In Docker mode, `~/.ssh` is mounted into the container automatically if the directory exists.
+
+**S3 mode** requires AWS credentials — either via `~/.aws` config files or environment variables
+(`AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_DEFAULT_REGION`, `AWS_REGION`,
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`).
+In Docker mode, `~/.aws` is mounted and any of those environment variables that are set
+are forwarded into the container automatically.
+
 ## Deploying — Docker Mode
 
 ```bash

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,4 +1,4 @@
-# Development
+# Development Notes
 
 **Note:** This page is for contributors developing DD Photos, not for users building their own sites with it.
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -55,8 +55,8 @@ If you have `ddphotos` on the path and the `ddphotos` repo checked out under `~/
 can use the script to photogen and run the [sample site](https://ddphotos.donohoe.info/):
 
 ```bash
-ddphotos --albums-dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config photogen
-ddphotos --albums-dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config run
+ddphotos --dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config photogen
+ddphotos --dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config run
 ```
 
 ---
@@ -169,7 +169,7 @@ Config dir:  /Users/anseladams/my-ddphotos/config
 Site ID:     my-photos
 ```
 
-The `--albums-dir`, `--config-dir`, and `--site-id` pre-command flags also work with `version`, making it useful for confirming which config a given invocation would use.
+The `--dir`, `--config-dir`, and `--site-id` pre-command flags also work with `version`, making it useful for confirming which config a given invocation would use.
 
 ---
 
@@ -179,7 +179,7 @@ These flags go before the command name and apply to all commands that need them:
 
 | Flag                  | Description                                                                                           |
 |-----------------------|-------------------------------------------------------------------------------------------------------|
-| `--albums-dir <path>` | Directory containing your config and albums output (default: same directory as the `ddphotos` script) |
+| `--dir <path>` | Directory containing your config and albums output (default: same directory as the `ddphotos` script) |
 | `--config-dir <path>` | Path to a config directory other than `<albums-dir>/config`                                           |
 | `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                        |
 | `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                          |
@@ -187,8 +187,8 @@ These flags go before the command name and apply to all commands that need them:
 Example — using a separate source repo as the albums dir:
 
 ```bash
-ddphotos --albums-dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config photogen
-ddphotos --albums-dir ~/work/ddphotos --site-id sample build
+ddphotos --dir ~/work/ddphotos --config-dir ~/work/ddphotos/sample/config photogen
+ddphotos --dir ~/work/ddphotos --site-id sample build
 ```
 
 ---

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -13,7 +13,7 @@ The `site.env` file holds variables used by `bin/deploy-photos.sh` — nothing t
 
 See [site.env](CONFIGURATION.md#siteenv) in the Configuration docs for rsync and S3 examples.
 
-## Album Location Variables
+## Album Location Variables (development)
 
 Two variables tell the dev server, build, and Docker container where to find album data:
 
@@ -34,7 +34,11 @@ DDPHOTOS_ALBUMS_DIR=~/photos/albums DDPHOTOS_SITE_ID=mySite make web-npm-build
 ```
 
 These variables are consumed by:
-- `vite.config.ts` — dev server middleware serves `/albums/**` from `<DDPHOTOS_ALBUMS_DIR>/<DDPHOTOS_SITE_ID>/`
+- `cmd/photogen` — writes processed photos and JSON to `<DDPHOTOS_ALBUMS_DIR>/<site-id>/` (site ID comes from the albums config YAML, not `DDPHOTOS_SITE_ID`)
+- `web/vite.config.ts` — dev server middleware serves `/albums/**` from `<DDPHOTOS_ALBUMS_DIR>/<DDPHOTOS_SITE_ID>/`
 - `web/svelte.config.js` — build output goes to `build/<DDPHOTOS_SITE_ID>/`; album slugs are read for pre-rendered entries
-- `web/hooks.server.ts` — intercepts fetch calls to `/albums/**` during `npm run build`
-- `web/apache-entrypoint.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the Apache document root at container startup
+- `web/src/hooks.server.ts` — intercepts fetch calls to `/albums/**` during `npm run build`
+- `web/setup-htdocs.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the web server document root at container startup (called by both `apache-entrypoint.sh` and `nginx-entrypoint.sh`)
+- `bin/deploy-photos.sh` — drives `npm run build`, Docker deployment, and S3/rsync sync
+- `bin/search_cover.sh` — locates album data when searching for cover images
+- `bin/run-tests.sh` — sets both when starting the dev server, building, and running Docker test containers

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1324,12 +1324,12 @@ Three values are baked in at build time via `ARG` + `RUN echo`:
 
 A single `ddphotos` bash script that users install locally and invoke instead of `docker run` directly. It handles all volume mounts, port bindings, and environment variable forwarding. Key design decisions:
 
-- Pre-command flags parsed before the command name: `--albums-dir`, `--config-dir`, `--site-id`, `--site-env`
+- Pre-command flags parsed before the command name: `--dir`, `--config-dir`, `--site-id`, `--site-env`
 - `DDPHOTOS_ALBUMS_DIR` (the `/ddphotos` mount) defaults to the script's own directory, so the script works whether it lives inside the album directory or somewhere on `$PATH`
 - `SCRIPT_DIR` is always mounted separately as `/ddphotos-script-dir` so the container can verify and upgrade the script regardless of what `DDPHOTOS_ALBUMS_DIR` points to
 - External `--config-dir` paths are mounted as `/ddphotos-config` when they fall outside `DDPHOTOS_ALBUMS_DIR`
 - `build_mount_args` parses `bases:` from `albums.yaml` and emits `-v` flags for external photo directories, resolving `~` and skipping paths already covered by the main mount
-- Pre-flight validation checks that `albums.yaml` exists before launching Docker for any command that needs it, with a helpful error message guiding PATH-installed users to pass `--albums-dir`
+- Pre-flight validation checks that `albums.yaml` exists before launching Docker for any command that needs it, with a helpful error message guiding PATH-installed users to pass `--dir`
 
 #### Entrypoint and Commands (`docker/entrypoint.sh`, `docker/do-*.sh`)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,4 @@
-# Non-Docker Setup
+# Developer Setup
 
 The following are aimed at developers who want to work directly from this repo,
 instead of using the [Docker](DOCKER.md)-based `ddphotos` tool.

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -13,10 +13,10 @@ password protection.
 
 Output goes to `<albums-dir>/<id>/` (git-ignored):
 
-| Mode      | Default output location                                                            | Override                                     |
-|-----------|------------------------------------------------------------------------------------|----------------------------------------------|
-| Docker    | `albums/` inside the `ddphotos` script directory (i.e. `~/my-ddphotos/albums/`)    | `--albums-dir` pre-command flag              |
-| Developer | `albums/` at the repo root (set by `DDPHOTOS_ALBUMS_DIR` in `config/defaults.env`) | `-out` flag or `DDPHOTOS_ALBUMS_DIR` env var |
+| Mode      | Default output location                                                            | Override                                       |
+|-----------|------------------------------------------------------------------------------------|------------------------------------------------|
+| Docker    | `albums/` inside the `ddphotos` script directory (i.e. `~/my-ddphotos/albums/`)    | `--dir` pre-command flag can change script dir |
+| Developer | `albums/` at the repo root (set by `DDPHOTOS_ALBUMS_DIR` in `config/defaults.env`) | `-out` flag or `DDPHOTOS_ALBUMS_DIR` env var   |
 
 To run with defaults:
 


### PR DESCRIPTION
A collection of small improvements to the Docker script, documentation, and build logging.

## Changes

**Rename `--albums-dir` to `--dir`** — the old flag name was misleading: it sets the directory
mounted as `/ddphotos` (which contains config, albums output, and build output), not just albums.
It was also easy to confuse with the `DDPHOTOS_ALBUMS_DIR` env var. Updated all references across
the script, docs, and history.

**Deploy credentials documented** — `docs/DEPLOY.md` Prerequisites now covers the SSH key
requirement for rsync mode and AWS credential options (files or env vars) for S3 mode, including
how Docker mode mounts/forwards them automatically.

**ENV.md consumer list corrected and completed** — fixed two wrong file paths
(`vite.config.ts` → `web/vite.config.ts`, `web/hooks.server.ts` → `web/src/hooks.server.ts`),
replaced the `web/apache-entrypoint.sh` entry with the actual consumer `web/setup-htdocs.sh`
(called by both Apache and nginx entrypoints), and added missing consumers: `cmd/photogen`,
`bin/deploy-photos.sh`, `bin/search_cover.sh`, and `bin/run-tests.sh`.

**README.md docs table split into user/developer** — separates user-facing docs (Docker, config,
deployment) from developer docs (setup, testing, Makefile). Renamed `INSTALL.md` title to
"Developer Setup" and `DEV.md` title to "Development Notes" to match.

**Build logging** — `docker/do-build.sh` now logs the site ID before running `npm run build`.

**SPDX copyright header in `ddphotos` script** — added a two-line header with the SPDX license
identifier and repo URL, since this script is copied to user directories outside the repo context.