### PR TITLE
Bunder wrangler and surge

### DIFF
--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           node-version-file: 'web/.nvmrc'
 
-      - name: Install wrangler and surge
-        run: npm install -g wrangler --ignore-scripts && npm install -g surge
+      - name: Install surge
+        run: npm install -g surge
 
       - name: Deploy sample sites
         env:

--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'web/.nvmrc'
-
-      - name: Install surge
-        run: npm install -g surge
-
       - name: Deploy sample sites
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then edit `config/albums.yaml` to define your own albums and repeat.
 
 ```bash
 ./ddphotos export --cloudflare
-wrangler pages deploy --project-name my-unique-site export/my-photos
+./ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 
 ./ddphotos export --copy
 surge --domain my-unique-site.surge.sh export/my-photos

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then edit `config/albums.yaml` to define your own albums and repeat.
 ./ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 
 ./ddphotos export --copy
-surge --domain my-unique-site.surge.sh export/my-photos
+./ddphotos surge --domain my-unique-site.surge.sh export/my-photos
 ```
 
 See the [Docker Mode](docs/DOCKER.md) page for full details including deploying via `rsync` or to S3.

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
         *)
             echo "Unknown flag: $1" >&2
             echo "" >&2
-            echo "Usage: deploy-photos.sh [OPTIONS]" >&2
+            echo "Usage: deploy-photos.sh [options]" >&2
             echo "" >&2
             echo "  --dry-run              Show what would be deployed without transferring files" >&2
             echo "  --s3                   Deploy to S3 (default: rsync; auto-set if S3_BUCKET in site.env)" >&2

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -107,20 +107,13 @@ if ! command -v node &>/dev/null; then
     source "$NVM_SH"
 fi
 
-# Check that required deploy tools are installed (only needed when actually uploading)
-if $DOIT; then
-    if $DO_CLOUDFLARE; then
-        command -v wrangler &>/dev/null || {
-            echo "Error: wrangler not found; install with: npm install -g wrangler --ignore-scripts" >&2
-            exit 1
-        }
-    fi
-    if $DO_SURGE; then
-        command -v surge &>/dev/null || {
-            echo "Error: surge not found; install with: npm install --global surge" >&2
-            exit 1
-        }
-    fi
+# Check that required deploy tools are installed (only needed when actually uploading).
+# wrangler is bundled in the Docker image and invoked via 'ddphotos wrangler'; no local install needed.
+if $DOIT && $DO_SURGE; then
+    command -v surge &>/dev/null || {
+        echo "Error: surge not found; install with: npm install --global surge" >&2
+        exit 1
+    }
 fi
 
 step() { echo; echo "=== $* ==="; }
@@ -213,7 +206,7 @@ _deploy_site() {
             fi
             if $DOIT; then
                 echo "wrangler: deploy $wrangler_project"
-                (cd "$site_dir" && wrangler pages deploy --project-name "$wrangler_project" export/cloudflare)
+                "$site_dir/ddphotos" wrangler pages deploy --project-name "$wrangler_project" export/cloudflare
             else
                 echo "wrangler: skipping upload (--doit not set)"
             fi

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -99,22 +99,7 @@ fi
 DEPLOY_DIR="$HOME/junk/ddphotos-deploy"
 mkdir -p "$DEPLOY_DIR"
 
-# Source nvm if node not on PATH
-if ! command -v node &>/dev/null; then
-    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-    [ -f "$NVM_SH" ] || { echo "Error: node not found; install Node.js or nvm" >&2; exit 1; }
-    # shellcheck source=/dev/null
-    source "$NVM_SH"
-fi
-
-# Check that required deploy tools are installed (only needed when actually uploading).
-# wrangler is bundled in the Docker image and invoked via 'ddphotos wrangler'; no local install needed.
-if $DOIT && $DO_SURGE; then
-    command -v surge &>/dev/null || {
-        echo "Error: surge not found; install with: npm install --global surge" >&2
-        exit 1
-    }
-fi
+# Both wrangler and surge are bundled in the Docker image via npx; no local install needed.
 
 step() { echo; echo "=== $* ==="; }
 
@@ -220,7 +205,7 @@ _deploy_site() {
             fi
             if $DOIT; then
                 echo "surge: deploy $surge_domain"
-                (cd "$site_dir" && surge --domain "$surge_domain" export/surge)
+                "$site_dir/ddphotos" surge --domain "$surge_domain" export/surge
             else
                 echo "surge: skipping upload (--doit not set)"
             fi

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -281,8 +281,13 @@ EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Wrangler w/out export"
 out=$("${DDPHOTOS_QUIET[@]}" --non-interactive wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
-echo "$out" | grep -q "Run 'export --cloudflare' first" || (echo "$out" && fail "deploy: expected 'Run export first' error when export dir missing")
+echo "$out" | grep -q "Run 'export --cloudflare' first" || (echo "$out" && fail "wrangler: expected 'Run export first' error when export dir missing")
 pass "wrangler: fails correctly when export dir missing"
+
+step "Surge w/out export"
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive surge --domain foo.surge.sh export/$SITE_ID 2>&1) || true
+echo "$out" | grep -q "not found" || (echo "$out" && fail "surge: expected 'Run export first' error when export dir missing")
+pass "surge: fails correctly when export dir is missing"
 
 step "Export (symlinks)"
 "${DDPHOTOS[@]}" export
@@ -313,6 +318,21 @@ step "Wrangler w/out --cloudflare (_worker.js missing)"
 out=$("${DDPHOTOS_QUIET[@]}" --non-interactive wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
 echo "$out" | grep -q "not just 'export'" || (echo "$out" && fail "deploy: expected 'not just export' error when --cloudflare not used")
 pass "wrangler: fails correctly when _worker.js missing"
+
+step "Surge w/out --copy (export contains symlinks)"
+# export/alternate was created without --copy so index.html is still a symlink
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive surge --domain foo.surge.sh export/alternate 2>&1) || true
+echo "$out" | grep -q "contains symlinks" || (echo "$out" && fail "surge: expected 'contains symlinks' error")
+pass "surge: fails correctly when export dir contains symlinks"
+
+step "Surge subcommands bypass directory check"
+# 'list' has no '/' so do-surge.sh skips the dir check and passes through to surge
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive surge list 2>&1) || true
+if echo "$out" | grep -q "Run 'ddphotos export --copy'"; then
+    echo "$out"
+    fail "surge: 'list' subcommand should not trigger directory check"
+fi
+pass "surge: subcommands bypass directory check"
 
 step "Export --cloudflare"
 "${DDPHOTOS[@]}" export --cloudflare

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -14,6 +14,7 @@ SITE_ID="docker-test-id"  # passed to init via --site-id, verified against album
 RUN_PORT=5173             # Vite host port; matches container default to keep port-mapping consistent
 SERVE_PORT=8090           # Apache host port (maps to container port 80; avoids conflicts with run-tests.sh)
 DO_BUILD=true
+SKIP_PLAYWRIGHT=false
 TEST_DIR=""
 TEST_DIR2=""
 TEMP_DECODE_DIR=""
@@ -25,8 +26,9 @@ SERVE_PID=""
 # --- flags ---
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --no-build) DO_BUILD=false; shift ;;
-        --help|-\?) echo "Usage: bin/docker-test.sh [--no-build]"; exit 0 ;;
+        --no-build)        DO_BUILD=false;        shift ;;
+        --skip-playwright) SKIP_PLAYWRIGHT=true;  shift ;;
+        --help|-\?) echo "Usage: bin/docker-test.sh [--no-build] [--skip-playwright]"; exit 0 ;;
         *) echo "Unknown flag: $1" >&2; exit 1 ;;
     esac
 done
@@ -60,6 +62,7 @@ if ! command -v node &>/dev/null; then
 fi
 
 run_playwright() {
+    $SKIP_PLAYWRIGHT && { echo "  (Playwright skipped)"; return 0; }
     local base_url="$1" passwords_file="${2:-}"
     (
         cd "$REPO_ROOT/web"
@@ -273,8 +276,13 @@ run_playwright "http://localhost:$SERVE_PORT" "$PASSWORDS_FILE"
 kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true; SERVE_PID=""
 pass "serve + Playwright + test-photos-server.sh OK"
 
-# ── 13. Export (symlink mode) ──────────────────────────────────────────────────
+# ── 13. Export  ──────────────────────────────────────────────────────────────────
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
+
+step "Wrangler w/out export"
+out=$("${DDPHOTOS_QUIET[@]}" wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
+echo "$out" | grep -q "Run 'export --cloudflare' first" || (echo "$out" && fail "deploy: expected 'Run export first' error when export dir missing")
+pass "wrangler: fails correctly when export dir missing"
 
 step "Export (symlinks)"
 "${DDPHOTOS[@]}" export
@@ -300,6 +308,11 @@ symlinks=$(find "$EXPORT_DIR" -type l)
 [ -z "$symlinks" ] || fail "export --copy still has symlinks: $symlinks"
 FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
 pass "export --copy OK ($FILE_COUNT files, no symlinks)"
+
+step "Wrangler w/out --cloudflare (_worker.js missing)"
+out=$("${DDPHOTOS_QUIET[@]}" wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
+echo "$out" | grep -q "not just 'export'" || (echo "$out" && fail "deploy: expected 'not just export' error when --cloudflare not used")
+pass "wrangler: fails correctly when _worker.js missing"
 
 step "Export --cloudflare"
 "${DDPHOTOS[@]}" export --cloudflare

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -280,7 +280,7 @@ pass "serve + Playwright + test-photos-server.sh OK"
 EXPORT_DIR="$TEST_DIR/export/$SITE_ID"
 
 step "Wrangler w/out export"
-out=$("${DDPHOTOS_QUIET[@]}" wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
 echo "$out" | grep -q "Run 'export --cloudflare' first" || (echo "$out" && fail "deploy: expected 'Run export first' error when export dir missing")
 pass "wrangler: fails correctly when export dir missing"
 
@@ -310,7 +310,7 @@ FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
 pass "export --copy OK ($FILE_COUNT files, no symlinks)"
 
 step "Wrangler w/out --cloudflare (_worker.js missing)"
-out=$("${DDPHOTOS_QUIET[@]}" wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
+out=$("${DDPHOTOS_QUIET[@]}" --non-interactive wrangler pages deploy --project-name docker-test export/$SITE_ID 2>&1) || true
 echo "$out" | grep -q "not just 'export'" || (echo "$out" && fail "deploy: expected 'not just export' error when --cloudflare not used")
 pass "wrangler: fails correctly when _worker.js missing"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=node-builder /app/web/node_modules /app/web/node_modules
 # Docker scripts
 COPY docker/entrypoint.sh docker/do-init.sh docker/do-photogen.sh \
      docker/do-build.sh docker/do-serve.sh docker/do-run.sh docker/do-export.sh docker/do-deploy.sh \
-     docker/do-decode.sh docker/do-search-cover.sh docker/do-wrangler.sh \
+     docker/do-decode.sh docker/do-search-cover.sh docker/do-wrangler.sh docker/do-surge.sh \
      docker/ddphotos docker/cloudflare-worker.js \
      web/setup-htdocs.sh bin/deploy-photos.sh bin/test-photos-server.sh /docker/
 RUN chmod +x /docker/*.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,8 +57,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 
-# Use a symlink so __dirname-relative paths in npm-cli.js resolve correctly
-RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+# Use symlinks so __dirname-relative paths in npm-cli.js / npx-cli.js resolve correctly
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Apache: enable mod_rewrite, replace default site with ddphotos config
 RUN a2enmod rewrite headers && a2dissite 000-default 2>/dev/null || true \
@@ -77,7 +78,8 @@ COPY --from=node-builder /app/web/node_modules /app/web/node_modules
 # Docker scripts
 COPY docker/entrypoint.sh docker/do-init.sh docker/do-photogen.sh \
      docker/do-build.sh docker/do-serve.sh docker/do-run.sh docker/do-export.sh docker/do-deploy.sh \
-     docker/do-decode.sh docker/do-search-cover.sh docker/ddphotos docker/cloudflare-worker.js \
+     docker/do-decode.sh docker/do-search-cover.sh docker/do-wrangler.sh \
+     docker/ddphotos docker/cloudflare-worker.js \
      web/setup-htdocs.sh bin/deploy-photos.sh bin/test-photos-server.sh /docker/
 RUN chmod +x /docker/*.sh
 

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # https://github.com/dougdonohoe/ddphotos
-set -e
+set -eo pipefail
 
 # IMAGE is replaced at docker build time (see Dockerfile).  In a production
 # build it will be something like dougdonohoe/ddphotos:v.1.##.0.
@@ -202,7 +202,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version) ;;
+    init|upgrade|help|version|wrangler) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
@@ -251,7 +251,7 @@ case "$cmd" in
             esac
         done
         if [[ $# -ne 1 ]]; then
-            echo "Usage: ddphotos [OPTIONS] decode [--passwords <file>] <file.enc.json>" >&2
+            echo "Usage: ddphotos [options] decode [--passwords <file>] <file.enc.json>" >&2
             exit 1
         fi
 
@@ -289,7 +289,7 @@ case "$cmd" in
 
     search-cover)
         if [[ $# -ne 1 ]]; then
-            echo "Usage: ddphotos [OPTIONS] search-cover <url>" >&2
+            echo "Usage: ddphotos [options] search-cover <url>" >&2
             exit 1
         fi
         print_mounts
@@ -364,6 +364,66 @@ case "$cmd" in
             "$IMAGE" deploy "$@"
         ;;
 
+    wrangler)
+        # Pass Cloudflare credentials from the host environment into the container.
+        # CLOUDFLARE_API_TOKEN is the preferred auth method for non-interactive use;
+        # the others cover legacy global API key auth and explicit account targeting.
+        WRANGLER_ENV=()
+        for var in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_EMAIL CLOUDFLARE_API_KEY; do
+            [ -n "${!var}" ] && WRANGLER_ENV+=(-e "$var=${!var}")
+        done
+        if [[ "${1:-}" == "login" ]]; then
+            # wrangler login runs an OAuth flow:
+            #   1. wrangler starts a temporary HTTP server on port 8976 to receive the callback
+            #   2. the user visits a Cloudflare URL in their browser and approves access
+            #   3. Cloudflare redirects to localhost:8976/oauth/callback
+            #   4. wrangler exchanges the code for a token and saves it to ~/.config/.wrangler/
+            #
+            # Running inside Docker complicates steps 1 and 2:
+            #   - --callback-host 0.0.0.0 makes wrangler bind on all interfaces (not just 127.0.0.1)
+            #     so Docker's port forwarding can reach it
+            #   - -p 8976:8976 forwards localhost:8976 on the host into the container
+            #   - --browser false suppresses wrangler's own browser-open attempt (no display in container)
+            #   - we pipe docker output through the host, detect the https:// URL, and open it ourselves
+            [[ " $* " != *" --callback-host "* ]] && set -- "$@" --callback-host 0.0.0.0
+            [[ " $* " != *" --browser "* ]]       && set -- "$@" --browser false
+            print_mounts
+            # No -it: wrangler login needs no terminal input; piping requires it off.
+            # Merge stderr into stdout (2>&1) so the URL line is visible to the while loop.
+            docker run --rm \
+                -w /ddphotos \
+                -v ddphotos-npm-cache:/root/.npm \
+                -v ddphotos-wrangler-config:/root/.config/.wrangler \
+                -p 8976:8976 \
+                "${MOUNT_FLAGS[@]}" \
+                "${WRANGLER_ENV[@]}" \
+                "$IMAGE" wrangler "$@" 2>&1 | \
+            while IFS= read -r line; do
+                printf '%s\n' "$line"
+                # Auto-open the Cloudflare auth URL in the host browser (open=Mac, xdg-open=Linux)
+                if [[ "$line" =~ (https://[^[:space:]]+) ]]; then
+                    if command -v open >/dev/null 2>&1; then
+                        open "${BASH_REMATCH[1]}"
+                    elif command -v xdg-open >/dev/null 2>&1; then
+                        xdg-open "${BASH_REMATCH[1]}" 2>/dev/null &
+                    fi
+                fi
+            done
+        else
+            # All other wrangler subcommands (pages deploy, whoami, etc.) run normally.
+            # Working dir is /ddphotos so relative paths like export/<site-id> resolve correctly.
+            # Credentials are read from the ddphotos-wrangler-config volume (populated by login).
+            print_mounts
+            docker run --rm "${IT_FLAGS[@]}" \
+                -w /ddphotos \
+                -v ddphotos-npm-cache:/root/.npm \
+                -v ddphotos-wrangler-config:/root/.config/.wrangler \
+                "${MOUNT_FLAGS[@]}" \
+                "${WRANGLER_ENV[@]}" \
+                "$IMAGE" wrangler "$@"
+        fi
+        ;;
+
     upgrade)
         UPGRADE_IMAGE="$IMAGE"
         if [[ "$CURRENT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -f "$UPGRADE_FILE" ]; then
@@ -387,7 +447,7 @@ case "$cmd" in
 
     help|*)
         [ "$cmd" != "help" ] && { echo "Unknown command: '$cmd'" >&2; echo "" >&2; }
-        echo "Usage: ddphotos [OPTIONS] {init|photogen|decode|search-cover|build|serve|run|export|deploy|upgrade} [args]"
+        echo "Usage: ddphotos [options] [command] [args]"
         echo ""
         echo "Options (before command):"
         echo "  --dir DIR          Directory to mount as /ddphotos (default: script location)"
@@ -411,6 +471,12 @@ case "$cmd" in
         echo "                        --cloudflare           Adds _worker.js for Cloudflare Pages photo permalinks"
         echo "                        --export-site-id [id]  Use export/<id>/ as destination instead of export/<site-id>/"
         echo "  deploy              Deploy build and albums to remote host"
+        echo "  wrangler [args]     Run wrangler (Cloudflare CLI) via npx; working dir is set to --dir"
+        echo "                        Paths like export/<site-id> resolve relative to --dir"
+        echo "                        Credentials: use 'wrangler login' or set CLOUDFLARE_API_TOKEN"
+        echo "                        'wrangler login' exposes port 8976 and opens the auth URL in your browser"
+        echo "                        Credentials cached in Docker volume 'ddphotos-wrangler-config'"
+        echo "                        First run downloads wrangler; cached in Docker volume 'ddphotos-npm-cache'"
         echo "  upgrade             Update this script to match the current 'ddphotos' image"
         echo "  version             Print script location, image, and config paths (no Docker required)"
         echo "                        --image  Also query the image for its version and git info"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -202,7 +202,7 @@ host_to_container() {
 
 # For commands that need a config, validate albums.yaml exists before launching Docker.
 case "$cmd" in
-    init|upgrade|help|version|wrangler) ;;
+    init|upgrade|help|version|wrangler|surge) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
             echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
@@ -424,6 +424,26 @@ case "$cmd" in
         fi
         ;;
 
+    surge)
+        SURGE_ENV=()
+        for var in SURGE_LOGIN SURGE_TOKEN; do
+            [ -n "${!var}" ] && SURGE_ENV+=(-e "$var=${!var}")
+        done
+        # Surge stores credentials in ~/.netrc. Mount it read-write so surge can write credentials
+        # on first login and read them on subsequent deploys. Create the file first if it doesn't
+        # exist — Docker would otherwise create a directory at that path on bind-mount.
+        [ -f "$HOME/.netrc" ] || { touch "$HOME/.netrc"; chmod 600 "$HOME/.netrc"; }
+        add_mount "$HOME/.netrc" /root/.netrc
+        print_mounts
+        # Working dir is /ddphotos so relative paths like export/<site-id> resolve correctly.
+        docker run --rm "${IT_FLAGS[@]}" \
+            -w /ddphotos \
+            -v ddphotos-npm-cache:/root/.npm \
+            "${MOUNT_FLAGS[@]}" \
+            "${SURGE_ENV[@]}" \
+            "$IMAGE" surge "$@"
+        ;;
+
     upgrade)
         UPGRADE_IMAGE="$IMAGE"
         if [[ "$CURRENT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -f "$UPGRADE_FILE" ]; then
@@ -477,6 +497,12 @@ case "$cmd" in
         echo "                        'wrangler login' exposes port 8976 and opens the auth URL in your browser"
         echo "                        Credentials cached in Docker volume 'ddphotos-wrangler-config'"
         echo "                        First run downloads wrangler; cached in Docker volume 'ddphotos-npm-cache'"
+        echo "  surge [args]        Run surge (static hosting CLI) via npx; working dir is set to --dir"
+        echo "                        Paths like export/<site-id> resolve relative to --dir"
+        echo "                        Credentials stored in ~/.netrc (mounted read-write into container)"
+        echo "                        Set SURGE_LOGIN and SURGE_TOKEN to authenticate non-interactively"
+        echo "                        Export must use --copy — Surge does not follow symlinks"
+        echo "                        First run downloads surge; cached in Docker volume 'ddphotos-npm-cache'"
         echo "  upgrade             Update this script to match the current 'ddphotos' image"
         echo "  version             Print script location, image, and config paths (no Docker required)"
         echo "                        --image  Also query the image for its version and git info"

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -9,7 +9,6 @@ IMAGE="ddphotos"
 
 # Setup
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CURRENT_VERSION="${IMAGE##*:}"
 STATE_DIR="${HOME}/.config/ddphotos"
 UPGRADE_FILE="$STATE_DIR/upgrade.txt"
 mkdir -p "$STATE_DIR"
@@ -27,9 +26,13 @@ while [[ "${1:-}" == --?* ]]; do
         --site-env)        OPT_SITE_ENV="$2";     shift 2 ;;
         --non-interactive) NON_INTERACTIVE=true;  shift ;;
         --show-mounts)     SHOW_MOUNTS=true;      shift ;;
+        --dev)             IMAGE="ddphotos";      shift ;;  # use locally-built image instead of pinned release
         *) echo "Unknown option: $1" >&2; echo "Options must appear before the command. Run 'ddphotos help' for usage." >&2; exit 1 ;;
     esac
 done
+
+# Determine current version here (might change in --dev mode)
+CURRENT_VERSION="${IMAGE##*:}"
 
 # Default to help if no cmd
 cmd="${1:-help}"
@@ -475,6 +478,7 @@ case "$cmd" in
         echo "  --config-dir DIR   Config directory override (default: albums-dir/config)"
         echo "  --site-env FILE    Path to site.env for deploy (default: config-dir/site.env)"
         echo "  --show-mounts      Print Docker volume mounts before running the command"
+        echo "  --dev              Use the local 'ddphotos' image instead of the pinned release tag"
         echo ""
         echo "Commands:"
         echo "  init                Initialize config scaffold"

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -50,9 +50,9 @@ chmod +x /ddphotos/ddphotos
 if [ -n "$SCRIPT_ONLY" ]; then
     echo "Standalone 'ddphotos' script installed."
     echo
-    echo "Usage with a separate albums directory:"
+    echo "Use --dir to specify your DD Photos directory (the one with config|albums|build|export):"
     echo
-    echo "  ddphotos --dir ~/my-ddphotos photogen|run|build|serve|export|upgrade|version"
+    echo "  ddphotos --dir ~/my-ddphotos [command]"
     echo
     exit 0
 fi

--- a/docker/do-surge.sh
+++ b/docker/do-surge.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Surge CLI via npx. On first run surge downloads into the npm cache
+# (mounted as a named Docker volume by the ddphotos wrapper so it persists).
+# Credentials are stored in ~/.netrc (mounted read-write from the host by the wrapper).
+# Surge does not follow symlinks — the export directory must be created with --copy.
+
+# Find the deploy directory: first non-flag arg (skip --flag value pairs).
+DEPLOY_DIR=""
+skip_next=false
+for arg in "$@"; do
+    if $skip_next; then skip_next=false; continue; fi
+    if [[ "$arg" == --* ]]; then
+        [[ "$arg" != *=* ]] && skip_next=true
+        continue
+    fi
+    DEPLOY_DIR="$arg"
+    break
+done
+
+# Only validate if DEPLOY_DIR looks like a path (contains / or is . or ..).
+# Bare words like 'list', 'whoami', 'login' are surge subcommands, not directories.
+if [ -n "$DEPLOY_DIR" ] && [[ "$DEPLOY_DIR" == */* || "$DEPLOY_DIR" == "." || "$DEPLOY_DIR" == ".." ]]; then
+    if [ ! -d "$DEPLOY_DIR" ]; then
+        echo "Error: $DEPLOY_DIR not found. Run 'ddphotos export --copy' first."
+        exit 1
+    elif [ -L "$DEPLOY_DIR/index.html" ]; then
+        echo "Error: $DEPLOY_DIR contains symlinks. Run 'ddphotos export --copy' (not just 'export') — Surge does not follow symlinks."
+        exit 1
+    fi
+fi
+
+exec npx --yes surge "$@"

--- a/docker/do-wrangler.sh
+++ b/docker/do-wrangler.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Cloudflare CLI via npx. On first run wrangler downloads into the npm cache
+# (mounted as a named Docker volume by the ddphotos wrapper so it persists).
+# Credentials via 'wrangler login' (port 8976 is exposed by the wrapper for the
+# OAuth callback) or CLOUDFLARE_API_TOKEN. Stored in ddphotos-wrangler-config volume.
+
+# For 'wrangler pages deploy', verify the export was run with --cloudflare.
+# The deploy directory is the first non-flag arg after 'pages deploy'.
+if [[ "${1:-}" == "pages" && "${2:-}" == "deploy" ]]; then
+    DEPLOY_DIR=""
+    skip_next=false
+    for arg in "${@:3}"; do
+        if $skip_next; then skip_next=false; continue; fi
+        if [[ "$arg" == --* ]]; then
+            # If the flag doesn't embed its value (--flag=value), the next arg is the value
+            [[ "$arg" != *=* ]] && skip_next=true
+            continue
+        fi
+        DEPLOY_DIR="$arg"
+        break
+    done
+    if [ -n "$DEPLOY_DIR" ]; then
+        if [ ! -d "$DEPLOY_DIR" ]; then
+            echo "Error: $DEPLOY_DIR not found. Run 'export --cloudflare' first."
+            exit 1
+        elif [ ! -f "$DEPLOY_DIR/_worker.js" ]; then
+            echo "Error: $DEPLOY_DIR/_worker.js not found. Run 'export --cloudflare' (not just 'export')."
+            exit 1
+        fi
+    fi
+fi
+
+exec npx --yes wrangler "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$#" -gt 0 ]; then shift; fi
 
 # Verify the mounted ddphotos script matches the image (only for commands that use it)
 case "$cmd" in
-    photogen|decode|search-cover|build|serve|run|export|deploy|wrangler)
+    photogen|decode|search-cover|build|serve|run|export|deploy|wrangler|surge)
         if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
             echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
             echo "          Run: 'ddphotos upgrade' to fix this." >&2
@@ -30,6 +30,7 @@ case "$cmd" in
     export)       exec /docker/do-export.sh "$@" ;;
     deploy)       exec /docker/do-deploy.sh "$@" ;;
     wrangler)     exec /docker/do-wrangler.sh "$@" ;;
+    surge)        exec /docker/do-surge.sh "$@" ;;
     version)
         echo "Version:  $(cat /docker/VERSION 2>/dev/null || echo unknown)"
         echo "Git:      $(cat /docker/GIT_DESCRIBE 2>/dev/null || echo unknown)"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$#" -gt 0 ]; then shift; fi
 
 # Verify the mounted ddphotos script matches the image (only for commands that use it)
 case "$cmd" in
-    photogen|decode|search-cover|build|serve|run|export|deploy)
+    photogen|decode|search-cover|build|serve|run|export|deploy|wrangler)
         if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
             echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
             echo "          Run: 'ddphotos upgrade' to fix this." >&2
@@ -29,6 +29,7 @@ case "$cmd" in
     run)          exec /docker/do-run.sh "$@" ;;
     export)       exec /docker/do-export.sh "$@" ;;
     deploy)       exec /docker/do-deploy.sh "$@" ;;
+    wrangler)     exec /docker/do-wrangler.sh "$@" ;;
     version)
         echo "Version:  $(cat /docker/VERSION 2>/dev/null || echo unknown)"
         echo "Git:      $(cat /docker/GIT_DESCRIBE 2>/dev/null || echo unknown)"
@@ -47,12 +48,10 @@ case "$cmd" in
         ;;
     help|*)
         [ "$cmd" != "help" ] && { echo "Unknown command: '$cmd'" >&2; echo >&2; }
-        echo "Usage: ddphotos [OPTIONS] COMMAND"
-        echo ""
-        echo "Commands: init, photogen, decode, search-cover, build, serve, run, export, deploy, upgrade, version"
+        echo "Usage: ddphotos [options] command"
         echo ""
         echo "This image is intended to be used via the 'ddphotos' wrapper script."
-        echo "See: https://github.com/dougdonohoe/ddphotos"
+        echo "Docs: https://github.com/dougdonohoe/ddphotos/blob/main/docs/DOCKER.md"
         echo ""
         [ "$cmd" = "help" ] || exit 1
         ;;

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -86,22 +86,22 @@ not needed).
 In Docker mode (`wrangler` is bundled — no local install needed):
 
 ```bash
-./ddphotos wrangler login   # one-time; credentials cached in Docker volume
 ./ddphotos export --cloudflare
+./ddphotos wrangler login   # one-time; credentials cached in Docker volume
 ./ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 ```
 
 In developer mode (requires `wrangler` installed locally: `npm install -g wrangler --ignore-scripts`):
 
 ```bash
-wrangler login
 export.sh --site-id <site-id> --cloudflare
+wrangler login
 wrangler pages deploy --project-name my-unique-site export/<site-id>
 ```
 
 The first deploy creates the project automatically and assigns a URL of
 https://my-unique-site.pages.dev. See [Cloudflare Pages Worker](DEPLOYMENT-SERVERS.md#cloudflare-pages-worker)
-for how routing works.
+for how page routing works.
 
 ### Surge
 
@@ -112,7 +112,8 @@ In Docker mode (`surge` is bundled — no local install needed):
 
 ```bash
 ./ddphotos export --copy
-./ddphotos surge --domain my-unique-site.surge.sh export/my-photos
+# prompts for login on first run; credentials cached in ~/.netrc
+./ddphotos surge --domain my-unique-site.surge.sh export/my-photos  
 ```
 
 In developer mode (requires `surge` installed locally: `npm install --global surge`):
@@ -124,7 +125,7 @@ surge --domain my-unique-site.surge.sh export/<site-id>
 
 The site will be at https://my-unique-site.surge.sh.
 
-See [Surge](DEPLOYMENT-SERVERS.md#surge) for routing behavior and known limitations.
+See [Surge](DEPLOYMENT-SERVERS.md#surge) for page routing behavior and known limitations.
 
 ## Apache + rsync
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -108,18 +108,18 @@ for how routing works.
 [Surge↗](https://surge.sh) is a simple, free alternative for hosting static sites.
 Export must use `--copy` since symlinks aren't followed.
 
-Assuming you have `surge` installed (`npm install --global surge`), in Docker mode:
+In Docker mode (`surge` is bundled — no local install needed):
 
 ```bash
 ./ddphotos export --copy
-./surge --domain my-unique-site.surge.sh export/my-photos
+./ddphotos surge --domain my-unique-site.surge.sh export/my-photos
 ```
 
-In developer mode:
+In developer mode (requires `surge` installed locally: `npm install --global surge`):
 
 ```bash
 export.sh --site-id <site-id> --copy
-./surge --domain my-unique-site.surge.sh export/<site-id>
+surge --domain my-unique-site.surge.sh export/<site-id>
 ```
 
 The site will be at https://my-unique-site.surge.sh.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -83,18 +83,20 @@ unlimited bandwidth. Photo permalink routing requires a `_worker.js` — use `--
 instead of `--copy` to generate it automatically (symlinks are followed, so `--copy` is
 not needed).
 
-Assuming you have `wrangler` installed (`npm install -g wrangler --ignore-scripts`), in Docker mode:
+In Docker mode (`wrangler` is bundled — no local install needed):
 
 ```bash
+./ddphotos wrangler login   # one-time; credentials cached in Docker volume
 ./ddphotos export --cloudflare
-wrangler pages deploy --project-name my-unique-site export/my-photos
+./ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 ```
 
-In developer mode:
+In developer mode (requires `wrangler` installed locally: `npm install -g wrangler --ignore-scripts`):
 
 ```bash
+wrangler login
 export.sh --site-id <site-id> --cloudflare
-wrangler pages deploy --project-name my-unique-site export/<site-id> 
+wrangler pages deploy --project-name my-unique-site export/<site-id>
 ```
 
 The first deploy creates the project automatically and assigns a URL of

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -33,16 +33,15 @@ cd ~/my-ddphotos
 ### 4. Deploy
 
 **Quick option — [Cloudflare Pages↗](https://pages.cloudflare.com)** - free, unlimited bandwidth (requires
-[Node.js](http://nodejs.org/) and a [Cloudflare account](https://dash.cloudflare.com/login)):
+a [Cloudflare account](https://dash.cloudflare.com/login); `wrangler` is bundled — no local install needed):
 
 ```bash
-# Install and login
-npm install -g wrangler --ignore-scripts
-wrangler login
+# One-time login (opens browser; credentials cached for future deploys)
+./ddphotos wrangler login
 
 # Export and deploy
 ./ddphotos export --cloudflare
-wrangler pages deploy --project-name my-unique-site export/my-photos
+./ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 ```
 
 The site will be at https://my-unique-site.pages.dev.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -100,14 +100,15 @@ ddphotos [options] [command] [args]
 
 These flags go before the command name and apply to all commands that need them:
 
-| Flag                  | Description                                                                                             |
-|-----------------------|---------------------------------------------------------------------------------------------------------|
-| `--dir <path>`        | Directory containing your `config` and `albums` dirs (default: same directory as the `ddphotos` script) |
-| `--config-dir <path>` | Path to a config directory other than `<dir>/config`                                                    |
-| `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                          |
-| `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                            |
-| `--non-interactive`   | Run `serve` and `run` without a TTY (no `-it` flag) — useful for scripted/CI contexts                   |
-| `--show-mounts`       | Print the Docker volume mounts before running the command — useful for debugging mount issues           |
+| Flag                  | Description                                                                                                |
+|-----------------------|------------------------------------------------------------------------------------------------------------|
+| `--dir <path>`        | Directory containing your `config` and `albums` dirs (default: same directory as the `ddphotos` script)    |
+| `--config-dir <path>` | Path to a config directory other than `<dir>/config`                                                       |
+| `--site-id <id>`      | Override the site ID (normally read from `config/albums.yaml`)                                             |
+| `--site-env <path>`   | Path to a `site.env` file other than `<config-dir>/site.env`                                               |
+| `--non-interactive`   | Run `serve` and `run` without a TTY (no `-it` flag) — useful for scripted/CI contexts                      |
+| `--show-mounts`       | Print the Docker volume mounts before running the command — useful for debugging mount issues              |
+| `--dev`               | Use the locally-built `ddphotos` image instead of the pinned release tag — useful for testing local builds |
 
 Example — using a separate source repo as the albums dir:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -46,16 +46,13 @@ a [Cloudflare account](https://dash.cloudflare.com/login); `wrangler` is bundled
 
 The site will be at https://my-unique-site.pages.dev.
 
-**Quick option — [Surge↗](https://surge.sh)** - free, one command, no server required (requires
-[Node.js](http://nodejs.org/)):
+**Quick option — [Surge↗](https://surge.sh)** - free, one command, no server required (`surge` is
+bundled — no local install needed):
 
 ```bash
-# Install
-npm install --global surge
-
-# Export and deploy (and on 1st time, create account/login)
+# Export and deploy (prompts for login on first run)
 ./ddphotos export --copy
-surge --domain my-unique-site.surge.sh export/my-photos
+./ddphotos surge --domain my-unique-site.surge.sh export/my-photos
 ```
 
 The site will be at https://my-unique-site.surge.sh.
@@ -224,7 +221,7 @@ Use `--copy` to produce real files instead of symlinks — required for services
 
 ```bash
 ddphotos export --copy
-surge --domain my-unique-site.surge.sh export/my-photos
+ddphotos surge --domain my-unique-site.surge.sh export/my-photos
 ```
 
 Use `--cloudflare` for [Cloudflare Pages↗](https://pages.cloudflare.com) — adds a `_worker.js`
@@ -232,7 +229,7 @@ for photo permalink routing (symlinks are followed, so `--copy` is not needed):
 
 ```bash
 ddphotos export --cloudflare
-wrangler pages deploy --project-name my-unique-site export/my-photos
+ddphotos wrangler pages deploy --project-name my-unique-site export/my-photos
 ```
 
 See [Cloudflare Pages Worker](DEPLOYMENT-SERVERS.md#cloudflare-pages-worker) for details.

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -1829,3 +1829,70 @@ Four GitHub Actions secrets are required, set via `gh secret set`:
 on a feature branch without merging, a temporary `push:` trigger was added targeting
 the branch. Once the push registered the workflow, `gh workflow run --ref <branch>`
 worked for subsequent manual triggers. The `push:` trigger was removed before merging.
+
+### 73. 05/10/2026 - Bundle `wrangler` and `surge` as Docker Commands
+
+Added `ddphotos wrangler` and `ddphotos surge` commands so users don't need Node.js,
+nvm, or those tools installed locally.
+
+#### Approach: npx On-Demand
+
+Bundling wrangler directly added ~200MB (it ships `workerd`, a full V8 runtime). Instead,
+tools are downloaded on first use via `npx --yes` and cached in a named Docker volume
+(`ddphotos-npm-cache`). Zero image bloat; subsequent runs are instant from cache.
+
+The Dockerfile adds an `npx` symlink alongside the existing `npm` symlink:
+```dockerfile
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+```
+
+#### New Files
+
+- `docker/do-wrangler.sh` — npx passthrough; validates `pages deploy` arguments
+  (checks deploy directory exists and contains `_worker.js` from `--cloudflare` export)
+- `docker/do-surge.sh` — npx passthrough; validates deploy directory exists and has no
+  symlinks (Surge doesn't follow symlinks); uses a path heuristic to skip the check for
+  Surge subcommands like `list` or `whoami`
+
+#### wrangler Login
+
+OAuth login redirects to `localhost:8976` but the server is inside the container.
+Three-part fix:
+1. Inject `--callback-host 0.0.0.0` so wrangler binds all interfaces
+2. Expose `-p 8976:8976` in the Docker run command
+3. Inject `--browser false`; pipe output and call `open`/`xdg-open` from the host
+   when a URL appears in the output
+
+Credentials persist in a named Docker volume (`ddphotos-wrangler-config`).
+
+Four Cloudflare env vars are forwarded into the container when set:
+`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (modern token auth),
+`CLOUDFLARE_EMAIL`, `CLOUDFLARE_API_KEY` (legacy global API key).
+
+#### surge Credentials
+
+Surge stores credentials in `~/.netrc`. The wrapper bind-mounts `~/.netrc` read-write
+(creating an empty 600-mode file first if it doesn't exist, to prevent Docker from
+creating a directory at that path). `SURGE_LOGIN`/`SURGE_TOKEN` env vars are forwarded
+for non-interactive CI use.
+
+#### Flag-Value Skipping
+
+Both `do-wrangler.sh` and `do-surge.sh` use a `skip_next` pattern when scanning
+positional arguments so that flag values like `--project-name ddphotos-init` are not
+mistaken for directory paths.
+
+#### CI and deploy-sample-sites.sh
+
+`bin/deploy-sample-sites.sh` updated to call `"$site_dir/ddphotos" wrangler pages deploy ...`
+and `"$site_dir/ddphotos" surge ...` instead of bare `wrangler`/`surge` commands.
+`.github/workflows/deploy-sample-sites.yml` drops the "Setup Node" and "Install wrangler
+and surge" steps entirely — both tools now run through Docker.
+
+#### Documentation
+
+- `README.md` — quick-start commands updated to `./ddphotos wrangler` / `./ddphotos surge`
+- `docs/DOCKER.md` — Cloudflare and Surge sections updated; bundled note added; removed
+  local install requirement for Docker mode
+- `docs/DEPLOY.md` — Docker mode vs developer mode split for both Cloudflare Pages and
+  Surge sections; developer mode still requires local npm install


### PR DESCRIPTION
Bundle `wrangler` (Cloudflare CLI) and `surge` as `ddphotos` commands so users don't
need Node.js, nvm, or those tools installed locally.

## What Changed

### Approach: npx on demand

Bundling wrangler directly adds ~200MB (it ships `workerd`, a full V8 runtime). Instead,
both tools download on first use via `npx --yes` and cache in a named Docker volume
(`ddphotos-npm-cache`). Zero image bloat; subsequent runs are instant.

### New commands

- `ddphotos wrangler [args]` — full wrangler passthrough
- `ddphotos surge [args]` — full surge passthrough

### wrangler login

OAuth login works out of the box: the wrapper injects `--callback-host 0.0.0.0` and
`--browser false`, exposes port 8976, and pipes wrangler output to detect the auth URL
and call `open`/`xdg-open` on the host automatically.

Credentials persist across runs in a named Docker volume (`ddphotos-wrangler-config`).

### surge credentials

`~/.netrc` is bind-mounted read-write (created if missing) so credentials survive
between sessions. `SURGE_LOGIN`/`SURGE_TOKEN` env vars are forwarded for CI use.

### Precondition checks

- `wrangler pages deploy` validates the deploy directory exists and contains `_worker.js`
  (ensuring `export --cloudflare` was used, not plain `export`)
- `surge <dir>` validates the directory exists and contains no symlinks (Surge doesn't
  follow them); bare subcommands like `surge list` bypass the check

### CI / deploy-sample-sites.sh

`bin/deploy-sample-sites.sh` now invokes `ddphotos wrangler` and `ddphotos surge`
instead of bare commands. The CI workflow drops Node setup and npm installs entirely.

### Misc

Add `--dev` flag to `ddphotos`, to run with local `ddphotos` image instead.  Make this useful to swap a prod install of the script with whatever is in local image.  E.g.,

```
make docker-build
ddphotos --dev upgrade
```

### Documentation

`README.md`, `docs/DOCKER.md`, and `docs/DEPLOY.md` updated to reflect Docker-bundled
vs developer-mode install for both Cloudflare Pages and Surge.

## Test plan

- [x] `ddphotos wrangler login` opens browser, stores credentials in Docker volume
- [x] `ddphotos wrangler pages deploy --project-name <name> export/<site-id>` deploys successfully
- [x] `ddphotos wrangler pages deploy` with missing dir or missing `_worker.js` prints clear error
- [x] `ddphotos surge --domain <domain> export/<site-id>` deploys successfully
- [x] `ddphotos surge export/no-such-dir` prints "not found" error
- [x] `ddphotos surge export/<site-id>` (symlink export) prints "contains symlinks" error
- [x] `ddphotos surge list` bypasses directory check
- [x] `make docker-test --skip-playwright` passes all wrangler and surge error tests
- [x] Deploy sample sites CI workflow runs without Node setup steps
