### PR TITLE
Fix privacy scroll test against dev server; add --test flag to run-tests.sh

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -2,7 +2,7 @@
 # Run Playwright tests against one variant of the sample site.
 #
 # Usage:
-#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|all] [--ci]
+#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--mode dev|apache|nginx|all] [--test <file>] [--ci]
 #
 # --passwords  Path to a passwords file (e.g. sample/config/passwords-all.yaml).
 #              Omit for the no-password variant.
@@ -13,6 +13,8 @@
 #              apache — static build + Docker/Apache on port 8083
 #              nginx  — static build + Docker/nginx on port 8084
 #              all    — dev, apache, and nginx
+# --test       Run only the specified test file (passed directly to Playwright).
+#              e.g. --test tests/privacy.spec.ts
 # --ci         Skip photogen if albums/<site-id> already exists; skip npm build if build/ exists.
 #              Speeds up CI by reusing output from a prior run or step.
 
@@ -36,6 +38,7 @@ usage() {
     echo "                        apache — static build + Docker/Apache on port 8083"
     echo "                        nginx  — static build + Docker/nginx on port 8084"
     echo "                        all    — dev, apache, and nginx"
+    echo "  --test <file>       Run only a specific test file (e.g. tests/privacy.spec.ts)."
     echo "  --ci                Skip photogen if albums/<site-id> exists; skip npm build if build/ exists."
     echo "  --help, -?          Show this help message and exit."
 }
@@ -49,6 +52,8 @@ while [[ $# -gt 0 ]]; do
         --mode)        MODE="$2"; shift 2 ;;
         --mode=*)      MODE="${1#*=}"; shift ;;
         --ci)          CI_MODE=true; shift ;;
+        --test)        TEST_FILTER="$2"; shift 2 ;;
+        --test=*)      TEST_FILTER="${1#*=}"; shift ;;
         --help|-\?)    usage; exit 0 ;;
         *) echo "Unknown flag: $1" >&2; exit 1 ;;
     esac
@@ -140,7 +145,7 @@ run_playwright() {
         export PLAYWRIGHT_BASE_URL="$base_url"
         [ -n "$PASSWORDS_FILE" ] && export PLAYWRIGHT_PASSWORDS_FILE="$PASSWORDS_FILE"
         [ -n "$CSS_FILE" ] && export PLAYWRIGHT_CUSTOM_CSS="true"
-        npx playwright test
+        npx playwright test ${TEST_FILTER:+"$TEST_FILTER"}
     )
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,12 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends binutils \
     && strip /usr/local/bin/node \
     && rm -rf /var/lib/apt/lists/*
 
-# npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry;
-# install 11.13.0 directly from the registry tarball instead.
+# npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry.
+# The normal way (npm install -g npm@11.14.0) fails; install via registry tarball instead.
 RUN node -e "\
 const https=require('https'),fs=require('fs');\
 function dl(u,cb){https.get(u,r=>{if(r.statusCode>=300&&r.statusCode<400)return dl(r.headers.location,cb);const f=fs.createWriteStream('/tmp/npm.tgz');r.pipe(f);f.on('finish',cb);});}\
-dl('https://registry.npmjs.org/npm/-/npm-11.13.0.tgz',()=>process.exit(0));" \
+dl('https://registry.npmjs.org/npm/-/npm-11.14.0.tgz',()=>process.exit(0));" \
     && tar -xz -C /tmp -f /tmp/npm.tgz \
     && /bin/rm -rf /usr/local/lib/node_modules/npm \
     && mv /tmp/package /usr/local/lib/node_modules/npm \

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -122,6 +122,7 @@ Tests are in `web/tests/` and cover:
 | `navigation.spec.ts`  | Cross-album client-side navigation shows correct photos, title, description                     |
 | `back-nav.spec.ts`    | Browser back button behavior: closes lightbox, restores URL, handles reload                     |
 | `back-to-top.spec.ts` | Back-to-top button visibility and scroll behavior                                               |
+| `privacy.spec.ts`     | Privacy page content, back link, scroll restoration on return to home                           |
 | `password.spec.ts`    | Site/album prompts, wrong/correct passwords, remember on reload, hints, logout button, `?clear` |
 | `css.spec.ts`         | Custom CSS `<link>` injection, `--text-color-2nd` override, album card border-radius            |
 
@@ -173,6 +174,9 @@ bin/run-tests.sh --passwords sample/config/passwords-all.yaml --mode apache
 
 # Run custom CSS variant against dev server
 bin/run-tests.sh --css sample/config/custom.css --mode dev
+
+# Run a single test file against dev server (useful for debugging a specific test)
+bin/run-tests.sh --mode dev --test tests/privacy.spec.ts
 ```
 
 ### Sanity Check

--- a/web/tests/privacy.spec.ts
+++ b/web/tests/privacy.spec.ts
@@ -39,6 +39,11 @@ test('Back to albums from privacy restores scroll position', async ({ page }) =>
 	await page.goto('/');
 	await unlockSiteIfNeeded(page, pw);
 	await page.locator('.albums').waitFor();
+	// Wait for all JS modules to finish loading so SvelteKit is fully hydrated.
+	// Without this, dev mode (Vite serves many individual modules) may click the
+	// privacy link before the SvelteKit router intercepts it, causing a full page
+	// reload that resets module-level savedScrollY to 0.
+	await page.waitForLoadState('networkidle');
 
 	// Scroll to the bottom of the home page.
 	await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));


### PR DESCRIPTION
## Summary

- **Fix flaky Playwright test** (`privacy.spec.ts`): the scroll-restoration test was passing on Apache but failing on the Vite dev server. Root cause: Vite serves JS as many individual modules, so SvelteKit hadn't finished hydrating when the test clicked the `/privacy` link — the browser fell back to a full page reload, resetting module-level `savedScrollY` to 0. Fix: add `waitForLoadState('networkidle')` after `.albums.waitFor()` so the test waits for hydration before clicking.
- **Add `--test <file>` flag to `bin/run-tests.sh`**: passes a single test file to Playwright, enabling a faster debug cycle (e.g. `bin/run-tests.sh --mode dev --test tests/privacy.spec.ts`).
- **Update docs**: add `--test` to the `run-tests.sh` header comment, `usage()`, and `docs/TESTING.md` examples; add `privacy.spec.ts` to the test file table in TESTING.md.
- **Bump npm to 11.14.0** in the Dockerfile tarball workaround (the `npm install -g` upgrade path is still broken in 11.14.0; workaround still required).

## Test plan

- [x] `bin/run-tests.sh --mode dev --test tests/privacy.spec.ts` — all 5 privacy tests pass
- [x] `make docker-test` — all docker tests pass