### PR TITLE
ddphotos search-cover command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 See the [docs/](docs/) directory for full developer documentation (architecture, data flow, env vars,
 Makefile targets, CLI flags, etc.).
 
+## Directory structure sync requirement
+
+If the `albums/` or `build/` directory structure changes, keep these in sync:
+
+- `bin/deploy-photos.sh` — rsync and S3 logic
+- `web/setup-htdocs.sh` — sets up the Apache htdocs directory
+- `bin/gen-deploy-tree.py` — generates the directory tree image used in docs
+- `## Syncing Logic` section in `docs/DEPLOY.md`
+
 ## Type sync requirement
 
 The Go structs in `pkg/photogen/json.go` (`AlbumIndex`, `AlbumSummary`, `PhotoIndex`, `PhotoSrcIndex`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,11 @@ define the JSON schema consumed by the frontend. Their TypeScript counterparts l
 ## Commands
 
 ```bash
-make build test vet          # Go build, unit tests, static analysis
-make sample-build            # build static site with sample data
-make web-sanity-test         # Playwright e2e tests: Apache, no-passwords + all-passwords (quick comprehensive web check)
+make build test vet              # Go build, unit tests, static analysis
+make sample-build                # build static site with sample data
+make web-sanity-test             # Playwright e2e tests: Apache, no-passwords + all-passwords (quick comprehensive web check)
 make web-playwright-test-apache  # Playwright e2e tests, Apache, no-passwords only
+make docker-test                 # Test 'ddphotos' docker commands
 ```
 
 System dependency required: `brew install vips pkg-config`

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -146,7 +146,17 @@ decoded=$("$TEST_DIR/ddphotos" decode "$TEMP_DECODE_DIR/secret/index.enc.json")
 echo "$decoded" | grep -q '"photos"' || fail "decode (external pwFile): decoded output missing 'photos' key"
 pass "decode: both enc.json and pwFile outside DDPHOTOS_DIR OK"
 
-# ── 5. Run (Vite dev server) + Playwright ─────────────────────────────────────
+# ── 5. Search-Cover ────────────────────────────────────────────────────────────
+step "Search-Cover"
+# Derive the URL from the decoded index so we don't hardcode the UUID.
+SC_DECODED=$("$TEST_DIR/ddphotos" decode "$ENC_FILE")
+SC_GRID=$(echo "$SC_DECODED" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['photos'][0]['src']['grid'])")
+SC_URL="http://localhost:5173/albums/secret/$SC_GRID"
+SC_OUT=$("$TEST_DIR/ddphotos" search-cover "$SC_URL")
+echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover: 'cover: 2024-The-Way-21.jpg' not in output"
+pass "search-cover: found cover file for secret album"
+
+# ── 6. Run (Vite dev server) + Playwright ─────────────────────────────────────
 step "Run — Vite dev server on port $RUN_PORT"
 RUN_PORT="$RUN_PORT" "$TEST_DIR/ddphotos" --non-interactive run &
 RUN_PID=$!
@@ -155,13 +165,13 @@ run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
 kill "$RUN_PID" 2>/dev/null || true; wait "$RUN_PID" 2>/dev/null || true; RUN_PID=""
 pass "run + Playwright OK"
 
-# ── 6. Build ───────────────────────────────────────────────────────────────────
+# ── 7. Build ───────────────────────────────────────────────────────────────────
 step "Build"
 "$TEST_DIR/ddphotos" build
 [ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"
 pass "build/$SITE_ID created"
 
-# ── 7. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
+# ── 8. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
 step "Serve — Apache on port $SERVE_PORT"
 SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
 SERVE_PID=$!
@@ -172,7 +182,7 @@ run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
 pass "serve + Playwright + test-photos-server.sh OK"
 
-# ── 8. Export (symlink mode) ───────────────────────────────────────────────────
+# ── 9. Export (symlink mode) ───────────────────────────────────────────────────
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Export (symlinks)"
@@ -201,7 +211,7 @@ step "Export --cloudflare"
 grep -q "ASSETS.fetch" "$EXPORT_DIR/_worker.js" || fail "_worker.js missing ASSETS.fetch"
 pass "export --cloudflare OK (_worker.js present)"
 
-# ── 9. Version ─────────────────────────────────────────────────────────────────
+# ── 10. Version ────────────────────────────────────────────────────────────────
 step "Version"
 version_out=$("$TEST_DIR/ddphotos" version)
 echo "$version_out"
@@ -215,7 +225,7 @@ echo "$version_image_out" | grep -q "Git:" || fail "version --image: missing Git
 echo "$version_image_out" | grep -q "Version:.*dev" || fail "version --image: missing Version: dev"
 pass "version --image: Script path OK, Git: and Version: dev present"
 
-# ── 10. Init --script-only ─────────────────────────────────────────────────────
+# ── 11. Init --script-only ─────────────────────────────────────────────────────
 step "Init --script-only"
 TEST_DIR2=$(mktemp -d)
 chmod 755 "$TEST_DIR2"
@@ -225,7 +235,7 @@ docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ ! -d "$TEST_DIR2/albums" ]   || fail "--script-only should not create albums/"
 pass "init --script-only OK (only ddphotos script installed)"
 
-# ── 11. Skip ──────────────────────────────────────────────────────
+# ── 12. Skip ──────────────────────────────────────────────────────
 # Note: decided to skip tests for deploy (s3/rsync) due to complexity
 #       of setup.  S3 works (it is actively used by yours truly). I have faith
 #       in rsync code, but if someone reports problems we can revisit it.

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -17,6 +17,7 @@ DO_BUILD=true
 TEST_DIR=""
 TEST_DIR2=""
 TEMP_DECODE_DIR=""
+EXT_CONFIG_DIR=""
 RUN_PID=""
 SERVE_PID=""
 
@@ -52,6 +53,7 @@ cleanup() {
         /bin/rm -rf "$TEST_DIR2"
     fi
     if [ -n "$TEMP_DECODE_DIR" ]; then /bin/rm -rf "$TEMP_DECODE_DIR"; fi
+    if [ -n "$EXT_CONFIG_DIR" ]; then /bin/rm -rf "$EXT_CONFIG_DIR";   fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -156,7 +158,34 @@ SC_OUT=$("$TEST_DIR/ddphotos" search-cover "$SC_URL")
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover: found cover file for secret album"
 
-# ── 6. Run (Vite dev server) + Playwright ─────────────────────────────────────
+# ── 6. Decode + Search-Cover with external --config-dir ───────────────────────
+# Regression test for: decode and search-cover failing to mount the config dir
+# when --config-dir points outside DDPHOTOS_DIR.
+#
+# Simulates photogen having been run with an external --config-dir by rewriting
+# the embedded pwFile path from /ddphotos/config/... to /ddphotos-config/...
+# (the container path used when --config-dir is outside DDPHOTOS_DIR).
+step "Decode + Search-Cover with external --config-dir"
+EXT_CONFIG_DIR=$(mktemp -d)
+/bin/cp "$TEST_DIR/config/passwords.yaml" "$EXT_CONFIG_DIR/"
+
+# Create modified enc.json (inside DDPHOTOS_DIR so decode path translation works)
+EXT_ENC_RELPATH="albums/$SITE_ID/secret/index-extconfig.enc.json"
+sed 's|"pwFile":"/ddphotos/config/passwords.yaml"|"pwFile":"/ddphotos-config/passwords.yaml"|' \
+    "$TEST_DIR/$ENC_FILE" > "$TEST_DIR/$EXT_ENC_RELPATH"
+
+decoded=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" decode "$EXT_ENC_RELPATH")
+echo "$decoded" | grep -q '"photos"' || fail "decode --config-dir: decoded output missing 'photos' key"
+pass "decode --config-dir: external config dir mounted correctly"
+
+# Replace the album enc.json with the modified version so search-cover decodes
+# it using /ddphotos-config/passwords.yaml, then reuse SC_URL from step 5.
+/bin/cp "$TEST_DIR/$EXT_ENC_RELPATH" "$TEST_DIR/$ENC_FILE"
+SC_OUT=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" search-cover "$SC_URL")
+echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover --config-dir: 'cover: 2024-The-Way-21.jpg' not in output"
+pass "search-cover --config-dir: external config dir mounted correctly"
+
+# ── 7. Run (Vite dev server) + Playwright ─────────────────────────────────────
 step "Run — Vite dev server on port $RUN_PORT"
 RUN_PORT="$RUN_PORT" "$TEST_DIR/ddphotos" --non-interactive run &
 RUN_PID=$!
@@ -165,13 +194,13 @@ run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
 kill "$RUN_PID" 2>/dev/null || true; wait "$RUN_PID" 2>/dev/null || true; RUN_PID=""
 pass "run + Playwright OK"
 
-# ── 7. Build ───────────────────────────────────────────────────────────────────
+# ── 8. Build ───────────────────────────────────────────────────────────────────
 step "Build"
 "$TEST_DIR/ddphotos" build
 [ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"
 pass "build/$SITE_ID created"
 
-# ── 8. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
+# ── 9. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
 step "Serve — Apache on port $SERVE_PORT"
 SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
 SERVE_PID=$!
@@ -182,7 +211,7 @@ run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
 pass "serve + Playwright + test-photos-server.sh OK"
 
-# ── 9. Export (symlink mode) ───────────────────────────────────────────────────
+# ── 10. Export (symlink mode) ──────────────────────────────────────────────────
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Export (symlinks)"
@@ -211,7 +240,7 @@ step "Export --cloudflare"
 grep -q "ASSETS.fetch" "$EXPORT_DIR/_worker.js" || fail "_worker.js missing ASSETS.fetch"
 pass "export --cloudflare OK (_worker.js present)"
 
-# ── 10. Version ────────────────────────────────────────────────────────────────
+# ── 11. Version ────────────────────────────────────────────────────────────────
 step "Version"
 version_out=$("$TEST_DIR/ddphotos" version)
 echo "$version_out"
@@ -225,7 +254,7 @@ echo "$version_image_out" | grep -q "Git:" || fail "version --image: missing Git
 echo "$version_image_out" | grep -q "Version:.*dev" || fail "version --image: missing Version: dev"
 pass "version --image: Script path OK, Git: and Version: dev present"
 
-# ── 11. Init --script-only ─────────────────────────────────────────────────────
+# ── 12. Init --script-only ─────────────────────────────────────────────────────
 step "Init --script-only"
 TEST_DIR2=$(mktemp -d)
 chmod 755 "$TEST_DIR2"
@@ -235,7 +264,7 @@ docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ ! -d "$TEST_DIR2/albums" ]   || fail "--script-only should not create albums/"
 pass "init --script-only OK (only ddphotos script installed)"
 
-# ── 12. Skip ──────────────────────────────────────────────────────
+# ── 13. Skip ──────────────────────────────────────────────────────
 # Note: decided to skip tests for deploy (s3/rsync) due to complexity
 #       of setup.  S3 works (it is actively used by yours truly). I have faith
 #       in rsync code, but if someone reports problems we can revisit it.

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -18,6 +18,7 @@ TEST_DIR=""
 TEST_DIR2=""
 TEMP_DECODE_DIR=""
 EXT_CONFIG_DIR=""
+SC_TEST_DIR=""
 RUN_PID=""
 SERVE_PID=""
 
@@ -41,6 +42,19 @@ cleanup() {
     # Belt-and-suspenders: stop any containers using the local image still running on our ports
     docker ps --filter publish="$RUN_PORT"   -q | xargs docker stop &>/dev/null || true
     docker ps --filter publish="$SERVE_PORT" -q | xargs docker stop &>/dev/null || true
+    # !! IMPORTANT: Docker containers run as root, so any files/dirs they create inside a
+    # !! mounted volume (e.g. TEST_DIR/albums/, TEST_DIR/build/) are root-owned with 700
+    # !! permissions — unreadable and unwritable from the host. This has bitten us 3-4 times.
+    # !!
+    # !! On Mac, Docker's VM layer masks this (writes may appear to succeed locally), but CI
+    # !! runs on Linux where host and container share the real filesystem — failures are real.
+    # !! Always write tests to pass on Linux / CI, not just on Mac.
+    # !!
+    # !! Rules to avoid it:
+    # !!   1. Never write test files into subdirs that Docker created (e.g. TEST_DIR/albums/...).
+    # !!   2. For test fixtures, use TEMP_DECODE_DIR or a fresh mktemp -d (user-owned).
+    # !!   3. If you need Docker output in a specific dir layout, copy it there after the fact.
+    # !!   4. Cleanup below must use Docker to remove root-owned files before /bin/rm -rf works.
     # Docker creates root-owned files in TEST_DIRs; clear them via Docker before removing the dir
     if [ -n "$TEST_DIR" ]; then
         docker run --rm --entrypoint /bin/sh -v "$TEST_DIR":/target "$IMAGE" \
@@ -53,7 +67,8 @@ cleanup() {
         /bin/rm -rf "$TEST_DIR2"
     fi
     if [ -n "$TEMP_DECODE_DIR" ]; then /bin/rm -rf "$TEMP_DECODE_DIR"; fi
-    if [ -n "$EXT_CONFIG_DIR" ]; then /bin/rm -rf "$EXT_CONFIG_DIR";   fi
+    if [ -n "$EXT_CONFIG_DIR" ]; then /bin/rm -rf "$EXT_CONFIG_DIR"; fi
+    if [ -n "$SC_TEST_DIR" ];   then /bin/rm -rf "$SC_TEST_DIR";   fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -166,22 +181,29 @@ pass "search-cover: found cover file for secret album"
 # the embedded pwFile path from /ddphotos/config/... to /ddphotos-config/...
 # (the container path used when --config-dir is outside DDPHOTOS_DIR).
 step "Decode + Search-Cover with external --config-dir"
+
+# Simulate photogen having been run with an external --config-dir by rewriting
+# the embedded pwFile path from /ddphotos/config/... to /ddphotos-config/...
 EXT_CONFIG_DIR=$(mktemp -d)
 /bin/cp "$TEST_DIR/config/passwords.yaml" "$EXT_CONFIG_DIR/"
 
-# Create modified enc.json (inside DDPHOTOS_DIR so decode path translation works)
-EXT_ENC_RELPATH="albums/$SITE_ID/secret/index-extconfig.enc.json"
+# Write the modified enc.json to TEMP_DECODE_DIR (user-owned) — the album
+# directory inside TEST_DIR is root-owned (created by Docker) and unwritable.
+EXT_ENC_FILE="$TEMP_DECODE_DIR/secret/index-extconfig.enc.json"
 sed 's|"pwFile":"/ddphotos/config/passwords.yaml"|"pwFile":"/ddphotos-config/passwords.yaml"|' \
-    "$TEST_DIR/$ENC_FILE" > "$TEST_DIR/$EXT_ENC_RELPATH"
+    "$TEST_DIR/$ENC_FILE" > "$EXT_ENC_FILE"
 
-decoded=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" decode "$EXT_ENC_RELPATH")
+decoded=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" decode "$EXT_ENC_FILE")
 echo "$decoded" | grep -q '"photos"' || fail "decode --config-dir: decoded output missing 'photos' key"
 pass "decode --config-dir: external config dir mounted correctly"
 
-# Replace the album enc.json with the modified version so search-cover decodes
-# it using /ddphotos-config/passwords.yaml, then reuse SC_URL from step 5.
-/bin/cp "$TEST_DIR/$EXT_ENC_RELPATH" "$TEST_DIR/$ENC_FILE"
-SC_OUT=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" search-cover "$SC_URL")
+# search-cover needs the modified enc.json at the album path. Use a fresh
+# user-owned SC_TEST_DIR with --dir so we can write to it freely.
+SC_TEST_DIR=$(mktemp -d)
+chmod 755 "$SC_TEST_DIR"
+mkdir -p "$SC_TEST_DIR/albums/$SITE_ID/secret"
+/bin/cp "$EXT_ENC_FILE" "$SC_TEST_DIR/albums/$SITE_ID/secret/index.enc.json"
+SC_OUT=$("$TEST_DIR/ddphotos" --dir "$SC_TEST_DIR" --config-dir "$EXT_CONFIG_DIR" search-cover "$SC_URL")
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover --config-dir: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover --config-dir: external config dir mounted correctly"
 

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -124,11 +124,13 @@ docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init
 [ -f "$TEST_DIR/config/passwords.yaml" ] || fail "config/passwords.yaml not created"
 pass "ddphotos script and config created at $TEST_DIR"
 
+DDPHOTOS=("$TEST_DIR/ddphotos" --show-mounts)
+DDPHOTOS_QUIET=("$TEST_DIR/ddphotos")
 PASSWORDS_FILE="$TEST_DIR/config/passwords.yaml"
 
 # ── 3. Photogen ────────────────────────────────────────────────────────────────
 step "Photogen"
-"$TEST_DIR/ddphotos" photogen
+"${DDPHOTOS[@]}" photogen
 [ -d "$TEST_DIR/albums/$SITE_ID" ] || fail "albums/$SITE_ID not created"
 ALBUM_COUNT=$(find "$TEST_DIR/albums/$SITE_ID" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
 pass "albums/$SITE_ID created ($ALBUM_COUNT albums)"
@@ -137,7 +139,7 @@ pass "albums/$SITE_ID created ($ALBUM_COUNT albums)"
 step "Decode"
 ENC_FILE="albums/$SITE_ID/secret/index.enc.json"
 [ -f "$TEST_DIR/$ENC_FILE" ] || fail "$ENC_FILE not found after photogen"
-decoded=$("$TEST_DIR/ddphotos" decode "$ENC_FILE")
+decoded=$("${DDPHOTOS[@]}" decode "$ENC_FILE")
 echo "$decoded" | grep -q '"photos"' || fail "decoded output missing 'photos' key"
 pass "decode: $ENC_FILE decrypted OK"
 
@@ -151,7 +153,7 @@ mkdir -p "$TEMP_DECODE_DIR/secret"
 /bin/cp "$TEST_DIR/$ENC_FILE"              "$TEMP_DECODE_DIR/secret/index.enc.json"
 
 # (a) explicit --passwords pointing outside DDPHOTOS_DIR
-decoded=$("$TEST_DIR/ddphotos" decode --passwords "$TEMP_DECODE_DIR/passwords.yaml" "$TEMP_DECODE_DIR/secret/index.enc.json")
+decoded=$("${DDPHOTOS[@]}" decode --passwords "$TEMP_DECODE_DIR/passwords.yaml" "$TEMP_DECODE_DIR/secret/index.enc.json")
 echo "$decoded" | grep -q '"photos"' || fail "decode --passwords (external): decoded output missing 'photos' key"
 pass "decode --passwords: files outside DDPHOTOS_DIR OK"
 
@@ -159,17 +161,17 @@ pass "decode --passwords: files outside DDPHOTOS_DIR OK"
 sed "s|\"pwFile\":\"[^\"]*\"|\"pwFile\":\"$TEMP_DECODE_DIR/passwords.yaml\"|" \
     "$TEMP_DECODE_DIR/secret/index.enc.json" > "$TEMP_DECODE_DIR/secret/index.enc.json.tmp"
 mv "$TEMP_DECODE_DIR/secret/index.enc.json.tmp" "$TEMP_DECODE_DIR/secret/index.enc.json"
-decoded=$("$TEST_DIR/ddphotos" decode "$TEMP_DECODE_DIR/secret/index.enc.json")
+decoded=$("${DDPHOTOS[@]}" decode "$TEMP_DECODE_DIR/secret/index.enc.json")
 echo "$decoded" | grep -q '"photos"' || fail "decode (external pwFile): decoded output missing 'photos' key"
 pass "decode: both enc.json and pwFile outside DDPHOTOS_DIR OK"
 
 # ── 5. Search-Cover ────────────────────────────────────────────────────────────
 step "Search-Cover"
 # Derive the URL from the decoded index so we don't hardcode the UUID.
-SC_DECODED=$("$TEST_DIR/ddphotos" decode "$ENC_FILE")
+SC_DECODED=$("${DDPHOTOS_QUIET[@]}" decode "$ENC_FILE")
 SC_GRID=$(echo "$SC_DECODED" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['photos'][0]['src']['grid'])")
 SC_URL="http://localhost:5173/albums/secret/$SC_GRID"
-SC_OUT=$("$TEST_DIR/ddphotos" search-cover "$SC_URL")
+SC_OUT=$("${DDPHOTOS[@]}" search-cover "$SC_URL")
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover: found cover file for secret album"
 
@@ -193,7 +195,7 @@ EXT_ENC_FILE="$TEMP_DECODE_DIR/secret/index-extconfig.enc.json"
 sed 's|"pwFile":"/ddphotos/config/passwords.yaml"|"pwFile":"/ddphotos-config/passwords.yaml"|' \
     "$TEST_DIR/$ENC_FILE" > "$EXT_ENC_FILE"
 
-decoded=$("$TEST_DIR/ddphotos" --config-dir "$EXT_CONFIG_DIR" decode "$EXT_ENC_FILE")
+decoded=$("${DDPHOTOS[@]}" --config-dir "$EXT_CONFIG_DIR" decode "$EXT_ENC_FILE")
 echo "$decoded" | grep -q '"photos"' || fail "decode --config-dir: decoded output missing 'photos' key"
 pass "decode --config-dir: external config dir mounted correctly"
 
@@ -203,13 +205,13 @@ SC_TEST_DIR=$(mktemp -d)
 chmod 755 "$SC_TEST_DIR"
 mkdir -p "$SC_TEST_DIR/albums/$SITE_ID/secret"
 /bin/cp "$EXT_ENC_FILE" "$SC_TEST_DIR/albums/$SITE_ID/secret/index.enc.json"
-SC_OUT=$("$TEST_DIR/ddphotos" --dir "$SC_TEST_DIR" --config-dir "$EXT_CONFIG_DIR" search-cover "$SC_URL")
+SC_OUT=$("${DDPHOTOS[@]}" --dir "$SC_TEST_DIR" --config-dir "$EXT_CONFIG_DIR" search-cover "$SC_URL")
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover --config-dir: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover --config-dir: external config dir mounted correctly"
 
 # ── 7. Run (Vite dev server) + Playwright ─────────────────────────────────────
 step "Run — Vite dev server on port $RUN_PORT"
-RUN_PORT="$RUN_PORT" "$TEST_DIR/ddphotos" --non-interactive run &
+RUN_PORT="$RUN_PORT" "${DDPHOTOS[@]}" --non-interactive run &
 RUN_PID=$!
 wait_for_http "http://localhost:$RUN_PORT" "Vite dev server"
 run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
@@ -218,13 +220,13 @@ pass "run + Playwright OK"
 
 # ── 8. Build ───────────────────────────────────────────────────────────────────
 step "Build"
-"$TEST_DIR/ddphotos" build
+"${DDPHOTOS[@]}" build
 [ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"
 pass "build/$SITE_ID created"
 
 # ── 9. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
 step "Serve — Apache on port $SERVE_PORT"
-SERVE_PORT="$SERVE_PORT" "$TEST_DIR/ddphotos" --non-interactive serve &
+SERVE_PORT="$SERVE_PORT" "${DDPHOTOS[@]}" --non-interactive serve &
 SERVE_PID=$!
 wait_for_http "http://localhost:$SERVE_PORT" "Apache"
 curl -s "http://localhost:$SERVE_PORT/albums/config.json" # sanity check before tests run
@@ -237,7 +239,7 @@ pass "serve + Playwright + test-photos-server.sh OK"
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Export (symlinks)"
-"$TEST_DIR/ddphotos" export
+"${DDPHOTOS[@]}" export
 [ -d "$EXPORT_DIR" ]            || fail "export /$SITE_ID not created"
 [ -f "$EXPORT_DIR/index.html" ] || fail "export/$SITE_ID/index.html missing"
 broken=$(find "$EXPORT_DIR" -type l ! -exec test -e {} \; -print)
@@ -246,7 +248,7 @@ ENTRY_COUNT=$(find "$EXPORT_DIR" \( -type f -o -type l \) | wc -l | tr -d ' ')
 pass "export/$SITE_ID OK ($ENTRY_COUNT entries, no broken symlinks)"
 
 step "Export --copy (resolved)"
-"$TEST_DIR/ddphotos" export --copy
+"${DDPHOTOS[@]}" export --copy
 [ -d "$EXPORT_DIR" ]            || fail "export/$SITE_ID not created"
 [ -f "$EXPORT_DIR/index.html" ] || fail "export/$SITE_ID/index.html missing"
 symlinks=$(find "$EXPORT_DIR" -type l)
@@ -255,7 +257,7 @@ FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
 pass "export --copy OK ($FILE_COUNT files, no symlinks)"
 
 step "Export --cloudflare"
-"$TEST_DIR/ddphotos" export --cloudflare
+"${DDPHOTOS[@]}" export --cloudflare
 [ -d "$EXPORT_DIR" ]                || fail "export/$SITE_ID not created"
 [ -f "$EXPORT_DIR/index.html" ]     || fail "export/$SITE_ID/index.html missing"
 [ -f "$EXPORT_DIR/_worker.js" ]     || fail "export/$SITE_ID/_worker.js missing"
@@ -264,12 +266,12 @@ pass "export --cloudflare OK (_worker.js present)"
 
 # ── 11. Version ────────────────────────────────────────────────────────────────
 step "Version"
-version_out=$("$TEST_DIR/ddphotos" version)
+version_out=$("${DDPHOTOS[@]}" version)
 echo "$version_out"
 echo "$version_out" | grep -qF "$TEST_DIR/ddphotos" || fail "version: Script path does not match $TEST_DIR/ddphotos"
 pass "version: Script path OK"
 
-version_image_out=$("$TEST_DIR/ddphotos" version --image)
+version_image_out=$("${DDPHOTOS[@]}" version --image)
 echo "$version_image_out"
 echo "$version_image_out" | grep -qF "$TEST_DIR/ddphotos" || fail "version --image: Script path does not match $TEST_DIR/ddphotos"
 echo "$version_image_out" | grep -q "Git:" || fail "version --image: missing Git: line"

--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -70,7 +70,6 @@ if [[ -z "$index_file" ]]; then
     exit 1
 fi
 
-echo ""
 echo "Searching..."
 echo "  Album:  $slug"
 echo "  Index:  $index_file"

--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -2,17 +2,23 @@
 # Find the fileName for a photo given its URL.
 #
 # Usage:
-#   bin/search_cover.sh <url>
+#   bin/search-cover.sh [--from-docker] <url>
 #
 # Example:
-#   bin/search_cover.sh http://localhost:5173/albums/banff-2002/full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+#   bin/search-cover.sh http://localhost:5173/albums/banff-2002/full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
 #
 # Respects DDPHOTOS_ALBUMS_DIR and DDPHOTOS_SITE_ID (falls back to config/defaults.env).
 
 set -eo pipefail
 
+FROM_DOCKER=false
+if [[ "${1:-}" == "--from-docker" ]]; then
+    FROM_DOCKER=true
+    shift
+fi
+
 if [[ $# -ne 1 ]]; then
-    echo "Usage: bin/search_cover.sh <url>" >&2
+    echo "Usage: bin/search_cover.sh [--from-docker] <url>" >&2
     exit 1
 fi
 
@@ -56,17 +62,28 @@ index_file=$(find "$SEARCH_ROOT" -maxdepth 2 -type f \( -name "index.enc.json" -
 
 if [[ -z "$index_file" ]]; then
     echo "No index file found for album slug '$slug' under $SEARCH_ROOT" >&2
-    echo "Try another site with DDPHOTOS_SITE_ID=<site-id> search_cover.sh $url" >&2
+    if $FROM_DOCKER; then
+        echo "Try another site with: ddphotos --site-id <site-id> search-cover $url" >&2
+    else
+        echo "Try another site with: DDPHOTOS_SITE_ID=<site-id> bin/search_cover.sh $url" >&2
+    fi
     exit 1
 fi
 
-echo "Album:  $slug"
-echo "Index:  $index_file"
-echo "src:    $src_path"
+echo ""
+echo "Searching..."
+echo "  Album:  $slug"
+echo "  Index:  $index_file"
+echo "  Source: $src_path"
 echo ""
 
 # Decode (handles both encrypted and plain JSON) and search for the src path
-decoded=$(go run cmd/decode/decode.go "$index_file" 2>/dev/null || cat "$index_file")
+if $FROM_DOCKER; then
+    DECODE_CMD="/usr/local/bin/decode"
+else
+    DECODE_CMD="$SDIR/decode"
+fi
+decoded=$("$DECODE_CMD" "$index_file" 2>/dev/null || cat "$index_file")
 
 # Extract the fileName for the matching src path (matches full or grid)
 echo "$decoded" | python3 -c "
@@ -77,12 +94,17 @@ src = sys.argv[1]
 for p in photos:
     srcs = p.get('src', {})
     if srcs.get('full') == src or srcs.get('grid') == src:
-        print('fileName: ' + p.get('fileName', ''))
-        print('id:       ' + p.get('id', ''))
+        print('Found:')
+        print('  id:         ' + p.get('id', ''))
         sp = p.get('sourcePath', '')
         if sp:
-            print('sourcePath: ' + sp)
+            print('  sourcePath: ' + sp)
+        print('  fileName:   ' + p.get('fileName', '') + '')
+        print('')
+        print('Use for cover:')
+        print('  cover: ' + p.get('fileName', ''))
+        print('')
         sys.exit(0)
-print('src path not found in index', file=sys.stderr)
+print('WARN: ' + src + ' not found in index', file=sys.stderr)
 sys.exit(1)
 " "$src_path"

--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -18,7 +18,7 @@ if [[ "${1:-}" == "--from-docker" ]]; then
 fi
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: bin/search_cover.sh [--from-docker] <url>" >&2
+    echo "Usage: bin/search-cover.sh [--from-docker] <url>" >&2
     exit 1
 fi
 
@@ -65,7 +65,7 @@ if [[ -z "$index_file" ]]; then
     if $FROM_DOCKER; then
         echo "Try another site with: ddphotos --site-id <site-id> search-cover $url" >&2
     else
-        echo "Try another site with: DDPHOTOS_SITE_ID=<site-id> bin/search_cover.sh $url" >&2
+        echo "Try another site with: DDPHOTOS_SITE_ID=<site-id> bin/search-cover.sh $url" >&2
     fi
     exit 1
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,9 +77,13 @@ COPY --from=node-builder /app/web/node_modules /app/web/node_modules
 # Docker scripts
 COPY docker/entrypoint.sh docker/do-init.sh docker/do-photogen.sh \
      docker/do-build.sh docker/do-serve.sh docker/do-run.sh docker/do-export.sh docker/do-deploy.sh \
-     docker/do-decode.sh docker/ddphotos docker/cloudflare-worker.js \
+     docker/do-decode.sh docker/do-search-cover.sh docker/ddphotos docker/cloudflare-worker.js \
      web/setup-htdocs.sh bin/deploy-photos.sh bin/test-photos-server.sh /docker/
 RUN chmod +x /docker/*.sh
+
+# search-cover.sh lives under /app/bin so do-search-cover.sh can call it
+COPY bin/search_cover.sh /app/bin/search_cover.sh
+RUN chmod +x /app/bin/search-cover.sh
 
 # Init templates and placeholder album directory
 COPY docker/init/ /docker/init/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ COPY docker/entrypoint.sh docker/do-init.sh docker/do-photogen.sh \
 RUN chmod +x /docker/*.sh
 
 # search-cover.sh lives under /app/bin so do-search-cover.sh can call it
-COPY bin/search_cover.sh /app/bin/search_cover.sh
+COPY bin/search-cover.sh /app/bin/search-cover.sh
 RUN chmod +x /app/bin/search-cover.sh
 
 # Init templates and placeholder album directory

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -184,7 +184,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version|decode) ;;
+    init|upgrade|help|version|decode|search-cover) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
@@ -267,6 +267,17 @@ case "$cmd" in
             "${SCRIPT_MOUNT[@]}" \
             "${DECODE_MOUNTS[@]}" \
             "$IMAGE" decode "${PW_ARGS[@]}" "$ENC_CONTAINER"
+        ;;
+    search-cover)
+        if [[ $# -ne 1 ]]; then
+            echo "Usage: ddphotos [OPTIONS] search-cover <url>" >&2
+            exit 1
+        fi
+        docker run --rm \
+            -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
+            -v "$DDPHOTOS_DIR":/ddphotos \
+            "${SCRIPT_MOUNT[@]}" \
+            "$IMAGE" search-cover "$@"
         ;;
     photogen)
         if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
@@ -377,7 +388,7 @@ case "$cmd" in
         echo "State dir:      $STATE_DIR"
         ;;
     *)
-        echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|build|serve|run|export|deploy|upgrade} [args]"
+        echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|search-cover|build|serve|run|export|deploy|upgrade} [args]"
         echo ""
         echo "Options (before command):"
         echo "  --dir DIR         Directory to mount as /ddphotos (default: script location)"
@@ -386,20 +397,22 @@ case "$cmd" in
         echo "  --site-env FILE   Path to site.env for deploy (default: config-dir/site.env)"
         echo ""
         echo "Commands:"
-        echo "  init      Initialize config scaffold (use --script-only to just install 'ddphotos')"
-        echo "  photogen  Process source photos into albums output"
-        echo "  decode    Decrypt an .enc.json file and print the contents"
-        echo "            --passwords FILE  use this passwords file instead of the embedded path"
-        echo "  build     Build the static site"
-        echo "  serve     Preview the site via Apache on port \$SERVE_PORT (default 8000)"
-        echo "  run       Preview the site via Vite dev server on port \$RUN_PORT (default 5173)"
-        echo "  export    Export site to export/<site-id>/ for local serving or static hosting"
-        echo "            --copy        Resolve symlinks (required for static hosting)"
-        echo "            --cloudflare  Adds _worker.js for Cloudflare Pages photo permalinks"
-        echo "  deploy    Deploy build and albums to remote host"
-        echo "  upgrade   Update this script to match the current 'ddphotos' image"
-        echo "  version           Print script location, image, and config paths (no Docker required)"
-        echo "  version --image   Also query the image for its version and git info"
+        echo "  init                Initialize config scaffold"
+        echo "                        --script-only  Just install 'ddphotos' script"
+        echo "  photogen            Process source photos into albums output"
+        echo "  decode [filename]   Decrypt an .enc.json file and print the contents"
+        echo "                        --passwords [filename]  Use this passwords file instead of the embedded path"
+        echo "  search-cover [url]  Find the original filename for a photo URL"
+        echo "  build               Build the static site"
+        echo "  serve               Preview the site via Apache on port \$SERVE_PORT (default 8000)"
+        echo "  run                 Preview the site via Vite dev server on port \$RUN_PORT (default 5173)"
+        echo "  export              Export site to export/<site-id>/ for local serving or static hosting"
+        echo "                        --copy        Resolve symlinks (required for static hosting)"
+        echo "                        --cloudflare  Adds _worker.js for Cloudflare Pages photo permalinks"
+        echo "  deploy              Deploy build and albums to remote host"
+        echo "  upgrade             Update this script to match the current 'ddphotos' image"
+        echo "  version             Print script location, image, and config paths (no Docker required)"
+        echo "                        --image  Also query the image for its version and git info"
         echo ""
         echo "Tip: pass -- to photogen for full flag control:"
         echo "  ddphotos photogen -- -hero-only"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -56,8 +56,8 @@ if [ -n "$OPT_CONFIG_DIR" ]; then
     if [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR"/* ]] || [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR" ]]; then
         DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#"$DDPHOTOS_DIR"}"
     else
-        EXTRA_MOUNT_ARGS+=(-v "$CONFIG_HOST_DIR":/ddphotos-config:ro)
         DDPHOTOS_CONFIG_DIR="/ddphotos-config"
+        EXTRA_MOUNT_ARGS+=(-v "$CONFIG_HOST_DIR":"$DDPHOTOS_CONFIG_DIR":ro)
         CONFIG_DIR_EXTRA_SRC="$CONFIG_HOST_DIR"
     fi
 fi
@@ -231,7 +231,11 @@ case "$cmd" in
             exit 1
         fi
 
-        DECODE_MOUNTS=()
+        DECODE_MOUNTS=("${EXTRA_MOUNT_ARGS[@]}")
+        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
+            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
+            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
+        fi
         MOUNT_SEQ=0
 
         ABS_ENC="$(abs_path "$1")"
@@ -244,17 +248,17 @@ case "$cmd" in
         PW_ARGS=()
         if [[ -n "$PW_FILE" ]]; then
             host_to_container "$(abs_path "$PW_FILE")"
-            PW_ARGS=(-passwords "$CONTAINER_PATH")
+            PW_ARGS=(--passwords "$CONTAINER_PATH")
         else
             stored_pw=$(sed -n 's/.*"pwFile":"\([^"]*\)".*/\1/p' "$ABS_ENC")
             if [[ -z "$stored_pw" ]]; then
-                echo "Error: no pwFile stored in $1 — use -passwords <file>" >&2; exit 1
+                echo "Error: no pwFile stored in $1 — use --passwords <file>" >&2; exit 1
             fi
-            if [[ "$stored_pw" != /ddphotos/* ]]; then
+            if [[ "$stored_pw" != /ddphotos* ]]; then # matches /ddphotos, /ddphotos-config
                 ABS_PW="$(abs_path "$stored_pw")"
                 if [[ ! -f "$ABS_PW" ]]; then
                     echo "Error: passwords file not found: $stored_pw" >&2
-                    echo "       Use -passwords <file> to specify an alternative." >&2
+                    echo "       Use --passwords <file> to specify an alternative." >&2
                     exit 1
                 fi
                 host_to_container "$ABS_PW"
@@ -262,6 +266,7 @@ case "$cmd" in
             fi
         fi
 
+        #print_mounts # uncomment for debugging; normally off so can pipe result to jq and the like.
         docker run --rm \
             -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
@@ -273,10 +278,19 @@ case "$cmd" in
             echo "Usage: ddphotos [OPTIONS] search-cover <url>" >&2
             exit 1
         fi
+
+        SEARCH_MOUNTS=("${EXTRA_MOUNT_ARGS[@]}")
+        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
+            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
+            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
+        fi
+
+        print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -v "$DDPHOTOS_DIR":/ddphotos \
             "${SCRIPT_MOUNT[@]}" \
+            "${SEARCH_MOUNTS[@]}" \
             "$IMAGE" search-cover "$@"
         ;;
     photogen)

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -3,8 +3,12 @@
 # https://github.com/dougdonohoe/ddphotos
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# IMAGE is replaced at docker build time (see Dockerfile).  In a production
+# build it will be something like dougdonohoe/ddphotos:v.1.##.0.
 IMAGE="ddphotos"
+
+# Setup
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURRENT_VERSION="${IMAGE##*:}"
 STATE_DIR="${HOME}/.config/ddphotos"
 UPGRADE_FILE="$STATE_DIR/upgrade.txt"
@@ -25,6 +29,7 @@ while [[ "${1:-}" == --?* ]]; do
     esac
 done
 
+# Default to help if no cmd
 cmd="${1:-help}"
 shift 2>/dev/null || true
 
@@ -47,33 +52,67 @@ if [ -z "$DDPHOTOS_SITE_ID" ]; then
 fi
 DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 
+# ── Mount registry ─────────────────────────────────────────────────────────────
+# All Docker volume mounts go through add_mount(), which updates both the display
+# arrays (MOUNT_FROM/TO/OPTS) and the ready-to-use MOUNT_FLAGS (-v args for docker run).
+
+MOUNT_FROM=()   # host paths
+MOUNT_TO=()     # container paths
+MOUNT_OPTS=()   # "ro", or "" for read-write
+MOUNT_FLAGS=()  # -v args, kept in sync by add_mount
+MOUNT_SEQ=0     # used when passing mounts as args
+
+add_mount() {
+    MOUNT_FROM+=("$1")
+    MOUNT_TO+=("$2")
+    MOUNT_OPTS+=("${3:-}")
+    if [ -n "${3:-}" ]; then
+        MOUNT_FLAGS+=(-v "$1:$2:$3")
+    else
+        MOUNT_FLAGS+=(-v "$1:$2")
+    fi
+}
+
+# Print all registered mounts.
+print_mounts() {
+    echo "Mounting:"
+    local i=0
+    while [ $i -lt ${#MOUNT_FROM[@]} ]; do
+        local suffix=""
+        [ "${MOUNT_OPTS[$i]}" = "ro" ] && suffix=" (read-only)"
+        echo "  ${MOUNT_FROM[$i]} -> ${MOUNT_TO[$i]}${suffix}"
+        i=$((i + 1))
+    done
+    echo ""
+}
+
+# Always-present mounts
+add_mount "$SCRIPT_DIR" /ddphotos-script-dir
+add_mount "$DDPHOTOS_DIR" /ddphotos
+
 # Resolve --config-dir to a container path.
 # If inside DDPHOTOS_DIR, translate directly; otherwise mount as /ddphotos-config.
-EXTRA_MOUNT_ARGS=()
 DDPHOTOS_CONFIG_DIR=""
-CONFIG_DIR_EXTRA_SRC=""  # set only when an extra mount is needed (for display)
 if [ -n "$OPT_CONFIG_DIR" ]; then
     if [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR"/* ]] || [[ "$CONFIG_HOST_DIR" == "$DDPHOTOS_DIR" ]]; then
         DDPHOTOS_CONFIG_DIR="/ddphotos${CONFIG_HOST_DIR#"$DDPHOTOS_DIR"}"
     else
         DDPHOTOS_CONFIG_DIR="/ddphotos-config"
-        EXTRA_MOUNT_ARGS+=(-v "$CONFIG_HOST_DIR":"$DDPHOTOS_CONFIG_DIR":ro)
-        CONFIG_DIR_EXTRA_SRC="$CONFIG_HOST_DIR"
+        add_mount "$CONFIG_HOST_DIR" /ddphotos-config ro
     fi
 fi
 
-# Resolve --site-env: always mount as an extra file at /ddphotos-site.env.
+# Resolve --site-env: mount as /ddphotos-site.env.
 DDPHOTOS_SITE_ENV=""
 if [ -n "$OPT_SITE_ENV" ]; then
     OPT_SITE_ENV="$(cd "$(dirname "$OPT_SITE_ENV")" && pwd)/$(basename "$OPT_SITE_ENV")"
-    EXTRA_MOUNT_ARGS+=(-v "$OPT_SITE_ENV":/ddphotos-site.env:ro)
     DDPHOTOS_SITE_ENV="/ddphotos-site.env"
+    add_mount "$OPT_SITE_ENV" "$DDPHOTOS_SITE_ENV" ro
 fi
 
-# Parse bases: section from albums.yaml and emit -v flags for external photo dirs.
+# Parse the 'bases:' section from albums.yaml and add mounts for external photo dirs.
 # Paths already inside DDPHOTOS_DIR are skipped (covered by the main /ddphotos mount).
-# Populates MOUNT_ARGS (for docker run), MOUNT_PATHS and MOUNT_DESTS (for display).
-build_mount_args() {
+build_config_bases_mounts() {
     local config="$CONFIG_HOST_DIR/albums.yaml"
     [ -f "$config" ] || return 0
     local in_bases=false
@@ -98,25 +137,10 @@ build_mount_args() {
             path="${path/#\~/$HOME}"
             # Only mount absolute paths that fall outside DDPHOTOS_DIR (which is already mounted)
             if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
-                MOUNT_ARGS+=(-v "$path:$path:ro")
-                MOUNT_PATHS+=("$path")
-                MOUNT_DESTS+=("$path")
+                add_mount "$path" "$path" ro
             fi
         fi
     done < "$config"
-}
-
-# Print all Docker volume mounts for the current command.
-print_mounts() {
-    echo "Mounting:"
-    echo "  $SCRIPT_DIR -> /ddphotos-script-dir"
-    echo "  $DDPHOTOS_DIR -> /ddphotos"
-    local i=0
-    while [ $i -lt ${#MOUNT_PATHS[@]} ]; do
-        echo "  ${MOUNT_PATHS[$i]} -> ${MOUNT_DESTS[$i]} (read-only)"
-        i=$((i + 1))
-    done
-    echo ""
 }
 
 # Query Docker Hub for the latest versioned release tag and write upgrade.txt if newer.
@@ -146,17 +170,10 @@ check_for_update() {
     fi
 }
 
+# Docker settings
 SERVE_PORT="${SERVE_PORT:-8000}"
-IT_FLAGS=(); $NON_INTERACTIVE || IT_FLAGS=(-it)
 RUN_PORT="${RUN_PORT:-5173}"
-
-MOUNT_ARGS=()
-MOUNT_PATHS=()
-MOUNT_DESTS=()
-
-# Always mount SCRIPT_DIR at a fixed path so the container can verify/upgrade the script
-# regardless of what DDPHOTOS_DIR points to.
-SCRIPT_MOUNT=(-v "$SCRIPT_DIR":/ddphotos-script-dir)
+IT_FLAGS=(); $NON_INTERACTIVE || IT_FLAGS=(-it)
 
 # Resolve a path to absolute. Relative paths are anchored to DDPHOTOS_DIR.
 abs_path() {
@@ -166,8 +183,7 @@ abs_path() {
 }
 
 # Translate an absolute host path to its container equivalent.
-# Paths inside DDPHOTOS_DIR map to /ddphotos/...; others get a dedicated read-only mount
-# appended to DECODE_MOUNTS (caller must initialize that array and MOUNT_SEQ=0).
+# Paths inside DDPHOTOS_DIR map to /ddphotos/...; others get a dedicated read-only mount.
 # Preserves <parent-dir>/<filename> so the decode binary can identify the album slug
 # from the container path (e.g. secret/index.enc.json → slug "secret").
 # Sets CONTAINER_PATH.
@@ -178,7 +194,7 @@ host_to_container() {
     else
         MOUNT_SEQ=$((MOUNT_SEQ + 1))
         CONTAINER_PATH="/ddphotos-args/arg-$MOUNT_SEQ/$(basename "$(dirname "$abs")")/$(basename "$abs")"
-        DECODE_MOUNTS+=(-v "$abs:$CONTAINER_PATH:ro")
+        add_mount "$abs" "$CONTAINER_PATH" ro
     fi
 }
 
@@ -213,11 +229,9 @@ fi
 
 case "$cmd" in
     init)
-        docker run --rm \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "$IMAGE" init "$@"
+        docker run --rm "${MOUNT_FLAGS[@]}" "$IMAGE" init "$@"
         ;;
+
     decode)
         PW_FILE=""
         while [[ "${1:-}" == -* ]]; do
@@ -230,13 +244,6 @@ case "$cmd" in
             echo "Usage: ddphotos [OPTIONS] decode [--passwords <file>] <file.enc.json>" >&2
             exit 1
         fi
-
-        DECODE_MOUNTS=("${EXTRA_MOUNT_ARGS[@]}")
-        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
-            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
-            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
-        fi
-        MOUNT_SEQ=0
 
         ABS_ENC="$(abs_path "$1")"
         if [[ ! -f "$ABS_ENC" ]]; then
@@ -266,130 +273,93 @@ case "$cmd" in
             fi
         fi
 
-        #print_mounts # uncomment for debugging; normally off so can pipe result to jq and the like.
-        docker run --rm \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "${DECODE_MOUNTS[@]}" \
-            "$IMAGE" decode "${PW_ARGS[@]}" "$ENC_CONTAINER"
+        # Not calling print_mounts: decode output goes to stdout for piping to jq etc.
+        docker run --rm "${MOUNT_FLAGS[@]}" "$IMAGE" decode "${PW_ARGS[@]}" "$ENC_CONTAINER"
         ;;
+
     search-cover)
         if [[ $# -ne 1 ]]; then
             echo "Usage: ddphotos [OPTIONS] search-cover <url>" >&2
             exit 1
         fi
-
-        SEARCH_MOUNTS=("${EXTRA_MOUNT_ARGS[@]}")
-        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
-            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
-            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
-        fi
-
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "${SEARCH_MOUNTS[@]}" \
+            "${MOUNT_FLAGS[@]}" \
             "$IMAGE" search-cover "$@"
         ;;
+
     photogen)
-        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
-            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
-            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
-        fi
-        build_mount_args
+        build_config_bases_mounts
         print_mounts
-        PHOTOGEN_ARGS=("${EXTRA_MOUNT_ARGS[@]}" "${MOUNT_ARGS[@]}")
-        [ -n "$DDPHOTOS_CONFIG_DIR" ] && PHOTOGEN_ARGS+=(-e "DDPHOTOS_CONFIG_DIR=$DDPHOTOS_CONFIG_DIR")
-        docker run --rm \
-            -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "${PHOTOGEN_ARGS[@]}" \
-            "$IMAGE" photogen "$@"
+        PHOTOGEN_ENV=(-e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID")
+        [ -n "$DDPHOTOS_CONFIG_DIR" ] && PHOTOGEN_ENV+=(-e "DDPHOTOS_CONFIG_DIR=$DDPHOTOS_CONFIG_DIR")
+        docker run --rm "${MOUNT_FLAGS[@]}" "${PHOTOGEN_ENV[@]}" "$IMAGE" photogen "$@"
         ;;
+
     build)
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
+            "${MOUNT_FLAGS[@]}" \
             "$IMAGE" build "$@"
         ;;
+
     serve)
         print_mounts
         docker run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e SERVE_PORT="$SERVE_PORT" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
+            "${MOUNT_FLAGS[@]}" \
             -p "$SERVE_PORT":80 \
             "$IMAGE" serve "$@"
         ;;
+
     run)
         print_mounts
         docker run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e RUN_PORT="$RUN_PORT" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
+            "${MOUNT_FLAGS[@]}" \
             -p "$RUN_PORT":5173 \
             "$IMAGE" run "$@"
         ;;
+
     export)
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
+            "${MOUNT_FLAGS[@]}" \
             "$IMAGE" export "$@"
         ;;
+
     deploy)
-        DEPLOY_ARGS=("${EXTRA_MOUNT_ARGS[@]}")
-        if [ -n "$CONFIG_DIR_EXTRA_SRC" ]; then
-            MOUNT_PATHS+=("$CONFIG_DIR_EXTRA_SRC")
-            MOUNT_DESTS+=("$DDPHOTOS_CONFIG_DIR")
-        fi
-        if [ -n "$DDPHOTOS_SITE_ENV" ]; then
-            MOUNT_PATHS+=("$OPT_SITE_ENV")
-            MOUNT_DESTS+=("/ddphotos-site.env")
-        fi
-        if [ -d "$HOME/.ssh" ]; then
-            DEPLOY_ARGS+=(-v "$HOME/.ssh":/root/.ssh:ro)
-            MOUNT_PATHS+=("$HOME/.ssh")
-            MOUNT_DESTS+=("/root/.ssh")
-        fi
-        if [ -d "$HOME/.aws" ]; then
-            DEPLOY_ARGS+=(-v "$HOME/.aws":/root/.aws:ro)
-            MOUNT_PATHS+=("$HOME/.aws")
-            MOUNT_DESTS+=("/root/.aws")
-        fi
+        [ -d "$HOME/.ssh" ] && add_mount "$HOME/.ssh" /root/.ssh ro
+        [ -d "$HOME/.aws" ] && add_mount "$HOME/.aws" /root/.aws ro
+        DEPLOY_ENV=()
         for var in AWS_PROFILE AWS_DEFAULT_PROFILE AWS_DEFAULT_REGION AWS_REGION \
                    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
-            [ -n "${!var}" ] && DEPLOY_ARGS+=(-e "$var=${!var}")
+            [ -n "${!var}" ] && DEPLOY_ENV+=(-e "$var=${!var}")
         done
-        [ -n "$DDPHOTOS_CONFIG_DIR" ] && DEPLOY_ARGS+=(-e "DDPHOTOS_CONFIG_DIR=$DDPHOTOS_CONFIG_DIR")
-        [ -n "$DDPHOTOS_SITE_ENV" ]   && DEPLOY_ARGS+=(-e "DDPHOTOS_SITE_ENV=$DDPHOTOS_SITE_ENV")
+        [ -n "$DDPHOTOS_CONFIG_DIR" ] && DEPLOY_ENV+=(-e "DDPHOTOS_CONFIG_DIR=$DDPHOTOS_CONFIG_DIR")
+        [ -n "$DDPHOTOS_SITE_ENV" ]   && DEPLOY_ENV+=(-e "DDPHOTOS_SITE_ENV=$DDPHOTOS_SITE_ENV")
         print_mounts
         docker run --rm \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "${DEPLOY_ARGS[@]}" \
+            "${MOUNT_FLAGS[@]}" \
+            "${DEPLOY_ENV[@]}" \
             "$IMAGE" deploy "$@"
         ;;
+
     upgrade)
         UPGRADE_IMAGE="$IMAGE"
         if [[ "$CURRENT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -f "$UPGRADE_FILE" ]; then
             TARGET_VERSION=$(cat "$UPGRADE_FILE")
             UPGRADE_IMAGE="${IMAGE%%:*}:$TARGET_VERSION"
         fi
-        docker run --rm \
-            -v "$DDPHOTOS_DIR":/ddphotos \
-            "${SCRIPT_MOUNT[@]}" \
-            "$UPGRADE_IMAGE" upgrade
+        docker run --rm "${MOUNT_FLAGS[@]}" "$UPGRADE_IMAGE" upgrade
         ;;
+
     version)
         echo "Script:         $SCRIPT_DIR/ddphotos"
         echo "Image:          $IMAGE"
@@ -401,6 +371,7 @@ case "$cmd" in
         echo "Site ID:        $DDPHOTOS_SITE_ID"
         echo "State dir:      $STATE_DIR"
         ;;
+
     *)
         echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|search-cover|build|serve|run|export|deploy|upgrade} [args]"
         echo ""

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -18,6 +18,7 @@ mkdir -p "$STATE_DIR"
 OPT_CONFIG_DIR=""
 OPT_SITE_ENV=""
 NON_INTERACTIVE=false
+SHOW_MOUNTS=false
 while [[ "${1:-}" == --?* ]]; do
     case "$1" in
         --dir) DDPHOTOS_DIR="$2"; shift 2 ;;
@@ -25,6 +26,7 @@ while [[ "${1:-}" == --?* ]]; do
         --config-dir)      OPT_CONFIG_DIR="$2";   shift 2 ;;
         --site-env)        OPT_SITE_ENV="$2";     shift 2 ;;
         --non-interactive) NON_INTERACTIVE=true;  shift ;;
+        --show-mounts)     SHOW_MOUNTS=true;      shift ;;
         *)            break ;;
     esac
 done
@@ -73,8 +75,9 @@ add_mount() {
     fi
 }
 
-# Print all registered mounts.
+# Print all registered mounts (no-op unless --show-mounts was passed).
 print_mounts() {
+    $SHOW_MOUNTS || return 0
     echo "Mounting:"
     local i=0
     while [ $i -lt ${#MOUNT_FROM[@]} ]; do
@@ -273,7 +276,7 @@ case "$cmd" in
             fi
         fi
 
-        # Not calling print_mounts: decode output goes to stdout for piping to jq etc.
+        print_mounts
         docker run --rm "${MOUNT_FLAGS[@]}" "$IMAGE" decode "${PW_ARGS[@]}" "$ENC_CONTAINER"
         ;;
 
@@ -376,10 +379,11 @@ case "$cmd" in
         echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|search-cover|build|serve|run|export|deploy|upgrade} [args]"
         echo ""
         echo "Options (before command):"
-        echo "  --dir DIR         Directory to mount as /ddphotos (default: script location)"
-        echo "  --site-id ID      Site ID override (default: settings.id from albums.yaml)"
-        echo "  --config-dir DIR  Config directory override (default: albums-dir/config)"
-        echo "  --site-env FILE   Path to site.env for deploy (default: config-dir/site.env)"
+        echo "  --dir DIR          Directory to mount as /ddphotos (default: script location)"
+        echo "  --site-id ID       Site ID override (default: settings.id from albums.yaml)"
+        echo "  --config-dir DIR   Config directory override (default: albums-dir/config)"
+        echo "  --site-env FILE    Path to site.env for deploy (default: config-dir/site.env)"
+        echo "  --show-mounts      Print Docker volume mounts before running the command"
         echo ""
         echo "Commands:"
         echo "  init                Initialize config scaffold"

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -48,7 +48,6 @@ if [ -n "$CLOUDFLARE" ]; then
     /bin/cp /docker/cloudflare-worker.js "$EXPORT_DIR/_worker.js"
 fi
 
-echo ""
 echo "  Exported $SITE_ID to export/$SITE_ID"
 echo "  Serve with: python3 -m http.server 8000 --directory export/$SITE_ID"
 echo ""

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -15,9 +15,7 @@ export VITE_GIT_BRANCH=""
 export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
 export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
-echo ""
 echo "  Dev server for $SITE_ID at:   http://localhost:${RUN_PORT}"
-echo ""
 
 export DDPHOTOS_ALBUMS_DIR=/ddphotos/albums
 export DDPHOTOS_SITE_ID="$SITE_ID"

--- a/docker/do-search-cover.sh
+++ b/docker/do-search-cover.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
+export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+
+exec /app/bin/search_cover.sh --from-docker "$@"

--- a/docker/do-search-cover.sh
+++ b/docker/do-search-cover.sh
@@ -4,4 +4,4 @@ set -e
 export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
 export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 
-exec /app/bin/search_cover.sh --from-docker "$@"
+exec /app/bin/search-cover.sh --from-docker "$@"

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -14,7 +14,6 @@ ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
 DDPHOTOS_SITE_ID=$SITE_ID \
 /docker/setup-htdocs.sh /htdocs
 
-echo ""
 echo "  Serving $SITE_ID at:   http://localhost:${SERVE_PORT}"
 echo ""
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,14 +14,15 @@ if [ "$cmd" != "init" ] && [ "$cmd" != "upgrade" ] && [ "$cmd" != "version" ]; t
 fi
 
 case "$cmd" in
-    init)     exec /docker/do-init.sh "$@" ;;
-    photogen) exec /docker/do-photogen.sh "$@" ;;
-    decode)   exec /docker/do-decode.sh "$@" ;;
-    build)    exec /docker/do-build.sh "$@" ;;
-    serve)    exec /docker/do-serve.sh "$@" ;;
-    run)      exec /docker/do-run.sh "$@" ;;
-    export)   exec /docker/do-export.sh "$@" ;;
-    deploy)   exec /docker/do-deploy.sh "$@" ;;
+    init)         exec /docker/do-init.sh "$@" ;;
+    photogen)     exec /docker/do-photogen.sh "$@" ;;
+    decode)       exec /docker/do-decode.sh "$@" ;;
+    search-cover) exec /docker/do-search-cover.sh "$@" ;;
+    build)        exec /docker/do-build.sh "$@" ;;
+    serve)        exec /docker/do-serve.sh "$@" ;;
+    run)          exec /docker/do-run.sh "$@" ;;
+    export)       exec /docker/do-export.sh "$@" ;;
+    deploy)       exec /docker/do-deploy.sh "$@" ;;
     version)
         echo "Version:  $(cat /docker/VERSION 2>/dev/null || echo unknown)"
         echo "Git:      $(cat /docker/GIT_DESCRIBE 2>/dev/null || echo unknown)"
@@ -39,18 +40,10 @@ case "$cmd" in
         fi
         ;;
     *)
-        echo "Usage: docker run ddphotos {init|photogen|decode|build|serve|run|export|deploy|upgrade}"
-        echo ""
-        echo "Commands:"
-        echo "  init      Create config scaffold (--script-only to install 'ddphotos' script only)"
-        echo "  photogen  Process source photos into albums output"
-        echo "  decode    Decrypt an .enc.json file and print the contents"
-        echo "  build     Build the static site"
-        echo "  serve     Preview the site via Apache on port 80"
-        echo "  run       Preview the site via Vite dev server on port 5173"
-        echo "  export    Export site to export/<site-id>/ for local serving"
-        echo "  deploy    Rsync build and albums to a remote host"
-        echo "  upgrade   Update the ddphotos script to match this image"
+        echo "Unknown command: '$cmd'"
+        echo
+        echo "This image is intended to be used via the 'ddphotos' wrapper script."
+        echo "See: https://github.com/dougdonohoe/ddphotos"
         exit 1
         ;;
 esac

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,9 +7,9 @@ shift 2>/dev/null || true
 # Verify the mounted ddphotos script matches the image (skip for init/upgrade/version)
 if [ "$cmd" != "init" ] && [ "$cmd" != "upgrade" ] && [ "$cmd" != "version" ]; then
     if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
-        echo "WARNING:  The local 'ddphotos' script does not match the image."
-        echo "          Run: 'ddphotos upgrade' to fix this."
-        echo ""
+        echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
+        echo "          Run: 'ddphotos upgrade' to fix this." >&2
+        echo "" >&2
     fi
 fi
 
@@ -31,19 +31,20 @@ case "$cmd" in
         SCRIPT=/ddphotos-script-dir/ddphotos
         VERSION=$(cat /docker/VERSION 2>/dev/null || echo "dev")
         if diff -q /docker/ddphotos "$SCRIPT" > /dev/null 2>&1; then
-            echo "ddphotos is up to date ($VERSION)."
+            echo "The 'ddphotos' script is up to date ($VERSION)."
         else
             /bin/cp /docker/ddphotos "${SCRIPT}.new"
             chmod +x "${SCRIPT}.new"
             /bin/mv -f "${SCRIPT}.new" "$SCRIPT"
-            echo "ddphotos script upgraded ($VERSION)."
+            echo "The 'ddphotos' script was upgraded ($VERSION)."
         fi
         ;;
     *)
-        echo "Unknown command: '$cmd'"
-        echo
-        echo "This image is intended to be used via the 'ddphotos' wrapper script."
-        echo "See: https://github.com/dougdonohoe/ddphotos"
+        echo "Unknown command: '$cmd'" >&2
+        echo >&2
+        echo "This image is intended to be used via the 'ddphotos' wrapper script." >&2
+        echo "See: https://github.com/dougdonohoe/ddphotos" >&2
+        echo >&2
         exit 1
         ;;
 esac

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -308,6 +308,7 @@ These flags go before the command name and apply to all commands that need them:
 | `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                          |
 | `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                            |
 | `--non-interactive`   | Run `serve` and `run` without a TTY (no `-it` flag) — useful for scripted/CI contexts                   |
+| `--show-mounts`       | Print the Docker volume mounts before running the command — useful for debugging mount issues           |
 
 Example — using a separate source repo as the albums dir:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -145,6 +145,38 @@ ddphotos decode --passwords config/passwords.yaml albums/my-photos/secret/index.
 Paths are resolved relative to the `--dir` directory (default: the `ddphotos` script
 location). Files outside that directory are mounted automatically.
 
+### `search-cover`
+
+Finds the original filename for a photo given its URL — useful for setting a cover image
+in `albums.yaml`. Pass any photo URL from your site (full-size or grid thumbnail):
+
+```bash
+ddphotos search-cover https://my-site.example.com/albums/banff-2002/full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+```
+
+Output:
+
+```
+Searching...
+  Album:  banff-2002
+  Index:  /ddphotos/albums/my-photos/banff-2002/index.json
+  Source: full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp
+
+Found:
+  id:         0918bedf-2f7d-dedc-9e89-b99ec5bb2752
+  sourcePath: /photos/banff-2002/IMG_1234.jpg
+  fileName:   IMG_1234.jpg
+
+Use for cover:
+  cover: IMG_1234.jpg
+```
+
+Use the `--site-id` flag to search a different site:
+
+```bash
+ddphotos --site-id other-site search-cover <url>
+```
+
 ### `run`
 
 Starts a Vite dev server at http://localhost:5173. Live-reloads on template/CSS changes.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -40,5 +40,5 @@ These variables are consumed by:
 - `web/src/hooks.server.ts` — intercepts fetch calls to `/albums/**` during `npm run build`
 - `web/setup-htdocs.sh` — symlinks `build/<DDPHOTOS_SITE_ID>/` into the web server document root at container startup (called by both `apache-entrypoint.sh` and `nginx-entrypoint.sh`)
 - `bin/deploy-photos.sh` — drives `npm run build`, Docker deployment, and S3/rsync sync
-- `bin/search_cover.sh` — locates album data when searching for cover images
+- `bin/search-cover.sh` — locates album data when searching for cover images
 - `bin/run-tests.sh` — sets both when starting the dev server, building, and running Docker test containers

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -197,7 +197,7 @@ The search is scoped to `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (defaults from
 `config/defaults.env`). Override to search a different site:
 
 ```bash
-DDPHOTOS_SITE_ID=sample-pw-all bin/search-cover.sh http://localhost:5173/albums/uganda/full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp```
+DDPHOTOS_SITE_ID=sample-pw-all bin/search-cover.sh http://localhost:5173/albums/uganda/full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp
 ```
 
 Output:

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -178,14 +178,14 @@ The correct password is selected automatically from the filename:
 | `html.enc.json`   | Site-wide password (`site.password`)             |
 | `index.enc.json`  | Per-album password for the parent directory slug |
 
-## Finding a Cover Photo (`search_cover.sh`)
+## Finding a Cover Photo (`search-cover.sh`)
 
 When browsing the site, and you want to set a photo as an album cover, you need its
 `fileName` value for the `cover:` field in `albums.yaml`. The easiest way to get it is
-to right-click the photo, copy the image URL, and pass it to `bin/search_cover.sh`:
+to right-click the photo, copy the image URL, and pass it to `bin/search-cover.sh`:
 
 ```bash
-bin/search_cover.sh <url>
+bin/search-cover.sh <url>
 ```
 
 The script parses the album slug and image path from the URL, locates the album's
@@ -197,17 +197,22 @@ The search is scoped to `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (defaults from
 `config/defaults.env`). Override to search a different site:
 
 ```bash
-DDPHOTOS_SITE_ID=sample-pw-all bin/search_cover.sh http://localhost:5173/albums/uganda/full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp```
+DDPHOTOS_SITE_ID=sample-pw-all bin/search-cover.sh http://localhost:5173/albums/uganda/full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp```
 ```
 
 Output:
 
 ```
-Album:  uganda
-Index:  /Users/donohoe/work/ddphotos/albums/sample-pw-all/uganda/index.enc.json
-src:    full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp
+Searching...
+  Album:  uganda
+  Index:  /Users/donohoe/work/ddphotos/albums/sample-pw-all/uganda/index.enc.json
+  Source: full/1996ae71-5ada-d233-8f26-53e46fac4f64.webp
 
-fileName: subfolder_img_840_d.jpg
-id:       subfolder_img_840_d
-sourcePath: uganda/subfolder/img_840_d.jpg
+Found:
+  id:         subfolder_img_840_d
+  sourcePath: uganda/subfolder/img_840_d.jpg
+  fileName:   subfolder_img_840_d.jpg
+
+Use for cover:
+  cover: subfolder_img_840_d.jpg
 ```

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1653,9 +1653,9 @@ Existing script was updated to:
 Added `search-cover` as a first-class Docker command:
 
 - **`docker/do-search-cover.sh`** — sets `DDPHOTOS_ALBUMS_DIR=/ddphotos/albums` and
-  `DDPHOTOS_SITE_ID`, then delegates to `/app/bin/search_cover.sh --from-docker "$@"`
+  `DDPHOTOS_SITE_ID`, then delegates to `/app/bin/search-cover.sh --from-docker "$@"`
 - **`docker/Dockerfile`** — added `docker/do-search-cover.sh` to the scripts `COPY` line;
-  added a separate `COPY bin/search_cover.sh /app/bin/search_cover.sh` so the script is
+  added a separate `COPY bin/searc-cover.sh /app/bin/search-cover.sh` so the script is
   available inside the container at the path `do-search-cover.sh` expects
 - **`docker/entrypoint.sh`** — added `search-cover)` case; simplified the `*` fallback to a
   short redirect message (full command list belongs in the `ddphotos` wrapper, not here)

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1628,3 +1628,47 @@ were updated to match.
   Fixed cleanup to use `if [ -n ... ]` pattern (avoids `&&...||` exit-code pitfall).
 - **`docs/DOCKER.md`** — added `### decode` command section
 - **`docs/PHOTOGEN.md`** — updated decode examples to use `--passwords`
+
+### 69. 05/03/2026 - Add `ddphotos search-cover` Command
+
+#### Motivation
+
+Finding an album cover required decoding an `.enc.json`, manually parsing the JSON, and
+matching a UUID from a photo URL back to an original filename. `search-cover` automates this:
+pass a photo URL from any page in the site, get back the `fileName` to use as `cover:` in
+`albums.yaml`.
+
+#### `bin/search_cover.sh`
+
+Existing script was updated to:
+- Replace the inline `go run cmd/decode/decode.go` call with a `$DECODE_CMD` variable,
+  set to `$SDIR/decode` (the `bin/decode` script) by default.
+- Add a `--from-docker` flag: uses `/usr/local/bin/decode` inside the container and prints
+  a Docker-appropriate "try another site" hint (`ddphotos --site-id <id> search-cover <url>`)
+  instead of the local shell form.
+- Cosmetic output improvements (aligned labels, "Found:" / "Use for cover:" sections).
+
+#### Docker: `ddphotos search-cover` Command
+
+Added `search-cover` as a first-class Docker command:
+
+- **`docker/do-search-cover.sh`** — sets `DDPHOTOS_ALBUMS_DIR=/ddphotos/albums` and
+  `DDPHOTOS_SITE_ID`, then delegates to `/app/bin/search_cover.sh --from-docker "$@"`
+- **`docker/Dockerfile`** — added `docker/do-search-cover.sh` to the scripts `COPY` line;
+  added a separate `COPY bin/search_cover.sh /app/bin/search_cover.sh` so the script is
+  available inside the container at the path `do-search-cover.sh` expects
+- **`docker/entrypoint.sh`** — added `search-cover)` case; simplified the `*` fallback to a
+  short redirect message (full command list belongs in the `ddphotos` wrapper, not here)
+- **`docker/ddphotos`** — added `search-cover` to the albums.yaml validation exemption,
+  added the `search-cover` dispatch case, and updated both usage strings
+
+No path translation is needed (unlike `decode`) — `search-cover` only takes a URL string
+and reads from the already-mounted `/ddphotos/albums` directory.
+
+#### Tests and Documentation
+
+- **`bin/docker-test.sh`** — added step 5 "Search-Cover": decodes the same `secret/index.enc.json`
+  used in the decode test to extract the actual grid UUID, constructs the URL dynamically,
+  runs `ddphotos search-cover`, and asserts the output contains `cover: 2024-The-Way-21.jpg`.
+  Renumbered subsequent steps 6-12.
+- **`docs/DOCKER.md`** — added `### search-cover` section with example output


### PR DESCRIPTION
Adds `ddphotos search-cover <url>` — a command to look up the original filename for a photo
given its URL. Useful when setting a cover image in `albums.yaml`: copy any photo URL from
the site, run `search-cover`, and it prints the `fileName` to use as `cover:`.

```
$ ddphotos search-cover https://my-site.example.com/albums/banff-2002/full/0918bedf-....webp

Searching...
  Album:  banff-2002
  Index:  /ddphotos/albums/my-photos/banff-2002/index.enc.json
  Source: full/0918bedf-2f7d-dedc-9e89-b99ec5bb2752.webp

Found:
  id:         2024-the-way-21
  sourcePath: ddphotos-secret/2024-The-Way-21.jpg
  fileName:   2024-The-Way-21.jpg

Use for cover:
  cover: 2024-The-Way-21.jpg
```

Works with both encrypted and plain index files. Use `--site-id` to search a different site.

## Changes

- **`--show-mounts`** - new option to `ddphotos` to show Docker mounts (helpful for debugging)
- Refactored internals of `ddphotos` to be smarter about Docker mounts
- **`bin/search_cover.sh`** — updated to use `bin/decode` script instead of `go run` directly;
  added `--from-docker` flag for Docker context (selects `/usr/local/bin/decode` binary and
  prints the correct "try another site" hint)
- **`docker/do-search-cover.sh`** — new; sets `DDPHOTOS_ALBUMS_DIR`/`DDPHOTOS_SITE_ID` and
  delegates to `search_cover.sh --from-docker`
- **`docker/Dockerfile`** — copies `do-search-cover.sh` and `bin/search_cover.sh` into image
- **`docker/entrypoint.sh`** — added `search-cover` case; simplified unknown-command fallback
  to a short redirect instead of repeating the full command list
- **`docker/ddphotos`** — added `search-cover` command with usage updates
- **`bin/docker-test.sh`** — added Search-Cover step: derives the URL from the decoded index
  to avoid hardcoding the UUID, then asserts output contains `cover: 2024-The-Way-21.jpg`
- **`docs/DOCKER.md`** — added `search-cover` section
- **`CLAUDE.md`** — added directory structure sync note