### PR TITLE
New secondary page layout

### DIFF
--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -134,7 +134,8 @@ step() { echo; echo "=== $* ==="; }
 # ---------------------------------------------------------------------------
 _deploy_site() {
     local site="$1"
-    shift
+    local site_url="$2"
+    shift 2
     local site_dir="$DEPLOY_DIR/$site"
 
     step "Site: $site"
@@ -182,7 +183,9 @@ _deploy_site() {
 
     if $DO_PHOTOGEN; then
         echo "photogen"
-        "$site_dir/ddphotos" --show-mounts photogen
+        local site_url_args=()
+        [ -n "$site_url" ] && site_url_args=(-site-url "$site_url")
+        "$site_dir/ddphotos" --show-mounts photogen "${site_url_args[@]}"
     else
         echo "photogen: skipping (--no-photogen set)"
     fi
@@ -244,8 +247,8 @@ SAMPLE_TARGETS=(
     "my-unique-site:"
 )
 
-if $DO_INIT;   then _deploy_site "init"   "${INIT_TARGETS[@]}";   fi
-if $DO_SAMPLE; then _deploy_site "sample" "${SAMPLE_TARGETS[@]}"; fi
+if $DO_INIT;   then _deploy_site "init"   "https://ddphotos-test.donohoe.info" "${INIT_TARGETS[@]}";   fi
+if $DO_SAMPLE; then _deploy_site "sample" ""                                   "${SAMPLE_TARGETS[@]}"; fi
 
 echo
 echo "Done."

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -250,7 +250,7 @@ else
     check_status "$BASE/albums/doesnotexist"          404 "Bad album slug"
     check_status "$BASE/albums/doesnotexist/1"        404 "Bad album slug with photo index"
     check_status "$BASE/nope"                         404 "Unknown path returns 404"
-    check_body   "$BASE/albums/doesnotexist"          "404 - DD Photos" "Custom 404 page served for bad album slug"
+    check_body   "$BASE/albums/doesnotexist"          "404 Not Found" "Custom 404 page served for bad album slug"
 fi
 
 echo ""

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -68,7 +68,7 @@ else
         REDIRECT_STATUS=301
     else
         # Apache behind CloudFront: Apache sees HTTP and returns http:// in Location headers
-        REDIRECT_BASE="http://${REMOTE_URL#https://}"
+        REDIRECT_BASE="${REMOTE_URL/#https:\/\//http://}"
         REDIRECT_STATUS=301
     fi
 fi

--- a/bin/test-photos-server.sh
+++ b/bin/test-photos-server.sh
@@ -25,8 +25,6 @@ set -e
 
 echo "test-photos-server.sh $* starting ..."
 
-SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-
 LOCAL=0
 PORT=8080
 REMOTE_URL=""
@@ -70,7 +68,7 @@ else
         REDIRECT_STATUS=301
     else
         # Apache behind CloudFront: Apache sees HTTP and returns http:// in Location headers
-        REDIRECT_BASE="$(echo "$REMOTE_URL" | sed 's|^https://|http://|')"
+        REDIRECT_BASE="http://${REMOTE_URL#https://}"
         REDIRECT_STATUS=301
     fi
 fi
@@ -247,10 +245,10 @@ if [ "$SURGE_MODE" -eq 1 ]; then
     check_status "$BASE/nope"                     200 "Unknown path serves SPA shell"
 else
     echo "404s (expect 404):"
-    check_status "$BASE/albums/doesnotexist"          404 "Bad album slug"
-    check_status "$BASE/albums/doesnotexist/1"        404 "Bad album slug with photo index"
-    check_status "$BASE/nope"                         404 "Unknown path returns 404"
-    check_body   "$BASE/albums/doesnotexist"          "404 Not Found" "Custom 404 page served for bad album slug"
+    check_status "$BASE/albums/doesnotexist"      404 "Bad album slug"
+    check_status "$BASE/albums/doesnotexist/1"    404 "Bad album slug with photo index"
+    check_status "$BASE/nope"                     404 "Unknown path returns 404"
+    check_body   "$BASE/albums/doesnotexist"      "404 Not Found" "Custom 404 page served for bad album slug"
 fi
 
 echo ""

--- a/web/src/lib/components/ErrorPage.svelte
+++ b/web/src/lib/components/ErrorPage.svelte
@@ -1,24 +1,28 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
-	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+	import FileQuestion from 'lucide-svelte/icons/file-question';
+	import AlertCircle from 'lucide-svelte/icons/alert-circle';
 
 	let { status, message }: { status: number; message?: string } = $props();
+
+	const siteName = $derived(page.data.siteConfig?.siteName ?? 'DD Photos');
+	const icon = $derived(status === 404 ? FileQuestion : AlertCircle);
+	const iconColor = $derived(status === 404 ? 'amber' : 'red') as 'amber' | 'red';
+	const errorTitle = $derived(status === 404 ? '404 Not Found' : `${status} Error`);
 </script>
 
 <svelte:head>
-	<title>{status} - DD Photos</title>
+	<title>{errorTitle} - {siteName}</title>
 </svelte:head>
 
-<SecondaryPage>
-	<div class="error-content">
-		<h1>{status}</h1>
-		{#if status === 404}
-			<p>Page <span id="missing-path" class="missing-path"></span> not found.</p>
-		{:else}
-			<p>{message || 'Something went wrong'}</p>
-		{/if}
-		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
-	</div>
+<SecondaryPage {icon} {iconColor} title={errorTitle} {siteName}>
+	{#if status === 404}
+		<p>It seems <span id="missing-path" class="missing-path"></span> was not found. Maybe that film
+		hasn't been developed yet?</p>
+	{:else}
+		<p>Doh! {message || 'Something went wrong'}</p>
+	{/if}
 	<script>
 		const el = document.getElementById('missing-path');
 		if (el) el.textContent = location.pathname;

--- a/web/src/lib/components/PasswordPrompt.svelte
+++ b/web/src/lib/components/PasswordPrompt.svelte
@@ -7,7 +7,7 @@
 		shakeCount?: number;
 	}
 
-	import Lock from 'lucide-svelte/icons/lock';
+	import PasswordIcon from 'lucide-svelte/icons/key-square';
 
 	let { prefix, name, hint, onunlock, shakeCount = 0 }: Props = $props();
 	let password = $state('');
@@ -35,8 +35,8 @@
 
 <div class="overlay">
 	<div class="card" class:shake={shaking}>
-		<div class="lock-icon">
-			<Lock size={40} strokeWidth={1.75} aria-hidden="true" />
+		<div class="pw-icon">
+			<PasswordIcon size={40} strokeWidth={1.75} aria-hidden="true" />
 		</div>
 		<h2>{prefix ? prefix + ' ' : ''}<span class="name">{name}</span><br>requires a password.</h2>
 		<form onsubmit={handleSubmit}>
@@ -76,7 +76,7 @@
 		text-align: center;
 	}
 
-	.lock-icon {
+	.pw-icon {
 		color: var(--text-muted);
 		margin-bottom: 1rem;
 	}

--- a/web/src/lib/components/SecondaryPage.svelte
+++ b/web/src/lib/components/SecondaryPage.svelte
@@ -1,50 +1,146 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
 
-	let { children }: { children: Snippet } = $props();
+	let {
+		icon: Icon,
+		iconColor = 'blue',
+		title,
+		siteName,
+		backHref = '/',
+		children
+	}: {
+		// lucide-svelte uses legacy Svelte 4 class components; no non-deprecated Svelte type bridges both
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		icon: any;
+		iconColor?: 'blue' | 'amber' | 'red' | 'gray';
+		title: string;
+		siteName: string;
+		backHref?: string;
+		children: Snippet;
+	} = $props();
 </script>
 
 <main>
-	{@render children()}
+	<div class="card">
+		<div class="card-header">
+			<div class="card-icon card-icon--{iconColor}">
+				<Icon size={32} aria-hidden="true" />
+			</div>
+			<div>
+				<div class="card-site-name">{siteName}</div>
+				<div class="card-title">{title}</div>
+			</div>
+		</div>
+		<div class="card-body">
+			{@render children()}
+			<a href={backHref} class="card-back">
+				<ArrowLeft size={12} aria-hidden="true" />Back to albums
+			</a>
+		</div>
+	</div>
 </main>
 
 <style>
 	main {
-		max-width: 600px;
+		max-width: 560px;
 		margin: 0 auto;
-		padding: 1rem 2rem 2rem;
+		padding: 48px 24px 15px;
 	}
 
-	main :global(h1) {
-		font-size: 2rem;
-		margin: 0 0 1.5rem 0;
+	.card {
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+		padding: 32px 36px;
+		background: var(--bg-secondary);
 	}
 
-	main :global(p),
-	main :global(ul) {
-		line-height: 1.2;
-		margin: 0 0 1rem 0;
+	.card-header {
+		display: flex;
+		align-items: flex-start;
+		gap: 14px;
+		margin-bottom: 20px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color);
 	}
 
-	main :global(ul) {
+	.card-icon {
+		width: 44px;
+		height: 44px;
+		border-radius: 10px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	:global(.card-icon--blue)  { background: rgba(59, 130, 246, 0.1);  color: rgb(59, 130, 246); }
+	:global(.card-icon--amber) { background: rgba(245, 158, 11, 0.1);  color: rgb(245, 158, 11); }
+	:global(.card-icon--red)   { background: rgba(239, 68, 68, 0.1);   color: rgb(239, 68, 68); }
+	:global(.card-icon--gray)  { background: rgba(107, 114, 128, 0.1); color: rgb(107, 114, 128); }
+
+	.card-site-name {
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		margin-bottom: 2px;
+	}
+
+	.card-title {
+		font-size: 1.5rem;
+		font-weight: 500;
+		color: var(--text-color);
+	}
+
+	.card-body {
+		font-size: 0.9rem;
+		line-height: 1.7;
+		color: var(--text-color);
+	}
+
+	.card-body :global(p),
+	.card-body :global(ul) {
+		margin: 0 0 0.75rem 0;
+	}
+
+	.card-body :global(ul) {
 		padding-left: 1.5rem;
 	}
 
-	main :global(li) {
-		margin-bottom: 0.5rem;
+	.card-body :global(li) {
+		margin-bottom: 0.35rem;
 	}
 
-	main :global(a) {
+	.card-body :global(a) {
 		text-decoration: none;
 	}
 
-	main :global(a:hover) {
+	.card-body :global(a:hover) {
 		text-decoration: underline;
 	}
 
-	main :global(.back-link) {
+	.card-back {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.35rem;
+		gap: 0.3rem;
+		margin-top: .25rem;
+		font-size: 12px;
+		color: var(--link-color);
+		text-decoration: none;
+	}
+
+	.card-back:hover {
+		text-decoration: underline;
+	}
+
+	@media (max-width: 480px) {
+		main {
+			padding: 48px 16px 10px;
+		}
+
+		.card {
+			padding: 24px 20px;
+		}
 	}
 </style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -123,7 +123,7 @@
 					{/if}
 					<dt>Source</dt>
 					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<dd><a href={gitRepoUrl} target="_blank" rel="noopener">{gitRepoSlug}</a></dd>
+					<dd><a href={gitRepoUrl} target="_blank" rel="noopener">{gitRepoSlug}↗</a></dd>
 				</dl>
 			</div>
 		</div>
@@ -176,33 +176,6 @@
 		font-family: monospace;
 	}
 
-	:global(.back-link) {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		text-decoration: none;
-	}
-
-	:global(.back-link:hover) {
-		text-decoration: underline;
-	}
-
-	:global(.error-content) {
-		text-align: center;
-	}
-
-	:global(.error-content a.back-link) {
-		margin-top: 1.3rem;
-	}
-
-	:global(.error-content h1) {
-		font-size: 4rem;
-		color: var(--text-muted);
-	}
-
-	:global(.error-content p) {
-		font-size: 1.25rem;
-	}
 
 	.app {
 		position: relative;

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,7 +1,13 @@
 import { error } from '@sveltejs/kit';
+import { browser } from '$app/environment';
 import type { AlbumSummary, SiteHtmlContent, MaybeEncrypted, SiteData } from '$lib/types';
 
-export async function load({ fetch, parent }) {
+export async function load({ fetch, parent, url }) {
+	// browser guard prevents url.searchParams access during pre-rendering
+	if (browser && url.searchParams.has('boom')) {
+		error(500, 'Whoops, the lens cap was on!');
+	}
+
 	const { siteConfig } = await parent();
 
 	const albumsRes = await fetch(`/albums/${siteConfig.albumsFile}`);

--- a/web/src/routes/privacy/+page.svelte
+++ b/web/src/routes/privacy/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+	import Shield from 'lucide-svelte/icons/shield';
 	import SecondaryPage from '$lib/components/SecondaryPage.svelte';
 
 	let { data } = $props();
@@ -11,9 +11,7 @@
 	<title>Privacy | {siteName}</title>
 </svelte:head>
 
-<SecondaryPage>
-	<h1>{siteName} - Privacy</h1>
-
+<SecondaryPage icon={Shield} iconColor="blue" title="Privacy" {siteName}>
 	<p>
 		This site stores the following items in your browser's local storage:
 	</p>
@@ -42,10 +40,6 @@
 	</p>
 	<p>
 		DD Photos is open source. You can review the full source code on
-		<a href="https://github.com/dougdonohoe/ddphotos" target="_blank" rel="noopener">GitHub</a>.
+		<a href="https://github.com/dougdonohoe/ddphotos" target="_blank" rel="noopener">GitHub↗</a>.
 	</p>
-
-	<div style="text-align: center; padding-top: 1.5rem">
-		<a href="/" class="back-link"><ArrowLeft size={16} aria-hidden="true" />Back to albums</a>
-	</div>
 </SecondaryPage>

--- a/web/tests/privacy.spec.ts
+++ b/web/tests/privacy.spec.ts
@@ -7,8 +7,8 @@ test('privacy page loads and shows correct title', async ({ page }) => {
 	const config = await page.request.get('/albums/config.json').then((r) => r.json());
 	await page.goto('/privacy');
 	await expect(page).toHaveTitle(`Privacy | ${config.siteName}`);
-	await expect(page.locator('h1')).toContainText(config.siteName);
-	await expect(page.locator('h1')).toContainText('Privacy');
+	await expect(page.locator('.card-site-name')).toContainText(config.siteName);
+	await expect(page.locator('.card-title')).toContainText('Privacy');
 });
 
 test('privacy page always shows theme and site ID bullets', async ({ page }) => {

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -70,6 +70,11 @@ test('album page og:site_name matches siteName from config.json', async ({ page 
 	await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', config.siteName);
 });
 
+test('?boom on home page shows 500 error card', async ({ page }) => {
+	await page.goto('/?boom');
+	await expect(page.locator('.card-title')).toContainText('500 Error');
+});
+
 test('home page has Open Graph image tag pointing to a JPEG', async ({ page }) => {
 	// In the pw-all variant every album is encrypted, so the home page derives no OG
 	// cover image (it only uses non-encrypted albums). Skip rather than expect a tag


### PR DESCRIPTION
## Summary

Redesigns the secondary page layout (error pages, privacy page) into a consistent card-based component, plus a few small polish items.

### SecondaryPage redesign

`SecondaryPage.svelte` is refactored from a bare content wrapper into a card component with a structured header. Callers now pass `icon`, `iconColor`, `title`, and `siteName` props:

- Card with rounded border, icon badge (color-coded: blue/amber/red/gray), site name label, and title
- "Back to albums" link moved inside the component — callers no longer manage it
- Responsive: tighter padding on mobile

### ErrorPage updates

- Uses `FileQuestion` (amber) for 404, `AlertCircle` (red) for other errors
- Error title and `<title>` tag now reflect the actual status code and site name
- Friendlier copy: "Maybe that film hasn't been developed yet?" for 404

### Privacy page

- Uses `Shield` (blue) icon
- External GitHub link gets an ↗ arrow

### PasswordPrompt

- Swaps the lock icon for `key-square`

### Other

- `?boom` query param on the home page triggers a 500 error (for manual/automated error page testing)
- External repo link in the about dialog gets an ↗ arrow
- `deploy-sample-sites.sh`: `_deploy_site` accepts an optional `site_url` param; init site passes `https://ddphotos-test.donohoe.info` to photogen