### PR TITLE
Deploy sample sites

### DIFF
--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -1,0 +1,34 @@
+name: Deploy Sample Sites
+
+# Triggered manually for testing; will later be chained from Docker Release.
+#
+# Required GitHub Actions secrets:
+#   CLOUDFLARE_API_TOKEN — Cloudflare API token with Cloudflare Pages: Edit permission
+#   CLOUDFLARE_ACCOUNT_ID — Cloudflare account ID
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'web/.nvmrc'
+
+      - name: Install wrangler
+        run: npm install -g wrangler --ignore-scripts
+
+      - name: Deploy sample sites
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bin/deploy-sample-sites.sh --doit --cloudflare --init

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -34,4 +34,6 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bin/deploy-sample-sites.sh --doit --cloudflare --init
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: bin/deploy-sample-sites.sh --doit --init

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -9,9 +9,6 @@ name: Deploy Sample Sites
 #   SURGE_TOKEN — Surge token (run 'surge token' locally to obtain)
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - deploy-sample-sites
   workflow_run:
     workflows: ["Docker Release"]
     types: [completed]

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -1,15 +1,17 @@
 name: Deploy Sample Sites
 
-# Triggered manually for testing; will later be chained from Docker Release.
+# Triggered manually or automatically after a successful Docker Release.
 #
 # Required GitHub Actions secrets:
 #   CLOUDFLARE_API_TOKEN — Cloudflare API token with Cloudflare Pages: Edit permission
 #   CLOUDFLARE_ACCOUNT_ID — Cloudflare account ID
+#   SURGE_LOGIN — Surge account email
+#   SURGE_TOKEN — Surge token (run 'surge token' locally to obtain)
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - deploy-sample-sites
+  workflow_run:
+    workflows: ["Docker Release"]
+    types: [completed]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -17,6 +19,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code
@@ -36,4 +39,4 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: bin/deploy-sample-sites.sh --doit --init
+        run: bin/deploy-sample-sites.sh --doit

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -9,6 +9,9 @@ name: Deploy Sample Sites
 #   SURGE_TOKEN — Surge token (run 'surge token' locally to obtain)
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - deploy-sample-sites
   workflow_run:
     workflows: ["Docker Release"]
     types: [completed]
@@ -40,3 +43,6 @@ jobs:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         run: bin/deploy-sample-sites.sh --doit
+
+      - name: Verify sample sites
+        run: bin/deploy-sample-sites.sh --verify

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -7,6 +7,9 @@ name: Deploy Sample Sites
 #   CLOUDFLARE_ACCOUNT_ID — Cloudflare account ID
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - deploy-sample-sites
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           node-version-file: 'web/.nvmrc'
 
-      - name: Install wrangler
-        run: npm install -g wrangler --ignore-scripts
+      - name: Install wrangler and surge
+        run: npm install -g wrangler --ignore-scripts && npm install -g surge
 
       - name: Deploy sample sites
         env:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -243,6 +243,35 @@ Use `bin/deploy-sample-sites.sh` to deploy `init` and `sample` sites to Cloudfla
 
 Use `deploy-sample-sites.sh --verify` to run smoke tests against these sites
 
+### CI Setup
+
+#### Cloudflare (wrangler)
+
+ * CLOUDFLARE_API_TOKEN — create at [dash.cloudflare.com](https://dash.cloudflare.com) > My 
+   Profile > API Tokens; use the "Edit Cloudflare Pages" template
+ * CLOUDFLARE_ACCOUNT_ID — visible in the Cloudflare dashboard sidebar
+
+#### Surge
+
+ * SURGE_LOGIN — your `surge` email
+ * SURGE_TOKEN — run `surge token` locally to print it
+
+```bash
+gh secret set CLOUDFLARE_ACCOUNT_ID --body "your-account-id"
+gh secret set CLOUDFLARE_API_TOKEN
+gh secret set SURGE_LOGIN --body "your@email.com"
+gh secret set SURGE_TOKEN
+gh secret list
+```
+
+Testing
+
+```bash
+gh workflow run deploy-sample-sites.yml --ref [branch name]
+# then watch the logs:
+gh run watch
+```
+
 ## Project History
 
 Much of this project was built with Claude Code. See [HISTORY.md](history/HISTORY.md)

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -231,7 +231,7 @@ The amount of space is set in _Docker Desktop → Settings → Resources → Adv
 
 ## Static Site Examples
 
-Use `bin/deploy-sample-sites.sh` to deploy `init` and `sample` sites to Cloudflare and surge.
+Use `bin/deploy-sample-sites.sh --doit` to deploy `init` and `sample` sites to Cloudflare and surge.
 
 * Surge sites
   * Init: [ddphotos-init.surge.sh↗](https://ddphotos-init.surge.sh) (was [ddphotos-test-docker.surge.sh↗](https://ddphotos-test-docker.surge.sh/), now redirects)
@@ -245,31 +245,33 @@ Use `deploy-sample-sites.sh --verify` to run smoke tests against these sites
 
 ### CI Setup
 
+The `deploy-sample-sites.yml` workflow is triggered when the `docker-release.yml` workflow succeeds.
+It runs `deploy-sample-sites.sh --doit` and then `--verify`.
+
 #### Cloudflare (wrangler)
 
- * CLOUDFLARE_API_TOKEN — create at [dash.cloudflare.com](https://dash.cloudflare.com) > My 
-   Profile > API Tokens; use the "Edit Cloudflare Pages" template
- * CLOUDFLARE_ACCOUNT_ID — visible in the Cloudflare dashboard sidebar
+ * `CLOUDFLARE_API_TOKEN` — create at [dash.cloudflare.com](https://dash.cloudflare.com) 
+   * _My Profile > API Tokens > + Create Token_ 
+   * **Create Custom Token** with **Account > Cloudflare Pages > Edit**
+ * `CLOUDFLARE_ACCOUNT_ID` — visible in the Cloudflare dashboard sidebar
 
 #### Surge
 
- * SURGE_LOGIN — your `surge` email
- * SURGE_TOKEN — run `surge token` locally to print it
+ * `SURGE_LOGIN` — your `surge` email
+ * `SURGE_TOKEN` — run `surge token` locally to print it
 
 ```bash
 gh secret set CLOUDFLARE_ACCOUNT_ID --body "your-account-id"
-gh secret set CLOUDFLARE_API_TOKEN
+gh secret set CLOUDFLARE_API_TOKEN # paste token
 gh secret set SURGE_LOGIN --body "your@email.com"
-gh secret set SURGE_TOKEN
+gh secret set SURGE_TOKEN # paste token
 gh secret list
 ```
 
-Testing
+Manual Trigger
 
 ```bash
 gh workflow run deploy-sample-sites.yml --ref [branch name]
-# then watch the logs:
-gh run watch
 ```
 
 ## Project History

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -241,6 +241,11 @@ The workflow in [.github/workflows/ci.yml](../.github/workflows/ci.yml) runs on 
 request to `main`. See that file for all the tests it runs.  Tests are configured to run in parallel
 to minimize CI run time.
 
+The workflow in [.github/workflows/docker-release.yml](../.github/workflows/docker-release.yml)
+runs when a new git version tag is created.  If this succeeds,
+[.github/workflows/deploy-sample-sites.yml](../.github/workflows/deploy-sample-sites.yml) is
+run to deploy latest code to the Cloudflare and Surge sample sites.
+
 ### Testing CI Locally with `act`
 
 It is often helpful to run GitHub CI locally using [`act`↗](https://nektosact.com/).

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1796,3 +1796,36 @@ script, documented in `docs/MAKEFILE.md`:
 - `ddphotos-patch` — copy `docker/ddphotos` to `~/.local/bin` while preserving the
   `IMAGE=` line from the currently installed script (useful when iterating on the script
   without a full image rebuild)
+
+### 72. 05/07/2026 - CI: Deploy Sample Sites Workflow
+
+Added `.github/workflows/deploy-sample-sites.yml` to automate deployment of the init
+and sample sites to Cloudflare Pages and Surge after each Docker release.
+
+#### Workflow Design
+
+- Triggered by `workflow_run` on successful completion of the **Docker Release** workflow,
+  plus `workflow_dispatch` for manual runs
+- The `if:` condition on the job ensures it skips when Docker Release fails:
+  `github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'`
+- The `workflow_run` trigger matches on the workflow's `name:` field (`Docker Release`),
+  not the filename
+- Installs `wrangler` (with `--ignore-scripts`) and `surge` globally before running
+  `bin/deploy-sample-sites.sh --doit`
+
+#### Auth Secrets
+
+Four GitHub Actions secrets are required, set via `gh secret set`:
+
+- `CLOUDFLARE_API_TOKEN` — custom token with **Account > Cloudflare Pages > Edit**
+  (no matching template exists in the Cloudflare UI; must use Create Custom Token)
+- `CLOUDFLARE_ACCOUNT_ID` — account ID from the Cloudflare dashboard sidebar
+- `SURGE_LOGIN` — surge account email
+- `SURGE_TOKEN` — obtained via `surge token` locally
+
+#### Branch Testing Trick
+
+`workflow_dispatch` only works on workflows registered on the default branch. To test
+on a feature branch without merging, a temporary `push:` trigger was added targeting
+the branch. Once the push registered the workflow, `gh workflow run --ref <branch>`
+worked for subsequent manual triggers. The `push:` trigger was removed before merging.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically deploy the sample sites after each Docker release.

- **`.github/workflows/deploy-sample-sites.yml`**: new workflow that triggers on successful
  completion of the Docker Release workflow (via `workflow_run`), plus `workflow_dispatch` for
  manual runs. Installs `wrangler` and `surge`, runs `bin/deploy-sample-sites.sh --doit` to
  deploy both init and sample sites to Cloudflare Pages and Surge, then runs `--verify` to
  smoke-test the deployed sites.
- **`docs/DEV.md`**: adds a CI Setup section documenting the four required GitHub Actions secrets
  (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `SURGE_LOGIN`, `SURGE_TOKEN`) and how to set
  them via `gh secret set`.
- **`docs/TESTING.md`**: documents the deploy-sample-sites workflow in the CI overview.

### Notes

- The `if:` condition on the job prevents it running when Docker Release fails:
  `github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'`
- `workflow_run` matches on the workflow's `name:` field, not the filename.
- Requires PR #53 (umask / file permissions fix) to be merged and a new Docker image published
  before the deploy step will succeed on Linux CI runners.