### PR TITLE
Check for new version of ddphotos image

### DIFF
--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -5,6 +5,10 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="ddphotos"
+CURRENT_VERSION="${IMAGE##*:}"
+STATE_DIR="${HOME}/.config/ddphotos"
+UPGRADE_FILE="$STATE_DIR/upgrade.txt"
+mkdir -p "$STATE_DIR"
 
 # Parse --dir, --site-id, --config-dir, --site-env flags before the command
 OPT_CONFIG_DIR=""
@@ -104,6 +108,33 @@ print_mounts() {
     echo ""
 }
 
+# Query Docker Hub for the latest versioned release tag and write upgrade.txt if newer.
+check_for_update() {
+    [[ "$CURRENT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 0
+    command -v curl >/dev/null 2>&1 || return 0
+
+    local last_check="$STATE_DIR/last-check"
+    if [ -f "$last_check" ] && [ -z "$(find "$last_check" -mmin +1440 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    local repo latest newer
+    repo="${IMAGE%%:*}"
+    latest=$(curl -sf --max-time 2 \
+        "https://hub.docker.com/v2/repositories/${repo}/tags?page_size=50&ordering=last_updated" \
+        | grep -oE '"name":"v[0-9]+\.[0-9]+\.[0-9]+"' \
+        | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' \
+        | sort -V | tail -1) || true
+
+    touch "$last_check"
+    [ -z "$latest" ] && return 0
+
+    newer=$(printf '%s\n%s' "$CURRENT_VERSION" "$latest" | sort -V | tail -1)
+    if [ "$newer" != "$CURRENT_VERSION" ]; then
+        echo "$latest" > "$UPGRADE_FILE"
+    fi
+}
+
 SERVE_PORT="${SERVE_PORT:-8000}"
 RUN_PORT="${RUN_PORT:-5173}"
 
@@ -131,6 +162,17 @@ case "$cmd" in
         fi
         ;;
 esac
+
+# Remove upgrade.txt if we're already on that version (post-upgrade cleanup)
+if [ -f "$UPGRADE_FILE" ] && [ "$(cat "$UPGRADE_FILE")" = "$CURRENT_VERSION" ]; then
+    rm -f "$UPGRADE_FILE"
+fi
+
+check_for_update
+
+if [ -f "$UPGRADE_FILE" ]; then
+    echo "Update available: $(cat "$UPGRADE_FILE") - run 'ddphotos upgrade' to update" >&2
+fi
 
 case "$cmd" in
     init)
@@ -226,10 +268,15 @@ case "$cmd" in
             "$IMAGE" deploy "$@"
         ;;
     upgrade)
+        UPGRADE_IMAGE="$IMAGE"
+        if [[ "$CURRENT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -f "$UPGRADE_FILE" ]; then
+            TARGET_VERSION=$(cat "$UPGRADE_FILE")
+            UPGRADE_IMAGE="${IMAGE%%:*}:$TARGET_VERSION"
+        fi
         docker run --rm \
             -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
-            "$IMAGE" upgrade
+            "$UPGRADE_IMAGE" upgrade
         ;;
     version)
         echo "Script:         $SCRIPT_DIR/ddphotos"
@@ -240,6 +287,7 @@ case "$cmd" in
         echo "DD Photos dir:  $DDPHOTOS_DIR"
         echo "Config dir:     $CONFIG_HOST_DIR"
         echo "Site ID:        $DDPHOTOS_SITE_ID"
+        echo "State dir:      $STATE_DIR"
         ;;
     *)
         echo "Usage: ddphotos [OPTIONS] {init|photogen|build|serve|run|export|deploy|upgrade} [args]"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -52,7 +52,7 @@ DDPHOTOS_CONFIG_DIR=""
 CONFIG_DIR_EXTRA_SRC=""  # set only when an extra mount is needed (for display)
 if [ -n "$OPT_CONFIG_DIR" ]; then
     if [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR"/* ]] || [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR" ]]; then
-        DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#$DDPHOTOS_DIR}"
+        DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#"$DDPHOTOS_DIR"}"
     else
         EXTRA_MOUNT_ARGS+=(-v "$CONFIG_HOST_DIR":/ddphotos-config:ro)
         DDPHOTOS_CONFIG_DIR="/ddphotos-config"
@@ -76,16 +76,25 @@ build_mount_args() {
     [ -f "$config" ] || return 0
     local in_bases=false
     while IFS= read -r line; do
+        # Look for the "bases:" section header; once found, start processing lines below it
         if [[ "$line" =~ ^bases: ]]; then
             in_bases=true
             continue
         fi
         if $in_bases; then
+            # A line starting with a letter/underscore is a new top-level YAML key — we've
+            # left the bases: section, so stop
             [[ "$line" =~ ^[a-zA-Z_] ]] && break
+            # Skip comment lines
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
+            # Extract the value from a "  name: /some/path" line:
+            # strip everything up to and including the first colon, then strip leading whitespace
             local path
-            path=$(echo "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//')
+            path="${line#*:}"
+            path="${path#"${path%%[^[:space:]]*}"}"
+            # Expand leading ~ to $HOME
             path="${path/#\~/$HOME}"
+            # Only mount absolute paths that fall outside DDPHOTOS_DIR (which is already mounted)
             if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
                 MOUNT_ARGS+=(-v "$path:$path:ro")
                 MOUNT_PATHS+=("$path")

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,9 +7,9 @@ shift 2>/dev/null || true
 # Verify the mounted ddphotos script matches the image (skip for init/upgrade/version)
 if [ "$cmd" != "init" ] && [ "$cmd" != "upgrade" ] && [ "$cmd" != "version" ]; then
     if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
-        echo "Error: local ddphotos script does not match the image."
-        echo "Run: ddphotos upgrade"
-        exit 1
+        echo "WARNING: the local 'ddphotos' script does not match the image."
+        echo "         Run: 'ddphotos upgrade' to fix this."
+        echo ""
     fi
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,8 +7,8 @@ shift 2>/dev/null || true
 # Verify the mounted ddphotos script matches the image (skip for init/upgrade/version)
 if [ "$cmd" != "init" ] && [ "$cmd" != "upgrade" ] && [ "$cmd" != "version" ]; then
     if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
-        echo "WARNING: the local 'ddphotos' script does not match the image."
-        echo "         Run: 'ddphotos upgrade' to fix this."
+        echo "WARNING:  The local 'ddphotos' script does not match the image."
+        echo "          Run: 'ddphotos upgrade' to fix this."
         echo ""
     fi
 fi

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -173,10 +173,8 @@ See [Deployment](DEPLOY.md) for full setup details.
 
 ### `upgrade`
 
-Pulls the latest release and updates the local `ddphotos` wrapper script. If an update
-notice has been shown (see [Version Check and Upgrade](#version-check-and-upgrade) below),
-this installs the newer version automatically. Otherwise it upgrades to match the currently
-pinned image.
+Updates the local `ddphotos` wrapper script to match the image. Run this when an update
+notice appears to install the newer version, or to fix a script/image mismatch.
 
 ```bash
 ddphotos upgrade
@@ -283,11 +281,11 @@ Every command (except `init`, `upgrade`, and `version`) also checks that your lo
 `ddphotos` script matches the running image. In normal use with a tagged release this
 should never fire — the automatic update check keeps things in sync. It is primarily
 relevant for `dev` builds, or in the unlikely event you manually edit the `ddphotos`
-script. If they differ, you'll see:
+script. If they differ, a warning is printed and the command continues normally:
 
 ```
-Error: local ddphotos script does not match the image.
-Run: ddphotos upgrade
+WARNING: the local 'ddphotos' script does not match the image.
+         Run: 'ddphotos upgrade' to fix this.
 ```
 
 Run `ddphotos upgrade` to bring the script back in sync.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -284,8 +284,8 @@ relevant for `dev` builds, or in the unlikely event you manually edit the `ddpho
 script. If they differ, a warning is printed and the command continues normally:
 
 ```
-WARNING: the local 'ddphotos' script does not match the image.
-         Run: 'ddphotos upgrade' to fix this.
+WARNING:  The local 'ddphotos' script does not match the image.
+          Run: 'ddphotos upgrade' to fix this.
 ```
 
 Run `ddphotos upgrade` to bring the script back in sync.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -173,7 +173,10 @@ See [Deployment](DEPLOY.md) for full setup details.
 
 ### `upgrade`
 
-Updates the local `ddphotos` wrapper script to match the current Docker image.
+Pulls the latest release and updates the local `ddphotos` wrapper script. If an update
+notice has been shown (see [Version Check and Upgrade](#version-check-and-upgrade) below),
+this installs the newer version automatically. Otherwise it upgrades to match the currently
+pinned image.
 
 ```bash
 ddphotos upgrade
@@ -188,11 +191,12 @@ ddphotos version
 ```
 
 ```
-Script:      /Users/anseladams/.local/bin/ddphotos
-Image:       dougdonohoe/ddphotos:v1.2.0
-Albums dir:  /Users/anseladams/my-ddphotos
-Config dir:  /Users/anseladams/my-ddphotos/config
-Site ID:     my-photos
+Script:         /Users/anseladams/.local/bin/ddphotos
+Image:          dougdonohoe/ddphotos:v1.2.0
+DD Photos dir:  /Users/anseladams/my-ddphotos
+Config dir:     /Users/anseladams/my-ddphotos/config
+Site ID:        my-photos
+State dir:      /Users/anseladams/.config/ddphotos
 ```
 
 Add `--image` to also query the image for its build details:
@@ -202,13 +206,14 @@ ddphotos version --image
 ```
 
 ```
-Script:      /Users/anseladams/.local/bin/ddphotos
-Image:       dougdonohoe/ddphotos:v1.2.0
-               Version:  v1.2.0
-               Git:      v1.2.0-0-gabcdef1
-Albums dir:  /Users/anseladams/my-ddphotos
-Config dir:  /Users/anseladams/my-ddphotos/config
-Site ID:     my-photos
+Script:         /Users/anseladams/.local/bin/ddphotos
+Image:          dougdonohoe/ddphotos:v1.2.0
+                  Version:  v1.2.0
+                  Git:      v1.2.0-0-gabcdef1
+DD Photos dir:  /Users/anseladams/my-ddphotos
+Config dir:     /Users/anseladams/my-ddphotos/config
+Site ID:        my-photos
+State dir:      /Users/anseladams/.config/ddphotos
 ```
 
 The `--dir`, `--config-dir`, and `--site-id` pre-command flags also work with `version`, making it useful for confirming which config a given invocation would use.
@@ -221,7 +226,7 @@ These flags go before the command name and apply to all commands that need them:
 
 | Flag                  | Description                                                                                           |
 |-----------------------|-------------------------------------------------------------------------------------------------------|
-| `--dir <path>` | Directory containing your config and albums output (default: same directory as the `ddphotos` script) |
+| `--dir <path>`        | Directory containing your config and albums output (default: same directory as the `ddphotos` script) |
 | `--config-dir <path>` | Path to a config directory other than `<albums-dir>/config`                                           |
 | `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                        |
 | `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                          |
@@ -257,11 +262,32 @@ my-ddphotos/
 
 ## Version Check and Upgrade
 
-Every command (except `init`, `upgrade`, and `version`) checks that your local `ddphotos` script matches the image. If they differ, you'll see:
+### Automatic update check
+
+Each time you run `ddphotos`, it checks Docker Hub for a newer release — at most once per
+day, and only when the script is pinned to a versioned release (not a `dev` build). State is
+stored in `~/.config/ddphotos/` (created automatically on first run).
+
+If a newer version is available, a notice prints to stderr on every subsequent run:
+
+```
+Update available: v1.3.0 - run 'ddphotos upgrade' to update
+```
+
+Run `ddphotos upgrade` to pull and install it. The notice is cleared automatically once
+the installed version matches the latest.
+
+### Script/image mismatch check
+
+Every command (except `init`, `upgrade`, and `version`) also checks that your local
+`ddphotos` script matches the running image. In normal use with a tagged release this
+should never fire — the automatic update check keeps things in sync. It is primarily
+relevant for `dev` builds, or in the unlikely event you manually edit the `ddphotos`
+script. If they differ, you'll see:
 
 ```
 Error: local ddphotos script does not match the image.
 Run: ddphotos upgrade
 ```
 
-Run `ddphotos upgrade` to update the script in place.
+Run `ddphotos upgrade` to bring the script back in sync.

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1442,3 +1442,45 @@ On narrow mobile screens, the Docker image name (e.g., `dougdonohoe/ddphotos:v1.
 - Changed to `word-break: break-word` — breaks only at natural word boundaries (`/`, `:`)
 - Added `@media (max-width: 480px)` rule reducing `.modal-body` font size from `1.15rem` to `0.95rem`, giving enough width to keep the image name on one line
 - Added `VITE_DOCKER_IMAGE` dev-server usage to `docs/DEV.md` so developers can test the dialog with a realistic image name: `VITE_DOCKER_IMAGE='dougdonohoe/ddphotos:v1.12.0' make sample-npm-run-dev`
+
+### 66. 04/30/2026 - Automatic Update Check
+
+#### Motivation
+
+The `ddphotos` script is pinned to a specific image version (e.g., `dougdonohoe/ddphotos:v1.13.0`). Users had no way to know when a newer release was available without manually checking Docker Hub. The goal was a low-friction, host-side check that notifies without interrupting normal use.
+
+#### Update Check Design
+
+After evaluating several approaches, the check runs host-side in the `ddphotos` bash script (no Docker involvement, no new mounts needed). State lives in `~/.config/ddphotos/` (created automatically on first run).
+
+Key design decisions:
+- **Docker Hub API** used to find the latest versioned tag (via `curl` + `grep -oE`)  
+- **`jq` and `python3` avoided** — not reliably present on all platforms; pure bash + `grep` + `sort -V` is sufficient
+- **`curl`** treated as safe to assume (it's required to install `ddphotos` in the first place)
+- **Once-per-day throttle** via mtime of `~/.config/ddphotos/last-check`; skipped entirely for `dev` builds
+- **Serial check** (not background) — `ddphotos` commands are long-running enough that a sub-2-second curl is not a concern
+
+#### Implementation (`docker/ddphotos`)
+
+- `STATE_DIR` (`~/.config/ddphotos/`) and `UPGRADE_FILE` (`upgrade.txt`) set up at script top; `mkdir -p` ensures the directory exists
+- `check_for_update()` function: queries Docker Hub, extracts version tags with `grep -oE`, compares with current version using `sort -V`, writes `upgrade.txt` if newer found; `curl --max-time 2` prevents hangs
+- On every command run: if `upgrade.txt` matches current version (post-upgrade), it is deleted; then `check_for_update` runs; then a notice is printed to stderr if `upgrade.txt` exists
+- `upgrade` command reads `upgrade.txt` when present and substitutes the target version into the image reference before calling `docker run`, so the container's existing upgrade logic installs the new script
+- `version` output now includes `State dir:` line
+
+#### Script/Image Mismatch Check
+
+Changed from a hard error (`exit 1`) to a warning that lets the command continue. The mismatch check is primarily relevant for `dev` builds; with the new automatic update flow, it should never fire for tagged releases in normal use.
+
+#### Shell Script Fixes
+
+Two IntelliJ/ShellCheck warnings addressed:
+- Quoted `$DDPHOTOS_DIR` inside `${CONFIG_HOST_DIR#"$DDPHOTOS_DIR"}` to prevent glob interpretation of the pattern
+- Replaced `echo "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//'` in `build_mount_args()` with pure bash parameter expansion: `path="${line#*:}"` then `path="${path#"${path%%[^[:space:]]*}"}"` — eliminates subprocess and the sed dependency
+- Added inline comments to `build_mount_args()` explaining the YAML parsing logic
+
+#### Documentation (`docs/DOCKER.md`)
+
+- `upgrade` command description rewritten to be accurate
+- `version` output examples corrected (`DD Photos dir:` was wrong as `Albums dir:`) and updated to include `State dir:`
+- `Version Check and Upgrade` section expanded into two subsections: **Automatic update check** (new) and **Script/image mismatch check** (existing, now described as a warning)


### PR DESCRIPTION
## Summary

- Adds an automatic daily update check to the `ddphotos` wrapper script: queries Docker Hub for a newer versioned release tag, writes `~/.config/ddphotos/upgrade.txt` if one is found, and prints a notice to stderr on subsequent runs
- `ddphotos upgrade` now reads `upgrade.txt` when present and installs the indicated version; `upgrade.txt` is cleaned up automatically once the installed version matches
- Changed the script/image mismatch check in `entrypoint.sh` from a hard error to a warning — the command continues normally, since this mainly affects dev builds and shouldn't block work
- Fixed two ShellCheck/IntelliJ warnings in `docker/ddphotos`: quoted variable inside `${var#pattern}` to suppress glob interpretation; replaced `echo | sed` in `build_mount_args()` with pure bash parameter expansion
- Added comments to `build_mount_args()` explaining the YAML parsing logic
- Updated `docs/DOCKER.md`: corrected `version` output examples, updated `upgrade` description, expanded the Version Check and Upgrade section

## How the update check works

- Runs host-side in the `ddphotos` bash script — no Docker involvement, no new volume mounts
- State stored in `~/.config/ddphotos/` (created automatically); throttled to once per day via mtime of `last-check`
- Skipped for `dev` builds; only active when the script is pinned to a `vX.Y.Z` tag
- Uses `curl` + `grep -oE` + `sort -V` — no `jq` or `python3` dependency
- `curl --max-time 2` prevents hangs if Docker Hub is slow or unreachable

## Test plan

- [x] Delete `~/.config/ddphotos/last-check` and `upgrade.txt`, set IMAGE to an old version, run `ddphotos version` — update notice appears
- [x] Run `ddphotos version` again immediately — no re-fetch (last-check is fresh), notice still shown
- [x] Run `ddphotos upgrade` — installs newer version, `upgrade.txt` removed on next run
- [x] Verify mismatch warning prints but command continues