### PR TITLE
Consolidate error pages, tweak layouts

### DIFF
--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -64,7 +64,6 @@ run_playwright() {
     (
         cd "$REPO_ROOT/web"
         export PLAYWRIGHT_BASE_URL="$base_url"
-        export PLAYWRIGHT_IGNORE_CUSTOM_CSS=1
         [ -n "$passwords_file" ] && export PLAYWRIGHT_PASSWORDS_FILE="$passwords_file"
         npx playwright test
     )

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -250,7 +250,7 @@ else
     check_status "$BASE/albums/doesnotexist"          404 "Bad album slug"
     check_status "$BASE/albums/doesnotexist/1"        404 "Bad album slug with photo index"
     check_status "$BASE/nope"                         404 "Unknown path returns 404"
-    check_body   "$BASE/albums/doesnotexist"          "404 - Not Found" "Custom 404 page served for bad album slug"
+    check_body   "$BASE/albums/doesnotexist"          "404 - DD Photos" "Custom 404 page served for bad album slug"
 fi
 
 echo ""

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -144,7 +144,6 @@ the appropriate site variant:
 |--------------------------------|----------------------|------------------------------------------------|
 | `PLAYWRIGHT_PASSWORDS_FILE`    | `bin/run-tests.sh`   | Path to passwords file; enables password tests |
 | `PLAYWRIGHT_CUSTOM_CSS`        | `bin/run-tests.sh`   | Set to `true`; enables CSS tests               |
-| `PLAYWRIGHT_IGNORE_CUSTOM_CSS` | `bin/docker-test.sh` | Set to `true`; skips no-CSS expected test      |
 
 Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants automatically.
 `bin/test-all.sh` runs four variants: no passwords, `passwords-all.yaml`, `passwords-uganda.yaml`,

--- a/web/src/lib/components/ErrorPage.svelte
+++ b/web/src/lib/components/ErrorPage.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+
+	let { status, message }: { status: number; message?: string } = $props();
+</script>
+
+<svelte:head>
+	<title>{status} - DD Photos</title>
+</svelte:head>
+
+<SecondaryPage>
+	<div class="error-content">
+		<h1>{status}</h1>
+		{#if status === 404}
+			<p>Page <span id="missing-path" class="missing-path"></span> not found.</p>
+		{:else}
+			<p>{message || 'Something went wrong'}</p>
+		{/if}
+		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
+	</div>
+	<script>
+		const el = document.getElementById('missing-path');
+		if (el) el.textContent = location.pathname;
+	</script>
+</SecondaryPage>

--- a/web/src/routes/+error.svelte
+++ b/web/src/routes/+error.svelte
@@ -1,24 +1,6 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
 	import { page } from '$app/state';
-	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
-	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
-
-	let pathname = $derived(browser ? window.location.pathname : '');
+	import ErrorPage from '$lib/components/ErrorPage.svelte';
 </script>
 
-<svelte:head>
-	<title>{page.status} - DD Photos</title>
-</svelte:head>
-
-<SecondaryPage>
-	<div class="error-content">
-		<h1>{page.status}</h1>
-		{#if page.status === 404}
-			<p>Page <span class="missing-path">{pathname}</span> not found.</p>
-		{:else}
-			<p>{page.error?.message || 'Something went wrong'}</p>
-		{/if}
-		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
-	</div>
-</SecondaryPage>
+<ErrorPage status={page.status} message={page.error?.message} />

--- a/web/src/routes/+error.svelte
+++ b/web/src/routes/+error.svelte
@@ -1,31 +1,24 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { page } from '$app/state';
 	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+
+	let pathname = $derived(browser ? window.location.pathname : '');
 </script>
 
 <svelte:head>
-	<title>Error - DD Photos</title>
+	<title>{page.status} - DD Photos</title>
 </svelte:head>
 
 <SecondaryPage>
 	<div class="error-content">
 		<h1>{page.status}</h1>
-		<p>{page.error?.message || 'Something went wrong'}</p>
-		<a href="/">Back to albums</a>
+		{#if page.status === 404}
+			<p>Page <span class="missing-path">{pathname}</span> not found.</p>
+		{:else}
+			<p>{page.error?.message || 'Something went wrong'}</p>
+		{/if}
+		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
 	</div>
 </SecondaryPage>
-
-<style>
-	.error-content {
-		text-align: center;
-	}
-
-	.error-content h1 {
-		font-size: 4rem;
-		color: var(--text-muted);
-	}
-
-	.error-content p {
-		font-size: 1.25rem;
-	}
-</style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -170,6 +170,40 @@
 		color: var(--link-color);
 	}
 
+	:global(.missing-path) {
+		font-style: italic;
+		font-weight: bold;
+		font-family: monospace;
+	}
+
+	:global(.back-link) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		text-decoration: none;
+	}
+
+	:global(.back-link:hover) {
+		text-decoration: underline;
+	}
+
+	:global(.error-content) {
+		text-align: center;
+	}
+
+	:global(.error-content a.back-link) {
+		margin-top: 1.5rem;
+	}
+
+	:global(.error-content h1) {
+		font-size: 4rem;
+		color: var(--text-muted);
+	}
+
+	:global(.error-content p) {
+		font-size: 1.25rem;
+	}
+
 	.app {
 		position: relative;
 		min-height: 100vh;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -192,7 +192,7 @@
 	}
 
 	:global(.error-content a.back-link) {
-		margin-top: 1.5rem;
+		margin-top: 1.3rem;
 	}
 
 	:global(.error-content h1) {

--- a/web/src/routes/404/+page.svelte
+++ b/web/src/routes/404/+page.svelte
@@ -1,19 +1,5 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
-	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
-	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
-
-	let pathname = $derived(browser ? window.location.pathname : '');
+	import ErrorPage from '$lib/components/ErrorPage.svelte';
 </script>
 
-<svelte:head>
-	<title>404 - Not Found</title>
-</svelte:head>
-
-<SecondaryPage>
-	<div class="error-content">
-		<h1>404</h1>
-		<p>Page <span class="missing-path">{pathname}</span> not found.</p>
-		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
-	</div>
-</SecondaryPage>
+<ErrorPage status={404} />

--- a/web/src/routes/404/+page.svelte
+++ b/web/src/routes/404/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+
+	let pathname = $derived(browser ? window.location.pathname : '');
 </script>
 
 <svelte:head>
@@ -9,22 +13,7 @@
 <SecondaryPage>
 	<div class="error-content">
 		<h1>404</h1>
-		<p>Page not found</p>
-		<a href="/">Back to albums</a>
+		<p>Page <span class="missing-path">{pathname}</span> not found.</p>
+		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
 	</div>
 </SecondaryPage>
-
-<style>
-	.error-content {
-		text-align: center;
-	}
-
-	.error-content h1 {
-		font-size: 4rem;
-		color: var(--text-muted);
-	}
-
-	.error-content p {
-		font-size: 1.25rem;
-	}
-</style>

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -9,6 +9,7 @@
 	import justifiedLayout from 'justified-layout';
 	import PhotoSwipe from 'photoswipe';
 	import 'photoswipe/style.css';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
 	import BackToTop from '$lib/components/BackToTop.svelte';
 	import OpenGraph from '$lib/components/OpenGraph.svelte';
 	import PasswordPrompt from '$lib/components/PasswordPrompt.svelte';
@@ -554,8 +555,8 @@
 
 		{#if invalidPhotoIndex !== null}
 			<div class="not-found">
-				<p>No photo #{invalidPhotoIndex} in '{album.title}'.</p>
-				<a href="/albums/{slug}">Back to the album</a>
+				<p>Sorry, there is no photo #{invalidPhotoIndex} in '{album.title}'.</p>
+				<a href="/albums/{slug}" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to the album</a>
 			</div>
 		{/if}
 
@@ -688,7 +689,7 @@
 	}
 
 	.not-found {
-		padding: 3rem 1rem;
+		padding: 1rem 1rem;
 		text-align: center;
 		color: var(--text-muted);
 	}

--- a/web/src/routes/privacy/+page.svelte
+++ b/web/src/routes/privacy/+page.svelte
@@ -45,5 +45,7 @@
 		<a href="https://github.com/dougdonohoe/ddphotos" target="_blank" rel="noopener">GitHub</a>.
 	</p>
 
-	<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
+	<div style="text-align: center; padding-top: 1.5rem">
+		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
+	</div>
 </SecondaryPage>

--- a/web/tests/css.spec.ts
+++ b/web/tests/css.spec.ts
@@ -1,16 +1,29 @@
 import { test, expect } from '@playwright/test';
+import { siteCustomCss } from './helpers';
 
 // Custom CSS tests — verify that a custom CSS file is applied site-wide when
-// configured via the -css flag.  All tests are skipped when PLAYWRIGHT_CUSTOM_CSS
-// is not set (no-CSS variant).
+// configured via the -css flag.
+//
+// Tests 1 and 2 derive CSS presence from config.json (programmatic).
+// Tests 3 and 4 require PLAYWRIGHT_CUSTOM_CSS to be set, since they check
+// specific values only meaningful for the known sample custom.css file.
 
 const hasCustomCss = !!process.env.PLAYWRIGHT_CUSTOM_CSS;
 
-test('custom CSS <link> is injected into the page', async ({ page }) => {
-	test.skip(!hasCustomCss, 'no custom CSS configured');
+test('custom CSS <link> is injected into the page', async ({ page, request }) => {
+	const css = await siteCustomCss(request);
+	test.skip(!css, 'no custom CSS configured');
+	await page.goto('/');
+	const link = page.locator(`link[rel="stylesheet"][href*="${css}"]`);
+	await expect(link).toHaveCount(1);
+});
+
+test('custom CSS <link> is NOT present when CSS is not configured', async ({ page, request }) => {
+	const css = await siteCustomCss(request);
+	test.skip(!!css, 'CSS is configured — skipping no-CSS check');
 	await page.goto('/');
 	const link = page.locator('link[rel="stylesheet"][href*="custom.css"]');
-	await expect(link).toHaveCount(1);
+	await expect(link).toHaveCount(0);
 });
 
 test('custom CSS overrides --text-color-2nd on home page', async ({ page }) => {
@@ -34,12 +47,4 @@ test('custom CSS applies border-radius to album cards', async ({ page }) => {
 	await expect(card).toBeVisible();
 	const radius = await card.evaluate((el) => getComputedStyle(el).borderRadius);
 	expect(radius).toBe('16px');
-});
-
-test('custom CSS <link> is NOT present when CSS is not configured', async ({ page }) => {
-	test.skip(hasCustomCss, 'CSS is configured — skipping no-CSS check');
-	test.skip(!!process.env.PLAYWRIGHT_IGNORE_CUSTOM_CSS, 'CSS presence unknown — skipping');
-	await page.goto('/');
-	const link = page.locator('link[rel="stylesheet"][href*="custom.css"]');
-	await expect(link).toHaveCount(0);
 });

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -106,6 +106,21 @@ export async function unlockAlbumIfNeeded(
 }
 
 /**
+ * Return the customCss value from config.json, or null if not set.
+ * Fails open (returns null) on API error so tests surface real failures.
+ */
+export async function siteCustomCss(request: APIRequestContext): Promise<string | null> {
+	try {
+		const resp = await request.get('/albums/config.json');
+		if (!resp.ok()) return null;
+		const config = await resp.json();
+		return config?.customCss || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Check whether a specific album slug exists in albums.json.
  * Fails open (returns true) on API error so tests surface real failures.
  */


### PR DESCRIPTION
## Summary

- **Consolidate error pages into a shared `ErrorPage` component** — `404/+page.svelte` and `+error.svelte` were nearly identical; both now delegate to `lib/components/ErrorPage.svelte`. Non-404 errors still show the error message; 404s show the missing path.
- **Show the missing path on 404** — displays the URL that wasn't found (e.g. `Page /privacyx not found`). Uses an inline synchronous `<script>` tag inside the component so the pathname is injected before first paint, avoiding any flash or layout shift.
- **Shared global styles** — `.error-content`, `.back-link`, and `.missing-path` styles moved to `+layout.svelte` so they're available across error pages and the privacy page without duplication.
- **Arrow icon on back links** — "Back to albums" (error pages, privacy page) and "Back to the album" (photo page) now use the `ArrowLeft` lucide icon with the shared `.back-link` style.
- **CSS tests made programmatic** — `css.spec.ts` tests 1 and 2 (link present / link absent) now read `customCss` directly from `config.json` via the running server instead of relying on the `PLAYWRIGHT_CUSTOM_CSS` env var. `PLAYWRIGHT_IGNORE_CUSTOM_CSS` is removed entirely. Tests 3 and 4 still use the env var since they assert specific values only meaningful for the sample `custom.css`.