### PR TITLE
Docker mode test suite and optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Run S3 deploy test
         run: make sample-s3-test
+
+      - name: Run Docker workflow tests
+        run: make docker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,26 +46,27 @@ jobs:
       - name: Install Playwright system dependencies
         run: cd web && npx playwright install-deps chromium
 
-      - name: Photogen and build
-        run: make sample-photogen sample-build
-
-      - name: Run Apache routing tests
-        run: make web-docker-build-apache sample-test-apache
-
-      - name: Run nginx routing tests
-        run: make web-docker-build-nginx sample-test-nginx
-
-      - name: Run Apache Playwright e2e tests (all password variants)
-        run: bin/test-all.sh --mode apache --ci
-
-      - name: Run nginx Playwright e2e tests (all password variants)
-        run: bin/test-all.sh --mode nginx --ci
-
-      - name: Run rsync deploy test
-        run: make sample-rsync-test
-
-      - name: Run S3 deploy test
-        run: make sample-s3-test
+# Temporary skip
+#      - name: Photogen and build
+#        run: make sample-photogen sample-build
+#
+#      - name: Run Apache routing tests
+#        run: make web-docker-build-apache sample-test-apache
+#
+#      - name: Run nginx routing tests
+#        run: make web-docker-build-nginx sample-test-nginx
+#
+#      - name: Run Apache Playwright e2e tests (all password variants)
+#        run: bin/test-all.sh --mode apache --ci
+#
+#      - name: Run nginx Playwright e2e tests (all password variants)
+#        run: bin/test-all.sh --mode nginx --ci
+#
+#      - name: Run rsync deploy test
+#        run: make sample-rsync-test
+#
+#      - name: Run S3 deploy test
+#        run: make sample-s3-test
 
       - name: Run Docker workflow tests
         run: make docker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,27 +46,26 @@ jobs:
       - name: Install Playwright system dependencies
         run: cd web && npx playwright install-deps chromium
 
-# Temporary skip
-#      - name: Photogen and build
-#        run: make sample-photogen sample-build
-#
-#      - name: Run Apache routing tests
-#        run: make web-docker-build-apache sample-test-apache
-#
-#      - name: Run nginx routing tests
-#        run: make web-docker-build-nginx sample-test-nginx
-#
-#      - name: Run Apache Playwright e2e tests (all password variants)
-#        run: bin/test-all.sh --mode apache --ci
-#
-#      - name: Run nginx Playwright e2e tests (all password variants)
-#        run: bin/test-all.sh --mode nginx --ci
-#
-#      - name: Run rsync deploy test
-#        run: make sample-rsync-test
-#
-#      - name: Run S3 deploy test
-#        run: make sample-s3-test
+      - name: Photogen and build
+        run: make sample-photogen sample-build
+
+      - name: Run Apache routing tests
+        run: make web-docker-build-apache sample-test-apache
+
+      - name: Run nginx routing tests
+        run: make web-docker-build-nginx sample-test-nginx
+
+      - name: Run Apache Playwright e2e tests (all password variants)
+        run: bin/test-all.sh --mode apache --ci
+
+      - name: Run nginx Playwright e2e tests (all password variants)
+        run: bin/test-all.sh --mode nginx --ci
+
+      - name: Run rsync deploy test
+        run: make sample-rsync-test
+
+      - name: Run S3 deploy test
+        run: make sample-s3-test
 
       - name: Run Docker workflow tests
         run: make docker-test

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ DDPHOTOS_IMAGE  ?= ddphotos
 ## docker-build: build the ddphotos Docker image
 docker-build:
 	docker build -t $(DDPHOTOS_IMAGE) \
+		--build-arg NODE_VERSION=$$(cat web/.nvmrc) \
 		--build-arg DDPHOTOS_GIT_DESCRIBE="$$(git describe --tags --long --dirty --always 2>/dev/null || echo unknown)" \
 		-f docker/Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ sample-test-apache: _check-docker-schema-apache
 		photos-apache
 	@echo "Waiting for Apache to be ready..."; \
 	until curl -s -o /dev/null http://localhost:8082; do sleep 1; done
-	bin/test-photos-server.sh --config-dir sample/config --local 8082; \
+	bin/test-photos-server.sh --local 8082; \
 	EXIT=$$?; docker stop sample-test-apache 2>/dev/null || true; exit $$EXIT
 
 .PHONY: sample-test-nginx
@@ -256,7 +256,7 @@ sample-test-nginx: _check-docker-schema-nginx
 		photos-nginx
 	@echo "Waiting for nginx to be ready..."; \
 	until curl -s -o /dev/null http://localhost:8082; do sleep 1; done
-	bin/test-photos-server.sh --config-dir sample/config --local 8082; \
+	bin/test-photos-server.sh --local 8082; \
 	EXIT=$$?; docker stop sample-test-nginx 2>/dev/null || true; exit $$EXIT
 
 .PHONY: sample-rsync-test
@@ -295,3 +295,8 @@ docker-build:
 ## docker-push: build multi-arch image and push to Docker Hub (tag is dev or vX.Y.Z+latest)
 docker-push:
 	bin/docker-push.sh
+
+.PHONY: docker-test
+## docker-test: build the ddphotos Docker image and run end-to-end Docker workflow tests
+docker-test:
+	bin/docker-test.sh

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -157,7 +157,6 @@ _pre_deploy() {
 
         echo "Running local server tests..."
         TEST_ARGS=(--local 8080)
-        [ -n "$CONFIG_DIR" ] && TEST_ARGS+=(--config-dir "$CONFIG_DIR")
         "$SDIR/test-photos-server.sh" "${TEST_ARGS[@]}"
 
         if [ "$SKIP_PLAYWRIGHT" = true ]; then
@@ -198,7 +197,6 @@ _post_deploy() {
         fi
         PROD_ARGS=(--remote "$SITE_URL")
         [ "$mode" = "s3" ] && PROD_ARGS=(--s3 "${PROD_ARGS[@]}")
-        [ -n "$CONFIG_DIR" ] && PROD_ARGS+=(--config-dir "$CONFIG_DIR")
         "$SDIR/test-photos-server.sh" "${PROD_ARGS[@]}"
     fi
 

--- a/bin/docker-push.sh
+++ b/bin/docker-push.sh
@@ -47,9 +47,11 @@ else
 fi
 
 GIT_DESCRIBE=$(git describe --tags --long --dirty --always 2>/dev/null || echo "unknown")
+NODE_VERSION=$(cat web/.nvmrc)
 
 docker buildx build \
     --platform linux/amd64,linux/arm64 \
+    --build-arg NODE_VERSION="$NODE_VERSION" \
     --build-arg DDPHOTOS_VERSION="$VERSION" \
     --build-arg DDPHOTOS_GIT_DESCRIBE="$GIT_DESCRIBE" \
     --build-arg DDPHOTOS_IMAGE="$IMAGE_TAG" \

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# End-to-end test of the ddphotos Docker workflow.
+#
+# Usage:
+#   bin/docker-test.sh              # build image then run all tests
+#   bin/docker-test.sh --no-build   # skip 'make docker-build' (reuse existing image)
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE="ddphotos"
+SITE_ID="my-photos"   # site-id created by 'init' template
+RUN_PORT=5173          # Vite host port; matches container default to keep port-mapping consistent
+SERVE_PORT=8090        # Apache host port (maps to container port 80; avoids conflicts with run-tests.sh)
+DO_BUILD=true
+TEST_DIR=""
+TEST_DIR2=""
+RUN_PID=""
+SERVE_PID=""
+
+# --- flags ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-build) DO_BUILD=false; shift ;;
+        --help|-\?) echo "Usage: bin/docker-test.sh [--no-build]"; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- helpers ---
+step()  { echo; echo "=== $* ==="; }
+pass()  { echo "  PASS: $*"; }
+fail()  { echo "  FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+    [ -n "$RUN_PID" ]   && kill "$RUN_PID"   2>/dev/null || true
+    [ -n "$SERVE_PID" ] && kill "$SERVE_PID" 2>/dev/null || true
+    # Belt-and-suspenders: stop any containers using the local image still running on our ports
+    docker ps --filter publish="$RUN_PORT"   -q | xargs docker stop &>/dev/null || true
+    docker ps --filter publish="$SERVE_PORT" -q | xargs docker stop &>/dev/null || true
+    [ -n "$TEST_DIR"  ] && /bin/rm -rf "$TEST_DIR"
+    [ -n "$TEST_DIR2" ] && /bin/rm -rf "$TEST_DIR2"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+# Source nvm if node not on PATH
+if ! command -v node &>/dev/null; then
+    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    [ -f "$NVM_SH" ] || { echo "Error: node not found; install Node.js or nvm" >&2; exit 1; }
+    # shellcheck source=/dev/null
+    source "$NVM_SH"
+fi
+
+run_playwright() {
+    local base_url="$1" passwords_file="${2:-}"
+    (
+        cd "$REPO_ROOT/web"
+        export PLAYWRIGHT_BASE_URL="$base_url"
+        export PLAYWRIGHT_IGNORE_CUSTOM_CSS=1
+        [ -n "$passwords_file" ] && export PLAYWRIGHT_PASSWORDS_FILE="$passwords_file"
+        npx playwright test
+    )
+}
+
+wait_for_http() {
+    local url="$1" label="$2" tries=0
+    echo "  Waiting for $label..."
+    until curl -s -o /dev/null "$url" 2>/dev/null; do
+        sleep 1
+        tries=$((tries + 1))
+        if [ "$tries" -ge 60 ]; then echo "Error: $label did not become ready" >&2; return 1; fi
+    done
+}
+
+cd "$REPO_ROOT"
+
+# ── 1. Build image ─────────────────────────────────────────────────────────────
+if $DO_BUILD; then
+    step "Building Docker image"
+    make docker-build
+else
+    step "Skipping Docker build (--no-build)"
+fi
+
+# ── 2. Init ────────────────────────────────────────────────────────────────────
+step "Init"
+TEST_DIR=$(mktemp -d)
+docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init
+[ -x "$TEST_DIR/ddphotos" ]              || fail "ddphotos script not installed"
+[ -f "$TEST_DIR/config/albums.yaml" ]    || fail "config/albums.yaml not created"
+[ -f "$TEST_DIR/config/passwords.yaml" ] || fail "config/passwords.yaml not created"
+pass "ddphotos script and config created at $TEST_DIR"
+
+PASSWORDS_FILE="$TEST_DIR/config/passwords.yaml"
+
+# ── 3. Photogen ────────────────────────────────────────────────────────────────
+step "Photogen"
+"$TEST_DIR/ddphotos" photogen
+[ -d "$TEST_DIR/albums/$SITE_ID" ] || fail "albums/$SITE_ID not created"
+ALBUM_COUNT=$(find "$TEST_DIR/albums/$SITE_ID" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
+pass "albums/$SITE_ID created ($ALBUM_COUNT albums)"
+
+# ── 4. Run (Vite dev server) + Playwright ─────────────────────────────────────
+step "Run — Vite dev server on port $RUN_PORT"
+RUN_PORT="$RUN_PORT" "$TEST_DIR/ddphotos" --non-interactive run &
+RUN_PID=$!
+wait_for_http "http://localhost:$RUN_PORT" "Vite dev server"
+run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
+kill "$RUN_PID" 2>/dev/null || true; wait "$RUN_PID" 2>/dev/null || true; RUN_PID=""
+pass "run + Playwright OK"
+
+# ── 5. Build ───────────────────────────────────────────────────────────────────
+step "Build"
+"$TEST_DIR/ddphotos" build
+[ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"
+pass "build/$SITE_ID created"
+
+# ── 6. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
+step "Serve — Apache on port $SERVE_PORT"
+SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
+SERVE_PID=$!
+wait_for_http "http://localhost:$SERVE_PORT" "Apache"
+run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
+"$SCRIPT_DIR/test-photos-server.sh" --local "$SERVE_PORT"
+kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
+pass "serve + Playwright + test-photos-server.sh OK"
+
+# ── 7. Export (symlink mode) ───────────────────────────────────────────────────
+EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
+
+step "Export (symlinks)"
+"$TEST_DIR/ddphotos" export
+[ -d "$EXPORT_DIR" ]            || fail "export/$SITE_ID not created"
+[ -f "$EXPORT_DIR/index.html" ] || fail "export/$SITE_ID/index.html missing"
+broken=$(find "$EXPORT_DIR" -type l ! -exec test -e {} \; -print)
+[ -z "$broken" ] || fail "broken symlinks in export/$SITE_ID: $broken"
+ENTRY_COUNT=$(find "$EXPORT_DIR" \( -type f -o -type l \) | wc -l | tr -d ' ')
+pass "export/$SITE_ID OK ($ENTRY_COUNT entries, no broken symlinks)"
+
+step "Export --copy (resolved)"
+"$TEST_DIR/ddphotos" export --copy
+[ -d "$EXPORT_DIR" ]            || fail "export/$SITE_ID not created"
+[ -f "$EXPORT_DIR/index.html" ] || fail "export/$SITE_ID/index.html missing"
+symlinks=$(find "$EXPORT_DIR" -type l)
+[ -z "$symlinks" ] || fail "export --copy still has symlinks: $symlinks"
+FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
+pass "export --copy OK ($FILE_COUNT files, no symlinks)"
+
+# ── 8. Version ─────────────────────────────────────────────────────────────────
+step "Version"
+"$TEST_DIR/ddphotos" version
+"$TEST_DIR/ddphotos" version --image
+
+# ── 9. Init --script-only ──────────────────────────────────────────────────────
+step "Init --script-only"
+TEST_DIR2=$(mktemp -d)
+docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
+[ -x "$TEST_DIR2/ddphotos" ]   || fail "ddphotos script not installed"
+[ ! -d "$TEST_DIR2/config" ]   || fail "--script-only should not create config/"
+[ ! -d "$TEST_DIR2/albums" ]   || fail "--script-only should not create albums/"
+pass "init --script-only OK (only ddphotos script installed)"
+
+echo ""
+echo "=== All docker tests passed ==="

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -39,8 +39,17 @@ cleanup() {
     # Belt-and-suspenders: stop any containers using the local image still running on our ports
     docker ps --filter publish="$RUN_PORT"   -q | xargs docker stop &>/dev/null || true
     docker ps --filter publish="$SERVE_PORT" -q | xargs docker stop &>/dev/null || true
-    [ -n "$TEST_DIR"  ] && /bin/rm -rf "$TEST_DIR"
-    [ -n "$TEST_DIR2" ] && /bin/rm -rf "$TEST_DIR2"
+    # Docker creates root-owned files in TEST_DIRs; clear them via Docker before removing the dir
+    if [ -n "$TEST_DIR" ]; then
+        docker run --rm --entrypoint /bin/sh -v "$TEST_DIR":/target "$IMAGE" \
+            -c 'find /target -mindepth 1 -delete' 2>/dev/null || true
+        /bin/rm -rf "$TEST_DIR"
+    fi
+    if [ -n "$TEST_DIR2" ]; then
+        docker run --rm --entrypoint /bin/sh -v "$TEST_DIR2":/target "$IMAGE" \
+            -c 'find /target -mindepth 1 -delete' 2>/dev/null || true
+        /bin/rm -rf "$TEST_DIR2"
+    fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -123,7 +132,7 @@ step "Serve — Apache on port $SERVE_PORT"
 SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
 SERVE_PID=$!
 wait_for_http "http://localhost:$SERVE_PORT" "Apache"
-curl "http://localhost:$SERVE_PORT/albums/config.json"
+curl -s "http://localhost:$SERVE_PORT/albums/config.json" # sanity check before tests run
 "$SCRIPT_DIR/test-photos-server.sh" --local "$SERVE_PORT"
 run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -87,6 +87,7 @@ fi
 # ── 2. Init ────────────────────────────────────────────────────────────────────
 step "Init"
 TEST_DIR=$(mktemp -d)
+chmod 755 "$TEST_DIR"
 docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init
 [ -x "$TEST_DIR/ddphotos" ]              || fail "ddphotos script not installed"
 [ -f "$TEST_DIR/config/albums.yaml" ]    || fail "config/albums.yaml not created"
@@ -166,6 +167,7 @@ pass "version --image: Script path OK, Git: and Version: dev present"
 # ── 9. Init --script-only ──────────────────────────────────────────────────────
 step "Init --script-only"
 TEST_DIR2=$(mktemp -d)
+chmod 755 "$TEST_DIR2"
 docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ -x "$TEST_DIR2/ddphotos" ]   || fail "ddphotos script not installed"
 [ ! -d "$TEST_DIR2/config" ]   || fail "--script-only should not create config/"

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -150,8 +150,17 @@ pass "export --copy OK ($FILE_COUNT files, no symlinks)"
 
 # ── 8. Version ─────────────────────────────────────────────────────────────────
 step "Version"
-"$TEST_DIR/ddphotos" version
-"$TEST_DIR/ddphotos" version --image
+version_out=$("$TEST_DIR/ddphotos" version)
+echo "$version_out"
+echo "$version_out" | grep -qF "$TEST_DIR/ddphotos" || fail "version: Script path does not match $TEST_DIR/ddphotos"
+pass "version: Script path OK"
+
+version_image_out=$("$TEST_DIR/ddphotos" version --image)
+echo "$version_image_out"
+echo "$version_image_out" | grep -qF "$TEST_DIR/ddphotos" || fail "version --image: Script path does not match $TEST_DIR/ddphotos"
+echo "$version_image_out" | grep -q "Git:" || fail "version --image: missing Git: line"
+echo "$version_image_out" | grep -q "Version:.*dev" || fail "version --image: missing Version: dev"
+pass "version --image: Script path OK, Git: and Version: dev present"
 
 # ── 9. Init --script-only ──────────────────────────────────────────────────────
 step "Init --script-only"

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -183,5 +183,18 @@ docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ ! -d "$TEST_DIR2/albums" ]   || fail "--script-only should not create albums/"
 pass "init --script-only OK (only ddphotos script installed)"
 
+# ── 10. Skip ──────────────────────────────────────────────────────
+# Note: decided to skip tests for deploy (s3/rsync) due to complexity
+#       of setup.  S3 works (it is actively used by yours truly). I have faith
+#       in rsync code, but if someone reports problems we can revisit it.
+#       The existing rsync-test.sh could be repurposed, but the
+#       $RSYNC_RSH var isn't passed on to the container, not is the temp
+#       .ssh key.  The existing s3-test.sh could also be repurposed,
+#       but it assumes the sample site contents.
+#
+# Note: Likewise, not testing upgrade logic since it depends on prod
+#       images. I did test manually by editing the ddphotos script to
+#       verify the detection logic works.
+
 echo ""
 echo "=== All docker tests passed ==="

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -122,8 +122,9 @@ step "Serve — Apache on port $SERVE_PORT"
 SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
 SERVE_PID=$!
 wait_for_http "http://localhost:$SERVE_PORT" "Apache"
-run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
+curl "http://localhost:$SERVE_PORT/albums/config.json"
 "$SCRIPT_DIR/test-photos-server.sh" --local "$SERVE_PORT"
+run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
 pass "serve + Playwright + test-photos-server.sh OK"
 

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -6,9 +6,9 @@
 # Works against any web server (Apache or nginx).
 #
 # Usage:
-#   bin/test-photos-server.sh --local              # test local Docker on port 8080
-#   bin/test-photos-server.sh --local 9090         # test local Docker on port 9090
-#   bin/test-photos-server.sh --remote URL         # test a remote site at URL
+#   bin/test-photos-server.sh --local          # test local Docker on port 8080
+#   bin/test-photos-server.sh --local 9090     # test local Docker on port 9090
+#   bin/test-photos-server.sh --remote URL     # test a remote site at URL
 #
 # Note: In production, Apache is behind CloudFront, so:
 #   - Redirect locations use http:// (Apache sees HTTP from CloudFront)
@@ -25,7 +25,6 @@ SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 LOCAL=0
 PORT=8080
 REMOTE_URL=""
-CONFIG_DIR=""
 S3_MODE=0
 
 while [[ $# -gt 0 ]]; do
@@ -38,23 +37,12 @@ while [[ $# -gt 0 ]]; do
             fi
             shift
             ;;
-        --remote)       REMOTE_URL="$2"; shift 2 ;;
-        --remote=*)     REMOTE_URL="${1#*=}"; shift ;;
-        --config-dir)   CONFIG_DIR="$2"; shift 2 ;;
-        --config-dir=*) CONFIG_DIR="${1#*=}"; shift ;;
-        --s3)           S3_MODE=1; shift ;;
+        --remote)   REMOTE_URL="$2"; shift 2 ;;
+        --remote=*) REMOTE_URL="${1#*=}"; shift ;;
+        --s3)       S3_MODE=1; shift ;;
         *) shift ;;
     esac
 done
-
-if [ -n "$CONFIG_DIR" ]; then
-    CONFIG="$CONFIG_DIR/site.env"
-else
-    CONFIG="$SDIR/../config/site.env"
-fi
-[ -f "$CONFIG" ] || { echo "Error: $CONFIG not found"; exit 1; }
-echo "Loading environment variables from $CONFIG ..."
-source "$CONFIG"
 
 if [ "$LOCAL" -eq 1 ]; then
     BASE="http://localhost:$PORT"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,10 +21,12 @@ FROM node:${NODE_VERSION}-bookworm-slim AS node-builder
 
 WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
+
 # Strip debug symbols from node binary before copying to runtime image
 RUN apt-get update && apt-get install -y --no-install-recommends binutils \
     && strip /usr/local/bin/node \
     && rm -rf /var/lib/apt/lists/*
+
 # npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry;
 # install 11.13.0 directly from the registry tarball instead.
 RUN node -e "\
@@ -53,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Node binary from node-builder (avoids NodeSource apt install)
 COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+
 # Use a symlink so __dirname-relative paths in npm-cli.js resolve correctly
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,20 @@ FROM node:22-bookworm-slim AS node-builder
 
 WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
-RUN npm ci
+# Strip debug symbols from node binary before copying to runtime image
+RUN apt-get update && apt-get install -y --no-install-recommends binutils \
+    && strip /usr/local/bin/node \
+    && rm -rf /var/lib/apt/lists/*
+# npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry;
+# install 11.13.0 directly from the registry tarball instead.
+RUN node -e "\
+const https=require('https'),fs=require('fs');\
+function dl(u,cb){https.get(u,r=>{if(r.statusCode>=300&&r.statusCode<400)return dl(r.headers.location,cb);const f=fs.createWriteStream('/tmp/npm.tgz');r.pipe(f);f.on('finish',cb);});}\
+dl('https://registry.npmjs.org/npm/-/npm-11.13.0.tgz',()=>process.exit(0));" \
+    && tar -xz -C /tmp -f /tmp/npm.tgz \
+    && /bin/rm -rf /usr/local/lib/node_modules/npm \
+    && mv /tmp/package /usr/local/lib/node_modules/npm \
+    && npm ci
 
 # ── Stage 3: Runtime image ────────────────────────────────────────────────────
 FROM debian:bookworm-slim
@@ -28,23 +41,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvips \
     ca-certificates \
     curl \
-    unzip \
     apache2 \
     rsync \
     openssh-client \
+    python3 \
+    awscli \
     && rm -rf /var/lib/apt/lists/*
 
-# AWS CLI v2
-RUN ARCH=$(uname -m) \
-    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o /tmp/awscliv2.zip \
-    && unzip -q /tmp/awscliv2.zip -d /tmp \
-    && /tmp/aws/install \
-    && rm -rf /tmp/aws /tmp/awscliv2.zip
-
-# Node 22 via NodeSource
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+# Node 22 binary from node-builder (avoids NodeSource apt install)
+COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+# Use a symlink so __dirname-relative paths in npm-cli.js resolve correctly
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
 # Apache: enable mod_rewrite, replace default site with ddphotos config
 RUN a2enmod rewrite headers && a2dissite 000-default 2>/dev/null || true \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
 
+ARG NODE_VERSION=22
+
 # ── Stage 1: Build photogen (Go + libvips) ────────────────────────────────────
 FROM golang:1.25-bookworm AS go-builder
 
@@ -15,7 +17,7 @@ COPY pkg pkg/
 RUN CGO_ENABLED=1 go build -o /photogen ./cmd/photogen/photogen.go
 
 # ── Stage 2: Pre-install Node dependencies ────────────────────────────────────
-FROM node:22-bookworm-slim AS node-builder
+FROM node:${NODE_VERSION}-bookworm-slim AS node-builder
 
 WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
@@ -48,7 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     awscli \
     && rm -rf /var/lib/apt/lists/*
 
-# Node 22 binary from node-builder (avoids NodeSource apt install)
+# Node binary from node-builder (avoids NodeSource apt install)
 COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 # Use a symlink so __dirname-relative paths in npm-cli.js resolve correctly

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -13,12 +13,14 @@ mkdir -p "$STATE_DIR"
 # Parse --dir, --site-id, --config-dir, --site-env flags before the command
 OPT_CONFIG_DIR=""
 OPT_SITE_ENV=""
+NON_INTERACTIVE=false
 while [[ "${1:-}" == --?* ]]; do
     case "$1" in
         --dir) DDPHOTOS_DIR="$2"; shift 2 ;;
-        --site-id)    DDPHOTOS_SITE_ID="$2";    shift 2 ;;
-        --config-dir) OPT_CONFIG_DIR="$2";      shift 2 ;;
-        --site-env)   OPT_SITE_ENV="$2";        shift 2 ;;
+        --site-id)         DDPHOTOS_SITE_ID="$2"; shift 2 ;;
+        --config-dir)      OPT_CONFIG_DIR="$2";   shift 2 ;;
+        --site-env)        OPT_SITE_ENV="$2";     shift 2 ;;
+        --non-interactive) NON_INTERACTIVE=true;  shift ;;
         *)            break ;;
     esac
 done
@@ -145,6 +147,7 @@ check_for_update() {
 }
 
 SERVE_PORT="${SERVE_PORT:-8000}"
+IT_FLAGS=(); $NON_INTERACTIVE || IT_FLAGS=(-it)
 RUN_PORT="${RUN_PORT:-5173}"
 
 MOUNT_ARGS=()
@@ -216,7 +219,7 @@ case "$cmd" in
         ;;
     serve)
         print_mounts
-        docker run --rm -it \
+        docker run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e SERVE_PORT="$SERVE_PORT" \
             -v "$DDPHOTOS_DIR":/ddphotos \
@@ -226,7 +229,7 @@ case "$cmd" in
         ;;
     run)
         print_mounts
-        docker run --rm -it \
+        docker run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e RUN_PORT="$RUN_PORT" \
             -v "$DDPHOTOS_DIR":/ddphotos \

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -154,7 +154,7 @@ To build the DD Photos Docker `ddphotos` image for testing locally:
 make docker-build
 ```
 
-To quickly test it out:
+To quickly test it out manually:
 
 ```bash
 rm -rf /tmp/my-ddphotos && mkdir -p /tmp/my-ddphotos
@@ -170,6 +170,8 @@ To install `ddphotos` in `~/.localbin`:
 ```bash
 docker run --rm -v ~/.local/bin:/ddphotos ddphotos init --script-only
 ```
+
+See [Testing Docker](TESTING.md#testing-docker) for information on the full test suite.
 
 ## Docker Push
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -228,6 +228,7 @@ These flags go before the command name and apply to all commands that need them:
 | `--config-dir <path>` | Path to a config directory other than `<albums-dir>/config`                                           |
 | `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                        |
 | `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                          |
+| `--non-interactive`   | Run `serve` and `run` without a TTY (no `-it` flag) — useful for scripted/CI contexts                 |
 
 Example — using a separate source repo as the albums dir:
 

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -51,3 +51,4 @@ as defined in `config/defaults.env`.
 | `gen-deploy-tree`             | Regenerate `docs/deploy-tree.svg` (run after changing the deploy directory structure)         |
 | `docker-build`                | Build the `ddphotos` Docker image locally (single-arch)                                       |
 | `docker-push`                 | Build multi-arch image and push to Docker Hub (`bin/docker-push.sh`)                          |
+| `docker-test`                 | Build the `ddphotos` image and run end-to-end Docker workflow tests (`bin/docker-test.sh`)    |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -196,6 +196,33 @@ make sample-rsync-test
 make sample-s3-test
 ```
 
+## Testing Docker
+
+`bin/docker-test.sh` exercises the full `ddphotos` Docker workflow end-to-end —
+from `init` through `photogen`, `run`, `build`, `serve`, `export`, and `version` —
+using the built-in sample photos that ship with the image.
+
+```bash
+make docker-test              # build the ddphotos image and run all tests
+bin/docker-test.sh --no-build # skip image build (reuse existing ddphotos image)
+```
+
+The script runs the following steps in a fresh temp workspace:
+
+1. Builds the `ddphotos` Docker image via `make docker-build`
+2. Runs `init` and verifies the `ddphotos` script and config files are created
+3. Runs `photogen` on the bundled sample photos and verifies album output
+4. Starts the Vite dev server (`run`) and runs Playwright e2e tests against it
+5. Runs `build` and verifies the static site output
+6. Starts Apache (`serve`) and runs Playwright e2e tests + `bin/test-photos-server.sh` routing tests
+7. Tests `export` (symlink mode) and `export --copy` (all files resolved, no symlinks)
+8. Verifies `version` and `version --image` output — checks script path and image `Git:`/`Version:` fields
+9. Runs `init --script-only` and verifies only the script is installed (no `config/` or `albums/`)
+
+Playwright tests skip assertions that depend on sample-site-specific albums (e.g. `antarctica`) when
+those albums are not present in the init site, so the full test suite runs cleanly against the
+smaller built-in sample. The temp workspace is cleaned up automatically on exit.
+
 ## CI (GitHub Actions)
 
 The workflow in `.github/workflows/ci.yml` runs on every push or pull request to `main`. It:
@@ -209,6 +236,9 @@ The workflow in `.github/workflows/ci.yml` runs on every push or pull request to
 7. Runs `make web-docker-build-nginx sample-test-nginx` — builds the nginx Docker image and runs routing tests
 8. Runs `bin/test-all.sh --mode apache` — Playwright e2e tests across all password/CSS variants against Apache
 9. Runs `bin/test-all.sh --mode nginx` — Playwright e2e tests across all password/CSS variants against nginx
+10. Runs `make sample-rsync-test` — tests the rsync deploy path against a local Docker container
+11. Runs `make sample-s3-test` — tests the S3 deploy path against LocalStack
+12. Runs `make docker-test` — builds the `ddphotos` image and runs end-to-end Docker workflow tests
 
 ### Testing CI Locally with `act`
 

--- a/web/tests/back-nav.spec.ts
+++ b/web/tests/back-nav.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { waitForHydration, loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded } from './helpers';
+import { waitForHydration, loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded, albumExists } from './helpers';
 
 const pw = loadPasswords();
+
+let hasAntarctica = true;
+test.beforeAll(async ({ request }) => {
+	hasAntarctica = await albumExists(request, 'antarctica');
+});
 
 // Browser back/forward navigation tests for the lightbox.
 //
@@ -10,6 +15,7 @@ const pw = loadPasswords();
 // (e.g. the album list) or leave the lightbox hanging open.
 
 test('back button after opening photo closes lightbox and returns to album URL', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -25,6 +31,7 @@ test('back button after opening photo closes lightbox and returns to album URL',
 });
 
 test('back button after navigating photos in lightbox closes lightbox', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -43,6 +50,7 @@ test('back button after navigating photos in lightbox closes lightbox', async ({
 });
 
 test('back button after closing lightbox navigates to previous page', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/');
 	await unlockSiteIfNeeded(page, pw);
 	await page.locator('.album-card', { hasText: 'Antarctica' }).click();
@@ -64,6 +72,7 @@ test('back button after closing lightbox navigates to previous page', async ({ p
 });
 
 test('after reload and back, album photos render correctly', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -95,6 +104,7 @@ test('after reload and back, album photos render correctly', async ({ page }) =>
 });
 
 test('URL never shows /albums/undefined', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);

--- a/web/tests/back-to-top.spec.ts
+++ b/web/tests/back-to-top.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded } from './helpers';
+import { loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded, albumExists } from './helpers';
 
 const pw = loadPasswords();
+
+let hasAntarctica = true;
+test.beforeAll(async ({ request }) => {
+	hasAntarctica = await albumExists(request, 'antarctica');
+});
 
 const MOBILE = { width: 390, height: 844 };
 const DESKTOP = { width: 1280, height: 800 };
@@ -20,6 +25,7 @@ async function simulateScroll(page: any, y = 700) {
 
 // Album grid page: back-to-top should appear on both desktop and mobile
 test('album page: back-to-top appears after scrolling on desktop', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.setViewportSize(DESKTOP);
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
@@ -30,6 +36,7 @@ test('album page: back-to-top appears after scrolling on desktop', async ({ page
 });
 
 test('album page: back-to-top appears after scrolling on mobile', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.setViewportSize(MOBILE);
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);

--- a/web/tests/captions.spec.ts
+++ b/web/tests/captions.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { waitForHydration, loadPasswords, unlockAlbumIfNeeded } from './helpers';
+import { waitForHydration, loadPasswords, unlockAlbumIfNeeded, albumExists } from './helpers';
 
 const pw = loadPasswords();
+
+let hasAntarctica = true;
+test.beforeAll(async ({ request }) => {
+	hasAntarctica = await albumExists(request, 'antarctica');
+});
 
 // Caption tests verify the rendering mechanism works (rAF fix, animate=false fix),
 // not specific caption text — so they work against any site (sample or prod).
@@ -16,6 +21,7 @@ async function expectCaptionVisible(page: import('@playwright/test').Page) {
 }
 
 test('caption shows when clicking a photo from the grid (animate=true path)', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto(`/albums/${ALBUM}`);
 	await unlockAlbumIfNeeded(page, ALBUM, pw);
 	await waitForHydration(page);
@@ -30,6 +36,7 @@ test('caption shows when clicking a photo from the grid (animate=true path)', as
 });
 
 test('caption shows when loading a photo permalink directly (animate=false path)', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	// Direct URL open: onMount calls openLightbox(..., false) before the router
 	// is fully initialised — exercises the `if (animate) replaceState(...)` fix.
 	//
@@ -51,6 +58,7 @@ test('caption shows when loading a photo permalink directly (animate=false path)
 });
 
 test('caption updates when navigating to prev/next photo', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto(`/albums/${ALBUM}`);
 	await unlockAlbumIfNeeded(page, ALBUM, pw);
 	await waitForHydration(page);

--- a/web/tests/css.spec.ts
+++ b/web/tests/css.spec.ts
@@ -38,6 +38,7 @@ test('custom CSS applies border-radius to album cards', async ({ page }) => {
 
 test('custom CSS <link> is NOT present when CSS is not configured', async ({ page }) => {
 	test.skip(hasCustomCss, 'CSS is configured — skipping no-CSS check');
+	test.skip(!!process.env.PLAYWRIGHT_IGNORE_CUSTOM_CSS, 'CSS presence unknown — skipping');
 	await page.goto('/');
 	const link = page.locator('link[rel="stylesheet"][href*="custom.css"]');
 	await expect(link).toHaveCount(0);

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { type Page, type Locator } from '@playwright/test';
+import { type APIRequestContext, type Page, type Locator } from '@playwright/test';
 
 export interface Passwords {
 	all: string | null;
@@ -103,6 +103,36 @@ export async function unlockAlbumIfNeeded(
 	]).catch(() => 'timeout');
 	if (result !== 'locked') return;
 	await unlockAlbum(page, pw);
+}
+
+/**
+ * Check whether a specific album slug exists in albums.json.
+ * Fails open (returns true) on API error so tests surface real failures.
+ */
+export async function albumExists(request: APIRequestContext, slug: string): Promise<boolean> {
+	try {
+		const resp = await request.get('/albums/albums.json');
+		if (!resp.ok()) return true;
+		const albums: { slug: string }[] = await resp.json();
+		return albums.some((a) => a.slug === slug);
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Check whether the site has at least n albums that contain photos (count > 0).
+ * Fails open (returns true) on API error.
+ */
+export async function hasAtLeastNAlbums(request: APIRequestContext, n: number): Promise<boolean> {
+	try {
+		const resp = await request.get('/albums/albums.json');
+		if (!resp.ok()) return true;
+		const albums: { count: number }[] = await resp.json();
+		return albums.filter((a) => a.count > 0).length >= n;
+	} catch {
+		return true;
+	}
 }
 
 /**

--- a/web/tests/navigation.spec.ts
+++ b/web/tests/navigation.spec.ts
@@ -4,7 +4,8 @@ import {
 	loadPasswords,
 	unlockSiteIfNeeded,
 	unlockAlbumIfNeeded,
-	slugFromCard
+	slugFromCard,
+	hasAtLeastNAlbums
 } from './helpers';
 
 // Cross-album navigation tests — covers the $effect fix for stale imageSrcs.
@@ -18,6 +19,11 @@ import {
 // work against any site (sample, dev, or prod) without hardcoding album names.
 
 const pw = loadPasswords();
+
+let threeAlbums = true;
+test.beforeAll(async ({ request }) => {
+	threeAlbums = await hasAtLeastNAlbums(request, 3);
+});
 
 test('navigating from one album to another shows correct content', async ({ page }) => {
 	await page.goto('/');
@@ -74,6 +80,7 @@ test('lightbox works correctly after cross-album navigation', async ({ page }) =
 });
 
 test('navigating through multiple albums maintains correct state', async ({ page }) => {
+	test.skip(!threeAlbums, 'fewer than 3 albums');
 	await page.goto('/');
 	await unlockSiteIfNeeded(page, pw);
 

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -1,12 +1,18 @@
 import { test, expect } from '@playwright/test';
-import { loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded } from './helpers';
+import { loadPasswords, unlockSiteIfNeeded, unlockAlbumIfNeeded, albumExists } from './helpers';
 
 // Smoke tests — basic rendering checks that catch build/deploy regressions.
 // Albums checked here (Antarctica, Uganda) are present in both sample and prod.
 
 const pw = loadPasswords();
 
+let hasAntarctica = true;
+test.beforeAll(async ({ request }) => {
+	hasAntarctica = await albumExists(request, 'antarctica');
+});
+
 test('home page lists albums including known overlap albums', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/');
 	await unlockSiteIfNeeded(page, pw);
 	// Spot-check albums present in both sample and prod
@@ -15,6 +21,7 @@ test('home page lists albums including known overlap albums', async ({ page }) =
 });
 
 test('home page album cards show description', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/');
 	await unlockSiteIfNeeded(page, pw);
 	// Antarctica's description is stable across sample and prod
@@ -22,6 +29,7 @@ test('home page album cards show description', async ({ page }) => {
 });
 
 test('album page shows title, description, and photo count', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await expect(page.locator('h1')).toHaveText('Antarctica');
@@ -30,6 +38,7 @@ test('album page shows title, description, and photo count', async ({ page }) =>
 });
 
 test('album page renders photos in the grid', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	// At least one photo button should be present
@@ -37,6 +46,7 @@ test('album page renders photos in the grid', async ({ page }) => {
 });
 
 test('album page has correct Open Graph tags', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /^Antarctica/);
@@ -53,6 +63,7 @@ test('home page og:site_name matches siteName from config.json', async ({ page }
 });
 
 test('album page og:site_name matches siteName from config.json', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	const config = await page.request.get('/albums/config.json').then((r) => r.json());
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);

--- a/web/tests/url.spec.ts
+++ b/web/tests/url.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { waitForHydration, loadPasswords, unlockAlbumIfNeeded } from './helpers';
+import { waitForHydration, loadPasswords, unlockAlbumIfNeeded, albumExists } from './helpers';
 
 const pw = loadPasswords();
+
+let hasAntarctica = true;
+test.beforeAll(async ({ request }) => {
+	hasAntarctica = await albumExists(request, 'antarctica');
+});
 
 // URL management tests — covers the replaceState fixes:
 //  - history.replaceState was replaced with SvelteKit's replaceState from $app/navigation
@@ -10,6 +15,7 @@ const pw = loadPasswords();
 //    (animate=false) don't call replaceState before the router is initialised.
 
 test('opening a photo updates URL to permalink', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -19,6 +25,7 @@ test('opening a photo updates URL to permalink', async ({ page }) => {
 });
 
 test('navigating photos updates URL', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -31,6 +38,7 @@ test('navigating photos updates URL', async ({ page }) => {
 });
 
 test('closing lightbox restores album URL', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await waitForHydration(page);
@@ -44,6 +52,7 @@ test('closing lightbox restores album URL', async ({ page }) => {
 });
 
 test('loading a permalink URL opens the correct photo', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
 	// If the album is encrypted, unlock at the base URL first so the password is
 	// stored in localStorage. Then navigating to the permalink triggers tryDecryptAlbum
 	// in onMount, which auto-decrypts and opens the lightbox. (handleUnlock, called by


### PR DESCRIPTION
## Summary

This PR adds a Docker-based end-to-end test suite and ships several related improvements.

### Docker test suite (`bin/docker-test.sh`)
- New script that builds the Docker image, starts a container, runs Playwright tests against it, and tears down cleanly
- Handles temp directory setup/cleanup and correct permissions
- Includes explanatory notes on which test scenarios (deploy/upgrade) are skipped and why
- Wired into `make` and documented in `docs/TESTING.md` and `docs/DEV.md`

### Playwright test improvements
- Tests skip Antarctica-specific cases when that album is absent, making the suite portable across different data sets
- Tests skip gracefully when the required number of albums with photos is not present
- New `PLAYWRIGHT_IGNORE_CUSTOM_CSS` flag for the `ddphotos` init-site special case (custom CSS in use, but not expected)
- `--non-interactive` flag added to `ddphotos` for CI/testing usage
- `test-photos-server.sh`; no longer needs `--config-dir` or reading `site.env`

### Docker image optimizations
- Dockerfile restructured to produce a slimmer image
- `NODE_VERSION` synced between `Makefile`, `docker/Dockerfile`, and `bin/docker-push.sh` so there is one source of truth
- Minor Dockerfile spacing/clarity improvements- - 