### PR TITLE
Docker hardening: error messages, configurable site ID, remove -albums flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,3 +301,17 @@ docker-push:
 ## docker-test: build the ddphotos Docker image and run end-to-end Docker workflow tests
 docker-test:
 	bin/docker-test.sh
+
+.PHONY: ddphotos-install-dev
+ddphotos-install-dev:
+	docker run --rm -v ~/.local/bin:/ddphotos ddphotos init --script-only
+
+.PHONY: ddphotos-install-prod
+ddphotos-install-prod:
+	docker run --rm -v ~/.local/bin:/ddphotos dougdonohoe/ddphotos:latest init --script-only
+
+.PHONY: ddphotos-patch
+ddphotos-patch:
+	@_img=$$(grep '^IMAGE=' ~/.local/bin/ddphotos); \
+	/bin/cp docker/ddphotos ~/.local/bin/ddphotos; \
+	sed -i '' "s|^IMAGE=.*|$$_img|" ~/.local/bin/ddphotos

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -29,7 +29,23 @@ while [[ $# -gt 0 ]]; do
         --config-dir=*)      CONFIG_DIR="${1#*=}"; shift ;;
         --site-env)          SITE_ENV_ARG="$2"; shift 2 ;;
         --site-env=*)        SITE_ENV_ARG="${1#*=}"; shift ;;
-        *) echo "Unknown flag: $1"; exit 1 ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            echo "" >&2
+            echo "Usage: deploy-photos.sh [OPTIONS]" >&2
+            echo "" >&2
+            echo "  --dry-run              Show what would be deployed without transferring files" >&2
+            echo "  --s3                   Deploy to S3 (default: rsync; auto-set if S3_BUCKET in site.env)" >&2
+            echo "  --config-dir DIR       Config directory (default: config/)" >&2
+            echo "  --site-env FILE        Path to site.env (default: config-dir/site.env)" >&2
+            echo "  --no-photogen          Skip photogen step" >&2
+            echo "  --no-build             Skip build step" >&2
+            echo "  --no-pre-deploy-tests  Skip pre-deploy server and Playwright tests" >&2
+            echo "  --no-rsync             Skip rsync/S3 sync and post-deploy steps" >&2
+            echo "  --no-playwright        Skip Playwright tests (pre- and post-deploy)" >&2
+            echo "  --no-server-test       Skip server tests (pre- and post-deploy)" >&2
+            exit 1
+            ;;
     esac
 done
 

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -132,7 +132,31 @@ DDPHOTOS=("$TEST_DIR/ddphotos" --show-mounts)
 DDPHOTOS_QUIET=("$TEST_DIR/ddphotos")
 PASSWORDS_FILE="$TEST_DIR/config/passwords.yaml"
 
-# ── 3. Photogen ────────────────────────────────────────────────────────────────
+# ── 3. Error handling ─────────────────────────────────────────────────────────
+step "Error handling: commands reject unexpected args"
+out=$("${DDPHOTOS_QUIET[@]}" build extra-arg 2>&1) || true
+echo "$out" | grep -q "takes no arguments" || fail "build: expected 'takes no arguments' error"
+pass "build rejects unexpected args"
+
+out=$("$TEST_DIR/ddphotos" --non-interactive serve --foo 2>&1) || true
+echo "$out" | grep -q "takes no arguments" || fail "serve: expected 'takes no arguments' error"
+pass "serve rejects unexpected args"
+
+out=$("${DDPHOTOS_QUIET[@]}" export --no-such-flag 2>&1) || true
+echo "$out" | grep -q "Unknown option" || fail "export: expected 'Unknown option' error"
+pass "export rejects unknown flags"
+
+step "Error handling: unknown pre-command option"
+out=$("$TEST_DIR/ddphotos" --no-such-flag build 2>&1) || true
+echo "$out" | grep -q "Unknown option" || fail "ddphotos: expected 'Unknown option' for unknown pre-command flag"
+pass "ddphotos rejects unknown pre-command options"
+
+step "Help command"
+out=$("${DDPHOTOS_QUIET[@]}" help 2>&1)
+echo "$out" | grep -q "photogen" || fail "help: missing expected content"
+pass "help exits 0 and shows usage"
+
+# ── 4. Photogen ────────────────────────────────────────────────────────────────
 step "Photogen"
 "${DDPHOTOS[@]}" photogen
 [ -d "$TEST_DIR/albums/$SITE_ID" ] || fail "albums/$SITE_ID not created"
@@ -289,6 +313,9 @@ echo "$version_image_out" | grep -qF "$TEST_DIR/ddphotos" || fail "version --ima
 echo "$version_image_out" | grep -q "Git:" || fail "version --image: missing Git: line"
 echo "$version_image_out" | grep -q "Version:.*dev" || fail "version --image: missing Version: dev"
 pass "version --image: Script path OK, Git: and Version: dev present"
+
+echo "$version_out" | grep -q "Site ID:.*$SITE_ID" || fail "version: Site ID does not show $SITE_ID"
+pass "version: Site ID '$SITE_ID' auto-detected from albums.yaml"
 
 # ── 12. Init --script-only ─────────────────────────────────────────────────────
 step "Init --script-only"

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -188,6 +188,7 @@ step "Decode + Search-Cover with external --config-dir"
 # the embedded pwFile path from /ddphotos/config/... to /ddphotos-config/...
 EXT_CONFIG_DIR=$(mktemp -d)
 /bin/cp "$TEST_DIR/config/passwords.yaml" "$EXT_CONFIG_DIR/"
+/bin/cp "$TEST_DIR/config/albums.yaml"    "$EXT_CONFIG_DIR/"
 
 # Write the modified enc.json to TEMP_DECODE_DIR (user-owned) — the album
 # directory inside TEST_DIR is root-owned (created by Docker) and unwritable.

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -10,9 +10,9 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 IMAGE="ddphotos"
-SITE_ID="my-photos"   # site-id created by 'init' template
-RUN_PORT=5173          # Vite host port; matches container default to keep port-mapping consistent
-SERVE_PORT=8090        # Apache host port (maps to container port 80; avoids conflicts with run-tests.sh)
+SITE_ID="docker-test-id"  # passed to init via --site-id, verified against albums.yaml after
+RUN_PORT=5173             # Vite host port; matches container default to keep port-mapping consistent
+SERVE_PORT=8090           # Apache host port (maps to container port 80; avoids conflicts with run-tests.sh)
 DO_BUILD=true
 TEST_DIR=""
 TEST_DIR2=""
@@ -116,13 +116,17 @@ fi
 step "Init"
 TEST_DIR=$(mktemp -d)
 chmod 755 "$TEST_DIR"
-docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init
+docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init --site-id "$SITE_ID"
 [ -x "$TEST_DIR/ddphotos" ]              || fail "ddphotos script not installed"
 [ -f "$TEST_DIR/config/albums.yaml" ]    || fail "config/albums.yaml not created"
 [ -f "$TEST_DIR/config/passwords.yaml" ] || fail "config/passwords.yaml not created"
 [ -f "$TEST_DIR/config/site.env" ]       || fail "config/site.env not created"
 [ -f "$TEST_DIR/config/passwords.yaml" ] || fail "config/passwords.yaml not created"
 pass "ddphotos script and config created at $TEST_DIR"
+
+VALIDATE_SITE_ID=$(awk '/^settings:/{f=1} f && /[[:space:]]id:/{gsub(/.*id:[[:space:]]*/,""); print; exit}' "$TEST_DIR/config/albums.yaml")
+[ "$VALIDATE_SITE_ID" = "$SITE_ID" ] || fail "SITE_ID mismatch: expected '$SITE_ID', got '$VALIDATE_SITE_ID' in config/albums.yaml"
+pass "site ID '$SITE_ID' written correctly to config/albums.yaml"
 
 DDPHOTOS=("$TEST_DIR/ddphotos" --show-mounts)
 DDPHOTOS_QUIET=("$TEST_DIR/ddphotos")

--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -18,7 +18,11 @@ if [[ "${1:-}" == "--from-docker" ]]; then
 fi
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: bin/search-cover.sh [--from-docker] <url>" >&2
+    if $FROM_DOCKER; then
+        echo "Usage: ddphotos [--site-id ID] search-cover <url>" >&2
+    else
+        echo "Usage: bin/search-cover.sh <url>" >&2
+    fi
     exit 1
 fi
 

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -54,7 +54,6 @@ func loadDefaultsEnv() {
 
 var (
 	configDir  = flag.String("config-dir", "config", "directory containing albums YAML and descriptions files")
-	albumsFile = flag.String("albums", "albums.yaml", "albums YAML filename within config-dir")
 	outputDir  = flag.String("out", "", "albums directory override (overrides DDPHOTOS_ALBUMS_DIR env var)")
 	doit       = flag.Bool("doit", false, "do actual work; otherwise log planned work without writing any files")
 	limit      = flag.Int("limit", 0, "limit number of photos per album (0 = no limit)")
@@ -76,7 +75,7 @@ func main() {
 	exit.HandleSignal()
 	loadDefaultsEnv()
 
-	albums, settings, err := photogen.LoadAlbumConfigs(*configDir, *albumsFile)
+	albums, settings, err := photogen.LoadAlbumConfigs(*configDir, "albums.yaml")
 	if err != nil {
 		exit.Fatal("Error loading config", err)
 	}

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -385,7 +385,8 @@ case "$cmd" in
         echo "State dir:      $STATE_DIR"
         ;;
 
-    *)
+    help|*)
+        [ "$cmd" != "help" ] && { echo "Unknown command: '$cmd'" >&2; echo "" >&2; }
         echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|search-cover|build|serve|run|export|deploy|upgrade} [args]"
         echo ""
         echo "Options (before command):"
@@ -416,6 +417,6 @@ case "$cmd" in
         echo ""
         echo "Tip: pass -- to photogen for full flag control:"
         echo "  ddphotos photogen -- -hero-only"
-        exit 1
+        [ "$cmd" = "help" ] || exit 1
         ;;
 esac

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -203,7 +203,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version|decode|search-cover) ;;
+    init|upgrade|help|version) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -207,11 +207,15 @@ case "$cmd" in
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
+            echo
             if [ "$DDPHOTOS_DIR" = "$SCRIPT_DIR" ]; then
-                echo "If ddphotos is installed in your PATH, specify your album directory:"
+                echo "'ddphotos' is installed in $SCRIPT_DIR."
+                echo "Since you are running 'ddphotos' standalone, you must specify the"
+                echo "DD Photos site directory (the one containing your 'config' dir):"
                 echo "  ddphotos --dir ~/my-ddphotos $cmd"
             else
-                echo "Run 'ddphotos init' to initialize the album directory."
+                echo "Run init to initialize the DD Photos site:"
+                echo "  ddphotos --dir $DDPHOTOS_DIR init"
             fi
             exit 1
         fi

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -203,7 +203,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version) ;;
+    init|upgrade|help|version|decode|search-cover) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -52,7 +52,6 @@ if [ -z "$DDPHOTOS_SITE_ID" ]; then
         DDPHOTOS_SITE_ID=$(awk '/^settings:/{f=1} f && /[[:space:]]id:/{gsub(/.*id:[[:space:]]*/,""); print; exit}' "$ALBUMS_YAML")
     fi
 fi
-DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 
 # ── Mount registry ─────────────────────────────────────────────────────────────
 # All Docker volume mounts go through add_mount(), which updates both the display

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -203,7 +203,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version|decode|search-cover) ;;
+    init|upgrade|help|version) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
@@ -222,9 +222,13 @@ case "$cmd" in
         ;;
 esac
 
-# Remove upgrade.txt if we're already on that version (post-upgrade cleanup)
-if [ -f "$UPGRADE_FILE" ] && [ "$(cat "$UPGRADE_FILE")" = "$CURRENT_VERSION" ]; then
-    rm -f "$UPGRADE_FILE"
+# Remove upgrade.txt if we're already on or past that version (post-upgrade cleanup)
+if [ -f "$UPGRADE_FILE" ]; then
+    _stored=$(cat "$UPGRADE_FILE")
+    _newer=$(printf '%s\n%s' "$CURRENT_VERSION" "$_stored" | sort -V | tail -1)
+    if [ "$_newer" = "$CURRENT_VERSION" ]; then
+        rm -f "$UPGRADE_FILE"
+    fi
 fi
 
 check_for_update

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -27,7 +27,7 @@ while [[ "${1:-}" == --?* ]]; do
         --site-env)        OPT_SITE_ENV="$2";     shift 2 ;;
         --non-interactive) NON_INTERACTIVE=true;  shift ;;
         --show-mounts)     SHOW_MOUNTS=true;      shift ;;
-        *)            break ;;
+        *) echo "Unknown option: $1" >&2; echo "Options must appear before the command. Run 'ddphotos help' for usage." >&2; exit 1 ;;
     esac
 done
 

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -2,7 +2,7 @@
 set -e
 
 export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
-export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 export VITE_GIT_DESCRIBE=$(cat /docker/GIT_DESCRIBE 2>/dev/null || echo "unknown")
 export VITE_DOCKER_IMAGE=$(cat /docker/IMAGE 2>/dev/null || echo "")

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -10,6 +10,12 @@ export VITE_GIT_BRANCH=""
 export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
 export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
+if [ $# -gt 0 ]; then
+    echo "Error: 'build' takes no arguments; got: $*" >&2
+    echo "Did you mean to pass options before the command? e.g.: ddphotos $* build" >&2
+    exit 1
+fi
+
 mkdir -p /ddphotos/build
 
 # svelte.config.js writes to ../build/$SITE_ID relative to web/; redirect to /ddphotos/build

--- a/docker/do-deploy.sh
+++ b/docker/do-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 CONFIG_DIR="${DDPHOTOS_CONFIG_DIR:-/ddphotos/config}"
 SITE_ENV="${DDPHOTOS_SITE_ENV:-$CONFIG_DIR/site.env}"
 

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -11,7 +11,16 @@ while [ "${1#--}" != "$1" ]; do
         --copy)             COPY=1;                shift ;;
         --cloudflare)       CLOUDFLARE=1;          shift ;;
         --export-site-id)   EXPORT_SITE_ID="$2";   shift 2 ;;
-        *) echo "Unknown option: $1" >&2; exit 1 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "" >&2
+            echo "Usage: ddphotos export [--copy] [--cloudflare] [--export-site-id ID]" >&2
+            echo "" >&2
+            echo "  --copy                 Resolve symlinks (required for static hosting)" >&2
+            echo "  --cloudflare           Add _worker.js for Cloudflare Pages photo permalinks" >&2
+            echo "  --export-site-id ID    Use export/ID/ as destination instead of export/<site-id>/" >&2
+            exit 1
+            ;;
     esac
 done
 

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 COPY=""
 CLOUDFLARE=""
 EXPORT_SITE_ID="$SITE_ID"

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -6,6 +6,24 @@ if [ ! -d "/ddphotos" ]; then
     exit 1
 fi
 
+_mp=$(grep ' /ddphotos ' /proc/self/mountinfo 2>/dev/null | tail -1)
+_named=false
+# Linux: named volume path appears in mountinfo source
+echo "$_mp" | grep -q 'docker/volumes' && _named=true
+# Docker Desktop Mac: bind mounts use virtiofs/grpcfuse/osxfs; named volumes don't
+if [ "$_named" = "false" ] && [ -n "$_mp" ]; then
+    if grep -qE 'virtiofs|grpcfuse|osxfs' /proc/mounts 2>/dev/null; then
+        echo "$_mp" | grep -qE 'virtiofs|grpcfuse|osxfs' || _named=true
+    fi
+fi
+if [ "$_named" = "true" ]; then
+    echo "Error: /ddphotos is mounted as a Docker named volume, not a host directory." >&2
+    echo "Files written inside the container will not appear on your filesystem." >&2
+    echo "Use a bind mount with a relative or absolute path:" >&2
+    echo "  docker run -v ./my-dir:/ddphotos ddphotos init" >&2
+    exit 1
+fi
+
 SCRIPT_ONLY=""
 while [ "${1#--}" != "$1" ]; do
     case "$1" in

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -25,15 +25,18 @@ if [ "$_named" = "true" ]; then
 fi
 
 SCRIPT_ONLY=""
+SITE_ID="my-photos"
 while [ "${1#--}" != "$1" ]; do
     case "$1" in
         --script-only) SCRIPT_ONLY=1; shift ;;
+        --site-id) SITE_ID="$2"; shift 2 ;;
         *)
             echo "Unknown option: $1" >&2
             echo "" >&2
-            echo "Usage: ddphotos init [--script-only]" >&2
+            echo "Usage: ddphotos init [--script-only] [--site-id ID]" >&2
             echo "" >&2
             echo "  --script-only    Install just the 'ddphotos' wrapper script, skip config scaffold" >&2
+            echo "  --site-id ID     Site ID written into albums.yaml (default: my-photos)" >&2
             exit 1
             ;;
     esac
@@ -64,8 +67,9 @@ fi
 
 mkdir -p "$CONFIG" /ddphotos/albums /ddphotos/build /ddphotos/export
 cp /docker/init/* "$CONFIG"
+sed -i "s/__SITE_ID__/$SITE_ID/g" "$CONFIG/albums.yaml"
 
-echo "Initialized ddphotos!"
+echo "Initialized ddphotos (site-id=$SITE_ID)!"
 echo
 echo "Next steps - generate, run, build and serve the example site:"
 echo

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -6,12 +6,27 @@ if [ ! -d "/ddphotos" ]; then
     exit 1
 fi
 
+SCRIPT_ONLY=""
+while [ "${1#--}" != "$1" ]; do
+    case "$1" in
+        --script-only) SCRIPT_ONLY=1; shift ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "" >&2
+            echo "Usage: ddphotos init [--script-only]" >&2
+            echo "" >&2
+            echo "  --script-only    Install just the 'ddphotos' wrapper script, skip config scaffold" >&2
+            exit 1
+            ;;
+    esac
+done
+
 # Always copy script
 cp /docker/ddphotos /ddphotos/ddphotos
 chmod +x /ddphotos/ddphotos
 
 # --script-only: install just the ddphotos wrapper script, skip config scaffold
-if [ "${1:-}" = "--script-only" ]; then
+if [ -n "$SCRIPT_ONLY" ]; then
     echo "Standalone 'ddphotos' script installed."
     echo
     echo "Usage with a separate albums directory:"

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -4,6 +4,12 @@ set -e
 SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 RUN_PORT="${RUN_PORT:-5173}"
 
+if [ $# -gt 0 ]; then
+    echo "Error: 'run' takes no arguments; got: $*" >&2
+    echo "Did you mean to pass options before the command? e.g.: ddphotos $* run" >&2
+    exit 1
+fi
+
 if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
     echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
     exit 1
@@ -26,5 +32,5 @@ cd /app/web
 set -m
 npm run dev -- --port "$RUN_PORT" &
 NPM_PID=$!
-trap "kill -- -$NPM_PID 2>/dev/null; exit 0" INT TERM
+trap 'kill -- -$NPM_PID 2>/dev/null; exit 0' INT TERM
 wait "$NPM_PID" || true

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 RUN_PORT="${RUN_PORT:-5173}"
 
 if [ $# -gt 0 ]; then

--- a/docker/do-search-cover.sh
+++ b/docker/do-search-cover.sh
@@ -2,6 +2,6 @@
 set -e
 
 export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
-export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 exec /app/bin/search-cover.sh --from-docker "$@"

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -4,6 +4,12 @@ set -e
 SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
 SERVE_PORT="${SERVE_PORT:-8000}"
 
+if [ $# -gt 0 ]; then
+    echo "Error: 'serve' takes no arguments; got: $*" >&2
+    echo "Did you mean to pass options before the command? e.g.: ddphotos $* serve" >&2
+    exit 1
+fi
+
 if [ ! -d "/ddphotos/build/$SITE_ID" ]; then
     echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first."
     exit 1

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SITE_ID="${DDPHOTOS_SITE_ID:-my-photos}"
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 SERVE_PORT="${SERVE_PORT:-8000}"
 
 if [ $# -gt 0 ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 set -e
-
 cmd="${1:-help}"
-shift 2>/dev/null || true
+if [ "$#" -gt 0 ]; then shift; fi
 
-# Verify the mounted ddphotos script matches the image (skip for init/upgrade/version)
-if [ "$cmd" != "init" ] && [ "$cmd" != "upgrade" ] && [ "$cmd" != "version" ]; then
-    if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
-        echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
-        echo "          Run: 'ddphotos upgrade' to fix this." >&2
-        echo "" >&2
-    fi
-fi
+# Verify the mounted ddphotos script matches the image (only for commands that use it)
+case "$cmd" in
+    photogen|decode|search-cover|build|serve|run|export|deploy)
+        if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
+            echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
+            echo "          Run: 'ddphotos upgrade' to fix this." >&2
+            echo "" >&2
+        fi
+        ;;
+esac
 
 case "$cmd" in
     init)         exec /docker/do-init.sh "$@" ;;
@@ -39,12 +40,15 @@ case "$cmd" in
             echo "The 'ddphotos' script was upgraded ($VERSION)."
         fi
         ;;
-    *)
-        echo "Unknown command: '$cmd'" >&2
-        echo >&2
-        echo "This image is intended to be used via the 'ddphotos' wrapper script." >&2
-        echo "See: https://github.com/dougdonohoe/ddphotos" >&2
-        echo >&2
-        exit 1
+    help|*)
+        [ "$cmd" != "help" ] && { echo "Unknown command: '$cmd'" >&2; echo >&2; }
+        echo "Usage: ddphotos [OPTIONS] COMMAND"
+        echo ""
+        echo "Commands: init, photogen, decode, search-cover, build, serve, run, export, deploy, upgrade, version"
+        echo ""
+        echo "This image is intended to be used via the 'ddphotos' wrapper script."
+        echo "See: https://github.com/dougdonohoe/ddphotos"
+        echo ""
+        [ "$cmd" = "help" ] || exit 1
         ;;
 esac

--- a/docker/init/albums.yaml
+++ b/docker/init/albums.yaml
@@ -25,7 +25,7 @@
 #   ./ddphotos serve
 
 settings:
-  id: my-photos
+  id: __SITE_ID__
   site_name: My Photos
   site_url: https://photos.yourdomain.com
   site_description: My personal photo gallery

--- a/docker/init/albums.yaml
+++ b/docker/init/albums.yaml
@@ -1,5 +1,8 @@
 # ddphotos configuration
-# See https://github.com/dougdonohoe/ddphotos for full documentation.
+#
+# See https://github.com/dougdonohoe/ddphotos/blob/main/docs/DOCKER.md for full documentation.
+# See https://github.com/dougdonohoe/ddphotos/blob/main/config/albums.example.yaml for
+#     specification of this file.
 #
 # Define bases pointing to where your source photos live. The ddphotos wrapper
 # script reads these paths and mounts them automatically into Docker.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -146,9 +146,17 @@ Creates the config scaffold and installs the `ddphotos` wrapper script.
 # Full init (script + config)
 docker run --rm -v ~/my-ddphotos:/ddphotos dougdonohoe/ddphotos init
 
+# Set a custom site ID (written into config/albums.yaml; default: my-photos)
+docker run --rm -v ~/my-ddphotos:/ddphotos dougdonohoe/ddphotos init --site-id my-site
+
 # Script only (no config scaffold)
 docker run --rm -v ~/.local/bin:/ddphotos dougdonohoe/ddphotos init --script-only
 ```
+
+| Flag            | Description                                                                       |
+|-----------------|-----------------------------------------------------------------------------------|
+| `--site-id ID`  | Site ID written into `config/albums.yaml` as `settings.id` (default: `my-photos`) |
+| `--script-only` | Install just the `ddphotos` wrapper script; skip config scaffold                  |
 
 ### `photogen`
 

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -52,3 +52,6 @@ as defined in `config/defaults.env`.
 | `docker-build`                | Build the `ddphotos` Docker image locally (single-arch)                                       |
 | `docker-push`                 | Build multi-arch image and push to Docker Hub (`bin/docker-push.sh`)                          |
 | `docker-test`                 | Build the `ddphotos` image and run end-to-end Docker workflow tests (`bin/docker-test.sh`)    |
+| `ddphotos-install-dev`        | Install `ddphotos` script from local dev image into `~/.local/bin`                            |
+| `ddphotos-install-prod`       | Install `ddphotos` script from `dougdonohoe/ddphotos:latest` into `~/.local/bin`              |
+| `ddphotos-patch`              | Copy `docker/ddphotos` to `~/.local/bin`, preserving the `IMAGE=` line from the installed one |

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -25,19 +25,11 @@ ddphotos photogen                         # Docker mode (default flags: -resize 
 bin/photogen -resize -index -clean -doit  # developer mode
 ```
 
-To use a different albums file (e.g., a development subset):
-
-```bash
-ddphotos photogen -- -albums albums-dev.yaml   # Docker mode
-bin/photogen -albums albums-dev.yaml           # developer mode
-```
-
 ## CLI Flags
 
 | Flag          | Default       | Description                                                                                                                          |
 |---------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `-config-dir` | `config`      | Directory containing the albums YAML and descriptions files                                                                          |
-| `-albums`     | `albums.yaml` | Albums YAML filename within `-config-dir`                                                                                            |
 | `-doit`       | `false`       | Write files; without this, runs in dry-run mode                                                                                      |
 | `-resize`     | `false`       | Generate resized WebP image variants                                                                                                 |
 | `-index`      | `false`       | Generate JSON index files and sitemap.xml                                                                                            |

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1721,3 +1721,78 @@ decisions:
 - **wrangler/surge run from site dir** — both tools are invoked via a subshell `cd` into
   the site directory with a relative export path, so they don't detect the repo as a git
   working directory and attach branch names to deployments.
+
+### 71. 05/05/2026 - Docker Robustness: Error Handling, Configurable Site ID, Remove `-albums`
+
+#### Motivation
+
+A cluster of hardening changes across the Docker tooling: clearer error messages when
+commands are misused, a proper `--site-id` flag for `init` so the default site ID isn't
+forever hardcoded to `my-photos`, and removal of the `-albums` photogen flag that had
+become a source of subtle site-id mismatches.
+
+#### Error Messages and Usage Text
+
+Several Docker entry-point scripts previously printed terse or misleading error output
+when given unexpected arguments. This pass made them consistent:
+
+- **`docker/do-build.sh`**, **`do-run.sh`**, **`do-serve.sh`** — added argument guards
+  (`Error: 'build' takes no arguments; got: ...`) with a hint about pre-command options
+- **`docker/do-export.sh`** — expanded the unknown-flag error into a full usage block
+- **`bin/deploy-photos.sh`** — same: replaced bare `exit 1` with a full usage block
+- **`bin/search-cover.sh`** — usage message now varies by context: `ddphotos search-cover`
+  when invoked from Docker, `bin/search-cover.sh` otherwise
+- **`docker/ddphotos`** — unknown pre-command options now exit with a message instead of
+  silently breaking; `albums.yaml`-missing error message is more specific about which path
+  to use; `decode` and `search-cover` were removed from the "skip config check" list so
+  they also validate that albums.yaml exists before launching Docker
+- **`docker/entrypoint.sh`** — unknown commands now show a short usage summary instead of
+  pointing to GitHub; `help` is a recognised command; stale-version check uses `sort -V`
+  so the upgrade file is cleared correctly when already at or past the stored version
+
+#### `init --site-id`
+
+Previously `init` always wrote `id: my-photos` into `config/albums.yaml`, and
+`my-photos` was the hardcoded fallback throughout every `do-*.sh` script. This was
+wrong for anyone who wanted a different site ID from the start.
+
+- **`docker/init/albums.yaml`** — `settings.id` changed to placeholder `__SITE_ID__`
+- **`docker/do-init.sh`** — added `--site-id ID` flag (default `my-photos`); `sed`
+  replaces `__SITE_ID__` in the generated `albums.yaml` at init time; also added named-
+  volume detection (errors out if `/ddphotos` is a Docker named volume rather than a
+  bind mount, since written files would be invisible on the host)
+- **`docker/ddphotos`** — removed the `:-my-photos` final fallback after the awk
+  `settings.id` auto-detection block; the outer script now propagates whatever the YAML
+  says, and if it's empty the inner scripts surface `site-id-undefined` rather than
+  silently using the wrong path
+- **`docker/do-build/run/serve/deploy/export/search-cover.sh`** — `:-my-photos`
+  fallbacks changed to `:-site-id-undefined` so misconfiguration is visible
+- **`docs/DOCKER.md`** — `init` section now documents both `--site-id` and `--script-only`
+  in a flag table with an example
+- **`bin/docker-test.sh`** — `SITE_ID` is now `docker-test-id` (not `my-photos`);
+  `init` receives `--site-id "$SITE_ID"`; after init, `VALIDATE_SITE_ID` is parsed from
+  `albums.yaml` and asserted equal to `SITE_ID` to confirm the substitution worked
+
+#### Remove `-albums` Flag from `photogen`
+
+The `-albums` flag allowed specifying an alternate YAML filename within the config dir.
+It was a development convenience and had a subtle correctness problem: when a non-default
+file was used, the outer `ddphotos` script would still auto-detect `settings.id` from
+the default `albums.yaml` and pass it as `-site-id`, silently overriding whatever ID the
+alternate file defined. Since `--config-dir` already covers legitimate multi-config
+scenarios, the flag was removed.
+
+- **`cmd/photogen/photogen.go`** — `albumsFile` flag removed; `LoadAlbumConfigs` now
+  always receives `"albums.yaml"`
+- **`docs/PHOTOGEN.md`** — usage example and table row for `-albums` removed
+
+#### Developer Make Targets
+
+Three new targets were added to `Makefile` for managing a locally installed `ddphotos`
+script, documented in `docs/MAKEFILE.md`:
+
+- `ddphotos-install-dev` — install from the local dev image into `~/.local/bin`
+- `ddphotos-install-prod` — install from `dougdonohoe/ddphotos:latest`
+- `ddphotos-patch` — copy `docker/ddphotos` to `~/.local/bin` while preserving the
+  `IMAGE=` line from the currently installed script (useful when iterating on the script
+  without a full image rebuild)


### PR DESCRIPTION
## Summary

- **Better error messages** across Docker entry-point scripts (`build`, `run`, `serve`, `export`, `deploy-photos.sh`, `search-cover.sh`, `entrypoint.sh`, `ddphotos`): unknown args/flags now print context-aware usage text instead of bare `exit 1` or silent breaks
- **`init --site-id ID`**: `init` now accepts a `--site-id` flag (default: `my-photos`) and writes it into `config/albums.yaml` via a `__SITE_ID__` placeholder; inner scripts fall back to `site-id-undefined` instead of `my-photos` so misconfiguration is visible rather than silent
- **Remove `-albums` flag from `photogen`**: it was a dev-only convenience with a correctness bug (outer script would auto-detect site ID from the wrong YAML file); `--config-dir` covers legitimate multi-config scenarios
- **Developer make targets**: `ddphotos-install-dev`, `ddphotos-install-prod`, `ddphotos-patch` for managing a locally installed `ddphotos` script

## Details

### Error handling
- `do-build.sh`, `do-run.sh`, `do-serve.sh`: argument guards with hint about pre-command options
- `do-export.sh`, `deploy-photos.sh`: bare `exit 1` replaced with full usage blocks
- `search-cover.sh`: usage varies by invocation context (Docker vs. direct)
- `ddphotos`: unknown pre-command options now exit with a message; missing-config error is more specific; `decode`/`search-cover` now validate `albums.yaml` exists before launching Docker; stale-version check uses `sort -V` so upgrade file clears correctly
- `entrypoint.sh`: unknown commands show a usage summary; `help` is a recognised command

### Site ID
- `docker/init/albums.yaml`: `settings.id` is now `__SITE_ID__` placeholder
- `do-init.sh`: parses `--site-id`, `sed`-substitutes the placeholder, detects named-volume mounts and errors out
- `docker/ddphotos`: removed `:-my-photos` final fallback (awk auto-detection remains)
- All `do-*.sh` scripts: `:-my-photos` → `:-site-id-undefined`
- `docs/DOCKER.md`: `init` section documents flags in a table
- `docker-test.sh`: uses `SITE_ID=docker-test-id`, passes to init, validates via `VALIDATE_SITE_ID` parse of generated `albums.yaml`

### Remove `-albums`
- `cmd/photogen/photogen.go`: flag removed, `LoadAlbumConfigs` hardcoded to `"albums.yaml"`
- `docs/PHOTOGEN.md`: usage example and table row removed

## Test plan
- [x] `make docker-test` passes with `docker-test-id` flowing end-to-end
- [x] `make build test vet` passes