### PR TITLE
Docker scripts refactoring and cleanup

### DIFF
--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -156,7 +156,25 @@ out=$("${DDPHOTOS_QUIET[@]}" help 2>&1)
 echo "$out" | grep -q "photogen" || fail "help: missing expected content"
 pass "help exits 0 and shows usage"
 
-# ── 4. Photogen ────────────────────────────────────────────────────────────────
+# ── 4. Pre-photogen error checks ───────────────────────────────────────────────
+step "Error handling: build/run/export/deploy fail before photogen"
+out=$("${DDPHOTOS_QUIET[@]}" build 2>&1) || true
+echo "$out" | grep -q "Run 'photogen' first" || fail "build: expected 'Run photogen first' error when albums dir missing"
+pass "build: fails correctly when albums dir missing"
+
+out=$("${DDPHOTOS_QUIET[@]}" run 2>&1) || true
+echo "$out" | grep -q "Run 'photogen' first" || fail "run: expected 'Run photogen first' error when albums dir missing"
+pass "run: fails correctly when albums dir missing"
+
+out=$("${DDPHOTOS_QUIET[@]}" export 2>&1) || true
+echo "$out" | grep -q "Run 'photogen' first" || fail "export: expected 'Run photogen first' error when albums dir missing"
+pass "export: fails correctly when albums dir missing"
+
+out=$("${DDPHOTOS_QUIET[@]}" deploy 2>&1) || true
+echo "$out" | grep -q "Run 'photogen' first" || fail "deploy: expected 'Run photogen first' error when albums dir missing"
+pass "deploy: fails correctly when albums dir missing"
+
+# ── 5. Photogen ────────────────────────────────────────────────────────────────
 step "Photogen"
 "${DDPHOTOS[@]}" photogen
 [ -d "$TEST_DIR/albums/$SITE_ID" ] || fail "albums/$SITE_ID not created"
@@ -247,7 +265,21 @@ run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
 kill "$RUN_PID" 2>/dev/null || true; wait "$RUN_PID" 2>/dev/null || true; RUN_PID=""
 pass "run + Playwright OK"
 
-# ── 8. Build ───────────────────────────────────────────────────────────────────
+# ── 8. Pre-build error checks ──────────────────────────────────────────────────
+step "Error handling: serve/export/deploy fail before build"
+out=$("${DDPHOTOS_QUIET[@]}" serve 2>&1) || true
+echo "$out" | grep -q "Run 'build' first" || fail "serve: expected 'Run build first' error when build dir missing"
+pass "serve: fails correctly when build dir missing"
+
+out=$("${DDPHOTOS_QUIET[@]}" export 2>&1) || true
+echo "$out" | grep -q "Run 'build' first" || fail "export: expected 'Run build first' error when build dir missing"
+pass "export: fails correctly when build dir missing"
+
+out=$("${DDPHOTOS_QUIET[@]}" deploy 2>&1) || true
+echo "$out" | grep -q "Run 'build' first" || fail "deploy: expected 'Run build first' error when build dir missing"
+pass "deploy: fails correctly when build dir missing"
+
+# ── 9. Build ───────────────────────────────────────────────────────────────────
 step "Build"
 "${DDPHOTOS[@]}" build
 [ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -267,7 +267,7 @@ pass "run + Playwright OK"
 
 # ── 10. Pre-build error checks ─────────────────────────────────────────────────
 step "Error handling: serve/export/deploy fail before build"
-out=$("${DDPHOTOS_QUIET[@]}" serve 2>&1) || true
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive serve 2>&1) || true
 echo "$out" | grep -q "Run 'build' first" || fail "serve: expected 'Run build first' error when build dir missing"
 pass "serve: fails correctly when build dir missing"
 

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -162,7 +162,7 @@ out=$("${DDPHOTOS_QUIET[@]}" build 2>&1) || true
 echo "$out" | grep -q "Run 'photogen' first" || fail "build: expected 'Run photogen first' error when albums dir missing"
 pass "build: fails correctly when albums dir missing"
 
-out=$("${DDPHOTOS_QUIET[@]}" run 2>&1) || true
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive run 2>&1) || true
 echo "$out" | grep -q "Run 'photogen' first" || fail "run: expected 'Run photogen first' error when albums dir missing"
 pass "run: fails correctly when albums dir missing"
 
@@ -181,7 +181,7 @@ step "Photogen"
 ALBUM_COUNT=$(find "$TEST_DIR/albums/$SITE_ID" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
 pass "albums/$SITE_ID created ($ALBUM_COUNT albums)"
 
-# ── 4. Decode ──────────────────────────────────────────────────────────────────
+# ── 6. Decode ──────────────────────────────────────────────────────────────────
 step "Decode"
 ENC_FILE="albums/$SITE_ID/secret/index.enc.json"
 [ -f "$TEST_DIR/$ENC_FILE" ] || fail "$ENC_FILE not found after photogen"
@@ -211,7 +211,7 @@ decoded=$("${DDPHOTOS[@]}" decode "$TEMP_DECODE_DIR/secret/index.enc.json")
 echo "$decoded" | grep -q '"photos"' || fail "decode (external pwFile): decoded output missing 'photos' key"
 pass "decode: both enc.json and pwFile outside DDPHOTOS_DIR OK"
 
-# ── 5. Search-Cover ────────────────────────────────────────────────────────────
+# ── 7. Search-Cover ────────────────────────────────────────────────────────────
 step "Search-Cover"
 # Derive the URL from the decoded index so we don't hardcode the UUID.
 SC_DECODED=$("${DDPHOTOS_QUIET[@]}" decode "$ENC_FILE")
@@ -221,7 +221,7 @@ SC_OUT=$("${DDPHOTOS[@]}" search-cover "$SC_URL")
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover: found cover file for secret album"
 
-# ── 6. Decode + Search-Cover with external --config-dir ───────────────────────
+# ── 8. Decode + Search-Cover with external --config-dir ───────────────────────
 # Regression test for: decode and search-cover failing to mount the config dir
 # when --config-dir points outside DDPHOTOS_DIR.
 #
@@ -256,7 +256,7 @@ SC_OUT=$("${DDPHOTOS[@]}" --dir "$SC_TEST_DIR" --config-dir "$EXT_CONFIG_DIR" se
 echo "$SC_OUT" | grep -q "cover: 2024-The-Way-21.jpg" || fail "search-cover --config-dir: 'cover: 2024-The-Way-21.jpg' not in output"
 pass "search-cover --config-dir: external config dir mounted correctly"
 
-# ── 7. Run (Vite dev server) + Playwright ─────────────────────────────────────
+# ── 9. Run (Vite dev server) + Playwright ─────────────────────────────────────
 step "Run — Vite dev server on port $RUN_PORT"
 RUN_PORT="$RUN_PORT" "${DDPHOTOS[@]}" --non-interactive run &
 RUN_PID=$!
@@ -265,7 +265,7 @@ run_playwright "http://localhost:$RUN_PORT" "$PASSWORDS_FILE"
 kill "$RUN_PID" 2>/dev/null || true; wait "$RUN_PID" 2>/dev/null || true; RUN_PID=""
 pass "run + Playwright OK"
 
-# ── 8. Pre-build error checks ──────────────────────────────────────────────────
+# ── 10. Pre-build error checks ─────────────────────────────────────────────────
 step "Error handling: serve/export/deploy fail before build"
 out=$("${DDPHOTOS_QUIET[@]}" serve 2>&1) || true
 echo "$out" | grep -q "Run 'build' first" || fail "serve: expected 'Run build first' error when build dir missing"
@@ -279,13 +279,13 @@ out=$("${DDPHOTOS_QUIET[@]}" deploy 2>&1) || true
 echo "$out" | grep -q "Run 'build' first" || fail "deploy: expected 'Run build first' error when build dir missing"
 pass "deploy: fails correctly when build dir missing"
 
-# ── 9. Build ───────────────────────────────────────────────────────────────────
+# ── 11. Build ──────────────────────────────────────────────────────────────────
 step "Build"
 "${DDPHOTOS[@]}" build
 [ -d "$TEST_DIR/build/$SITE_ID" ] || fail "build/$SITE_ID not created"
 pass "build/$SITE_ID created"
 
-# ── 9. Serve (Apache) + Playwright + test-photos-server.sh ────────────────────
+# ── 12. Serve (Apache) + Playwright + test-photos-server.sh ───────────────────
 step "Serve — Apache on port $SERVE_PORT"
 SERVE_PORT="$SERVE_PORT" "${DDPHOTOS[@]}" --non-interactive serve &
 SERVE_PID=$!
@@ -296,7 +296,7 @@ run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
 pass "serve + Playwright + test-photos-server.sh OK"
 
-# ── 10. Export (symlink mode) ──────────────────────────────────────────────────
+# ── 13. Export (symlink mode) ──────────────────────────────────────────────────
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Export (symlinks)"
@@ -332,7 +332,7 @@ step "Export --cloudflare"
 grep -q "ASSETS.fetch" "$EXPORT_DIR/_worker.js" || fail "_worker.js missing ASSETS.fetch"
 pass "export --cloudflare OK (_worker.js present)"
 
-# ── 11. Version ────────────────────────────────────────────────────────────────
+# ── 14. Version ────────────────────────────────────────────────────────────────
 step "Version"
 version_out=$("${DDPHOTOS[@]}" version)
 echo "$version_out"
@@ -349,7 +349,7 @@ pass "version --image: Script path OK, Git: and Version: dev present"
 echo "$version_out" | grep -q "Site ID:.*$SITE_ID" || fail "version: Site ID does not show $SITE_ID"
 pass "version: Site ID '$SITE_ID' auto-detected from albums.yaml"
 
-# ── 12. Init --script-only ─────────────────────────────────────────────────────
+# ── 15. Init --script-only ─────────────────────────────────────────────────────
 step "Init --script-only"
 TEST_DIR2=$(mktemp -d)
 chmod 755 "$TEST_DIR2"
@@ -359,7 +359,7 @@ docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ ! -d "$TEST_DIR2/albums" ]   || fail "--script-only should not create albums/"
 pass "init --script-only OK (only ddphotos script installed)"
 
-# ── 13. Skip ──────────────────────────────────────────────────────
+# ── 16. Skip ──────────────────────────────────────────────────────
 # Note: decided to skip tests for deploy (s3/rsync) due to complexity
 #       of setup.  S3 works (it is actively used by yours truly). I have faith
 #       in rsync code, but if someone reports problems we can revisit it.

--- a/bin/export.sh
+++ b/bin/export.sh
@@ -3,11 +3,10 @@
 set -eo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-
-SITE_ID="${DDPHOTOS_SITE_ID:-$(sed -n 's/^DDPHOTOS_SITE_ID=//p' "$REPO_ROOT/config/defaults.env")}"
 BUILD_DIR="$REPO_ROOT/build"
 ALBUMS_DIR="$REPO_ROOT/albums"
 
+SITE_ID="${DDPHOTOS_SITE_ID:-$(sed -n 's/^DDPHOTOS_SITE_ID=//p' "$REPO_ROOT/config/defaults.env")}"
 COPY=""
 CLOUDFLARE=""
 EXPORT_SITE_ID=""
@@ -26,6 +25,7 @@ done
 
 SITE_ID="${SITE_ID:-sample}"
 EXPORT_SITE_ID="${EXPORT_SITE_ID:-$SITE_ID}"
+EXPORT_DIR="$REPO_ROOT/export/$EXPORT_SITE_ID"
 
 if [ ! -d "$ALBUMS_DIR/$SITE_ID" ]; then
     echo "Error: $ALBUMS_DIR/$SITE_ID not found." >&2
@@ -42,8 +42,6 @@ if [ ! -d "$BUILD_DIR/$SITE_ID" ]; then
     fi
     exit 1
 fi
-
-EXPORT_DIR="$REPO_ROOT/export/$EXPORT_SITE_ID"
 
 if [ -n "$COPY" ]; then
     LINK_DIR=$(mktemp -d)

--- a/bin/export.sh
+++ b/bin/export.sh
@@ -19,7 +19,19 @@ while [[ "${1:-}" == --* ]]; do
         --export-site-id)   EXPORT_SITE_ID="$2";   shift 2 ;;
         --build-dir)        BUILD_DIR="$2";        shift 2 ;;
         --albums-dir)       ALBUMS_DIR="$2";       shift 2 ;;
-        *) echo "Unknown option: $1" >&2; exit 1 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "" >&2
+            echo "Usage: export.sh [--copy] [--cloudflare] [--site-id ID] [--export-site-id ID] [--build-dir DIR] [--albums-dir DIR]" >&2
+            echo "" >&2
+            echo "  --copy                 Resolve symlinks (required for static hosting)" >&2
+            echo "  --cloudflare           Add _worker.js for Cloudflare Pages photo permalinks" >&2
+            echo "  --site-id ID           Site ID to export (default: \$DDPHOTOS_SITE_ID or 'sample')" >&2
+            echo "  --export-site-id ID    Use export/ID/ as destination instead of export/<site-id>/" >&2
+            echo "  --build-dir DIR        Build directory (default: <repo>/build)" >&2
+            echo "  --albums-dir DIR       Albums directory (default: <repo>/albums)" >&2
+            exit 1
+            ;;
     esac
 done
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,6 +106,8 @@ ARG DDPHOTOS_IMAGE=ddphotos
 RUN echo "$DDPHOTOS_IMAGE" > /docker/IMAGE \
     && sed -i "s|^IMAGE=\"ddphotos\"|IMAGE=\"$DDPHOTOS_IMAGE\"|" /docker/ddphotos
 
+ENV DDPHOTOS_ALBUMS_DIR=/ddphotos/albums
+
 EXPOSE 80
 
 ENTRYPOINT ["/docker/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,12 +101,17 @@ RUN echo "$DDPHOTOS_VERSION" > /docker/VERSION
 
 ARG DDPHOTOS_GIT_DESCRIBE=unknown
 RUN echo "$DDPHOTOS_GIT_DESCRIBE" > /docker/GIT_DESCRIBE
+ENV VITE_GIT_DESCRIBE=$DDPHOTOS_GIT_DESCRIBE
 
 ARG DDPHOTOS_IMAGE=ddphotos
 RUN echo "$DDPHOTOS_IMAGE" > /docker/IMAGE \
     && sed -i "s|^IMAGE=\"ddphotos\"|IMAGE=\"$DDPHOTOS_IMAGE\"|" /docker/ddphotos
+ENV VITE_DOCKER_IMAGE=$DDPHOTOS_IMAGE
 
-ENV DDPHOTOS_ALBUMS_DIR=/ddphotos/albums
+ENV DDPHOTOS_ALBUMS_DIR=/ddphotos/albums \
+    VITE_GIT_BRANCH="" \
+    VITE_GIT_REPO_SLUG=dougdonohoe/ddphotos \
+    VITE_GIT_REPO_URL=https://github.com/dougdonohoe/ddphotos
 
 EXPOSE 80
 

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -1,14 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 set -e
-
-export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
-export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
-
-export VITE_GIT_DESCRIBE=$(cat /docker/GIT_DESCRIBE 2>/dev/null || echo "unknown")
-export VITE_DOCKER_IMAGE=$(cat /docker/IMAGE 2>/dev/null || echo "")
-export VITE_GIT_BRANCH=""
-export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
-export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
 if [ $# -gt 0 ]; then
     echo "Error: 'build' takes no arguments; got: $*" >&2
@@ -16,12 +7,31 @@ if [ $# -gt 0 ]; then
     exit 1
 fi
 
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
+
+if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
+    echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
+    exit 1
+fi
+
+export VITE_GIT_DESCRIBE=$(cat /docker/GIT_DESCRIBE 2>/dev/null || echo "unknown")
+export VITE_DOCKER_IMAGE=$(cat /docker/IMAGE 2>/dev/null || echo "")
+export VITE_GIT_BRANCH=""
+export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
+export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
+
+export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
+export DDPHOTOS_SITE_ID="$SITE_ID"
+
+# npm commands run from web dir
+cd /app/web
+
+# Ensure build dir exists
 mkdir -p /ddphotos/build
 
-# svelte.config.js writes to ../build/$SITE_ID relative to web/; redirect to /ddphotos/build
+# svelte.config.js (from /app/web) writes to ../build/$SITE_ID; redirect /app/build => /ddphotos/build
 ln -sfn /ddphotos/build /app/build
 
 echo "Building $DDPHOTOS_SITE_ID ..."
 
-cd /app/web
 exec npm run build

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -14,12 +14,6 @@ if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
     exit 1
 fi
 
-export VITE_GIT_DESCRIBE=$(cat /docker/GIT_DESCRIBE 2>/dev/null || echo "unknown")
-export VITE_DOCKER_IMAGE=$(cat /docker/IMAGE 2>/dev/null || echo "")
-export VITE_GIT_BRANCH=""
-export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
-export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
-
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
 # npm commands run from web dir

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -20,7 +20,6 @@ export VITE_GIT_BRANCH=""
 export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
 export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
-export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
 # npm commands run from web dir

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -9,8 +9,8 @@ fi
 
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
-if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
-    echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
+if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
     exit 1
 fi
 

--- a/docker/do-decode.sh
+++ b/docker/do-decode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd /ddphotos
 exec /usr/local/bin/decode "$@"

--- a/docker/do-deploy.sh
+++ b/docker/do-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"

--- a/docker/do-deploy.sh
+++ b/docker/do-deploy.sh
@@ -20,7 +20,7 @@ case " $* " in
     *) [ -n "${S3_BUCKET:-}" ] && set -- --s3 "$@" ;;
 esac
 
-ALBUMS_CONFIG="/ddphotos/albums/$SITE_ID/config.json"
+ALBUMS_CONFIG="$DDPHOTOS_ALBUMS_DIR/$SITE_ID/config.json"
 BUILD_INDEX="/ddphotos/build/$SITE_ID/index.html"
 
 if [ ! -f "$ALBUMS_CONFIG" ]; then

--- a/docker/do-deploy.sh
+++ b/docker/do-deploy.sh
@@ -44,7 +44,6 @@ if [ -n "$(find "$ALBUMS_CONFIG" -newer "$BUILD_INDEX" 2>/dev/null)" ]; then
 fi
 
 export REPO_ROOT="/ddphotos"
-export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
 echo "Deploying: $SITE_ID"

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -26,8 +26,8 @@ done
 
 EXPORT_DIR="/ddphotos/export/$EXPORT_SITE_ID"
 
-if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
-    echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
+if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
     exit 1
 fi
 
@@ -40,7 +40,7 @@ if [ -n "$COPY" ]; then
     LINK_DIR=$(mktemp -d)
     RELATIVE_LINKS=1 \
     BUILD_ROOT=/ddphotos/build \
-    ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
+    ALBUMS_DIR=$DDPHOTOS_ALBUMS_DIR/$SITE_ID \
     DDPHOTOS_SITE_ID=$SITE_ID \
     /docker/setup-htdocs.sh "$LINK_DIR"
     mkdir -p "$EXPORT_DIR"
@@ -51,7 +51,7 @@ else
     mkdir -p "$EXPORT_DIR"
     RELATIVE_LINKS=1 \
     BUILD_ROOT=/ddphotos/build \
-    ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
+    ALBUMS_DIR=$DDPHOTOS_ALBUMS_DIR/$SITE_ID \
     DDPHOTOS_SITE_ID=$SITE_ID \
     /docker/setup-htdocs.sh "$EXPORT_DIR"
 fi

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -6,7 +6,7 @@ COPY=""
 CLOUDFLARE=""
 EXPORT_SITE_ID="$SITE_ID"
 
-while [ "${1#--}" != "$1" ]; do
+while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --copy)             COPY=1;                shift ;;
         --cloudflare)       CLOUDFLARE=1;          shift ;;

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -26,7 +26,7 @@ fi
 
 SCRIPT_ONLY=""
 SITE_ID="my-photos"
-while [ "${1#--}" != "$1" ]; do
+while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --script-only) SCRIPT_ONLY=1; shift ;;
         --site-id) SITE_ID="$2"; shift 2 ;;

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -65,7 +65,7 @@ if [ -f "$CONFIG/albums.yaml" ]; then
     exit 1
 fi
 
-mkdir -p "$CONFIG" /ddphotos/albums /ddphotos/build /ddphotos/export
+mkdir -p "$CONFIG" "$DDPHOTOS_ALBUMS_DIR" /ddphotos/build /ddphotos/export
 cp /docker/init/* "$CONFIG"
 sed -i "s/__SITE_ID__/$SITE_ID/g" "$CONFIG/albums.yaml"
 

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 if [ ! -d "/ddphotos" ]; then

--- a/docker/do-photogen.sh
+++ b/docker/do-photogen.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
-
 # Relative base paths in albums.yaml are anchored to cwd; cd to the album dir so they resolve correctly.
 cd /ddphotos
 

--- a/docker/do-photogen.sh
+++ b/docker/do-photogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -14,12 +14,6 @@ if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
     exit 1
 fi
 
-export VITE_GIT_DESCRIBE=$(cat /docker/GIT_DESCRIBE 2>/dev/null || echo "unknown")
-export VITE_DOCKER_IMAGE=$(cat /docker/IMAGE 2>/dev/null || echo "")
-export VITE_GIT_BRANCH=""
-export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
-export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
-
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
 # npm commands run from web dir

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -20,7 +20,6 @@ export VITE_GIT_BRANCH=""
 export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
 export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
-export DDPHOTOS_ALBUMS_DIR=/ddphotos/albums
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
 # npm commands run from web dir

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 set -e
 
-SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
-RUN_PORT="${RUN_PORT:-5173}"
-
 if [ $# -gt 0 ]; then
     echo "Error: 'run' takes no arguments; got: $*" >&2
     echo "Did you mean to pass options before the command? e.g.: ddphotos $* run" >&2
     exit 1
 fi
+
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
     echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
@@ -21,11 +20,14 @@ export VITE_GIT_BRANCH=""
 export VITE_GIT_REPO_SLUG="dougdonohoe/ddphotos"
 export VITE_GIT_REPO_URL="https://github.com/dougdonohoe/ddphotos"
 
-echo "  Dev server for $SITE_ID at:   http://localhost:${RUN_PORT}"
-
 export DDPHOTOS_ALBUMS_DIR=/ddphotos/albums
 export DDPHOTOS_SITE_ID="$SITE_ID"
+
+# npm commands run from web dir
 cd /app/web
+
+RUN_PORT="${RUN_PORT:-5173}"
+echo "  Running dev server for $SITE_ID at: http://localhost:${RUN_PORT}"
 
 # set -m puts background jobs in their own process group, so Ctrl-C (SIGINT) goes
 # only to this shell — not npm — letting us kill it cleanly without npm's error output.

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -9,8 +9,8 @@ fi
 
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
-if [ ! -d "/ddphotos/albums/$SITE_ID" ]; then
-    echo "Error: /ddphotos/albums/$SITE_ID not found. Run 'photogen' first."
+if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
     exit 1
 fi
 

--- a/docker/do-search-cover.sh
+++ b/docker/do-search-cover.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"
 export DDPHOTOS_SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 exec /app/bin/search-cover.sh --from-docker "$@"

--- a/docker/do-search-cover.sh
+++ b/docker/do-search-cover.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 export DDPHOTOS_ALBUMS_DIR="/ddphotos/albums"

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -1,8 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 set -e
-
-SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
-SERVE_PORT="${SERVE_PORT:-8000}"
 
 if [ $# -gt 0 ]; then
     echo "Error: 'serve' takes no arguments; got: $*" >&2
@@ -10,17 +7,21 @@ if [ $# -gt 0 ]; then
     exit 1
 fi
 
+SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
+
 if [ ! -d "/ddphotos/build/$SITE_ID" ]; then
     echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first."
     exit 1
 fi
 
+# setup htdocs symlinks in for Apache to serve
 BUILD_ROOT=/ddphotos/build \
-ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
-DDPHOTOS_SITE_ID=$SITE_ID \
-/docker/setup-htdocs.sh /htdocs
+  ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
+  DDPHOTOS_SITE_ID=$SITE_ID \
+  /docker/setup-htdocs.sh /htdocs
 
-echo "  Serving $SITE_ID at:   http://localhost:${SERVE_PORT}"
+SERVE_PORT="${SERVE_PORT:-8000}"
+echo "  Serving $SITE_ID at: http://localhost:${SERVE_PORT}"
 echo ""
 
 . /etc/apache2/envvars

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -16,7 +16,7 @@ fi
 
 # setup htdocs symlinks in for Apache to serve
 BUILD_ROOT=/ddphotos/build \
-  ALBUMS_DIR=/ddphotos/albums/$SITE_ID \
+  ALBUMS_DIR=$DDPHOTOS_ALBUMS_DIR/$SITE_ID \
   DDPHOTOS_SITE_ID=$SITE_ID \
   /docker/setup-htdocs.sh /htdocs
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cmd="${1:-help}"
 if [ "$#" -gt 0 ]; then shift; fi


### PR DESCRIPTION
## Summary

- Switch all `docker/*.sh` scripts from `#!/bin/sh` to `#!/bin/bash` for consistency (already required for `trap` in `do-run.sh`)
- Move `DDPHOTOS_ALBUMS_DIR`, `VITE_GIT_DESCRIBE`, `VITE_DOCKER_IMAGE`, and three static `VITE_*` vars from per-script `export` statements into the Dockerfile as `ENV` — single source of truth, no redundancy
- Replace all remaining hardcoded `/ddphotos/albums` paths in `docker/*.sh` with `$DDPHOTOS_ALBUMS_DIR`
- Add pre-flight checks to `do-build.sh` (albums dir exists) to match the existing checks in `do-run.sh`, `do-serve.sh`, `do-export.sh`, and `do-deploy.sh`; reorder statements for consistency across scripts
- Add docker-test.sh coverage for pre-photogen and pre-build error checks (build/run/export/deploy before photogen; serve/export/deploy before build); fix `run` test to pass `--non-interactive` to avoid TTY allocation failure
- Fix arg-parsing loops in `do-init.sh` and `do-export.sh` to use bash-style `[[ "${1:-}" == --* ]]` instead of POSIX `[ "${1#--}" != "$1" ]`
- Add full usage block to `bin/export.sh` for unknown options, documenting all six flags including `--site-id`, `--build-dir`, and `--albums-dir` not present in `do-export.sh`