### PR TITLE
s3 support for CI deployments

### DIFF
--- a/.github/workflows/deploy-sample-sites.yml
+++ b/.github/workflows/deploy-sample-sites.yml
@@ -3,10 +3,13 @@ name: Deploy Sample Sites
 # Triggered manually or automatically after a successful Docker Release.
 #
 # Required GitHub Actions secrets:
-#   CLOUDFLARE_API_TOKEN — Cloudflare API token with Cloudflare Pages: Edit permission
+#   CLOUDFLARE_API_TOKEN  — Cloudflare API token with Cloudflare Pages: Edit permission
 #   CLOUDFLARE_ACCOUNT_ID — Cloudflare account ID
-#   SURGE_LOGIN — Surge account email
-#   SURGE_TOKEN — Surge token (run 'surge token' locally to obtain)
+#   SURGE_LOGIN           — Surge account email
+#   SURGE_TOKEN           — Surge token (run 'surge token' locally to obtain)
+#   DDPHOTOS_DEPLOY_ROLE_ARN     — IAM role ARN for OIDC deploy (from Terraform output)
+#   DDPHOTOS_CF_ID               — CloudFront distribution ID for ddphotos.donohoe.info
+#   DDPHOTOS_TEST_CF_ID          — CloudFront distribution ID for ddphotos-test.donohoe.info
 on:
   workflow_dispatch:
   workflow_run:
@@ -15,6 +18,10 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+  id-token: write   # required for OIDC AWS authentication
 
 jobs:
   deploy:
@@ -25,12 +32,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DDPHOTOS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Deploy sample sites
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          DDPHOTOS_CF_ID: ${{ secrets.DDPHOTOS_CF_ID }}
+          DDPHOTOS_TEST_CF_ID: ${{ secrets.DDPHOTOS_TEST_CF_ID }}
         run: bin/deploy-sample-sites.sh --doit
 
       - name: Verify sample sites

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -134,9 +134,6 @@ _setup_site() {
         docker run "${PULL_FLAG[@]}" --rm -v "$site_dir":/ddphotos "$IMAGE" init --script-only
     fi
 
-    # Temp fix: cp in do-init.sh preserves rw-r--r-- on config files; remove once a new image is released.
-    chmod -R a+w "$site_dir/config"
-
     if [ "$site" = "sample" ]; then
         echo "config: copy sample/config"
         /bin/rm -rf "$site_dir/config"
@@ -181,6 +178,10 @@ _run_s3() {
         "$SCRIPT_DIR/test-photos-server.sh" --remote "$s3_url" --s3
         return
     fi
+
+    # TODO: Temp fix: Docker init creates site.env as root-owned rw-r--r--; delete so we can recreate it.
+    #       Remove once do-init.sh's chmod a+w is in a released image.
+    /bin/rm -f "$site_dir/config/site.env"
     {
         printf 'S3_BUCKET=%s\n' "$s3_bucket"
         [ -n "$s3_cf_id" ] && printf 'CLOUDFRONT_ID=%s\n' "$s3_cf_id"

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -133,11 +133,9 @@ _setup_site() {
         echo "docker: init --script-only ($site_dir exists)"
         docker run "${PULL_FLAG[@]}" --rm -v "$site_dir":/ddphotos "$IMAGE" init --script-only
     fi
-    # Docker creates config/ as root; make it writable so the host user can write site.env etc.
-    #chmod a+w "$site_dir/config"
 
-    echo "site_dir $site_dir:"
-    ls -Rl $site_dir
+    # Temp fix: cp in do-init.sh preserves rw-r--r-- on config files; remove once a new image is released.
+    chmod -R a+w "$site_dir/config"
 
     if [ "$site" = "sample" ]; then
         echo "config: copy sample/config"

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -43,6 +43,7 @@
 #   --help        Show this usage message
 
 set -eo pipefail
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -132,6 +133,11 @@ _setup_site() {
         echo "docker: init --script-only ($site_dir exists)"
         docker run "${PULL_FLAG[@]}" --rm -v "$site_dir":/ddphotos "$IMAGE" init --script-only
     fi
+    # Docker creates config/ as root; make it writable so the host user can write site.env etc.
+    #chmod a+w "$site_dir/config"
+
+    echo "site_dir $site_dir:"
+    ls -Rl $site_dir
 
     if [ "$site" = "sample" ]; then
         echo "config: copy sample/config"

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -6,29 +6,37 @@
 #   - sample: the sample site in this repo (sample/)
 #
 # Usage:
-#   bin/deploy-sample-sites.sh [--init] [--sample] [--surge] [--cloudflare] [--dev] [--doit]
+#   bin/deploy-sample-sites.sh [--init] [--sample] [--surge] [--cloudflare] [--s3] [--dev] [--doit]
 #
 # Sites:
 #   Surge:
-#     Init:     https://ddphotos-init.surge.sh (old, now redirects https://ddphotos-test-docker.surge.sh/)
+#     Init:     https://ddphotos-init.surge.sh   (old, now redirects https://ddphotos-test-docker.surge.sh/)
 #     Sample:   https://ddphotos-sample.surge.sh (old, now redirects https://ddphotos-test-sample.surge.sh/)
 #   Cloudflare:
 #     Init:     https://ddphotos-init.pages.dev
 #     Sample:   https://ddphotos-sample.pages.dev
 #     Sample 2: https://my-unique-site.pages.dev/
+#   S3/CloudFront:
+#     Init:     https://ddphotos-test.donohoe.info  (bucket: ddphotos-test-donohoe-info)
+#     Sample:   https://ddphotos.donohoe.info       (bucket: ddphotos-donohoe-info)
 #
 # With no site flags, both sites are deployed.
-# With no provider flags, both providers are used.
+# With no provider flags, all providers are used.
 # Flags combine: --cloudflare --sample deploys only sample to Cloudflare.
-# Without --doit, everything runs except the final surge/wrangler upload.
+# Without --doit, everything runs except the final surge/wrangler/S3 upload.
+#
+# S3 credentials: set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN in the
+# environment, or configure ~/.aws. CloudFront invalidation requires DDPHOTOS_CF_ID
+# (sample site) and DDPHOTOS_TEST_CF_ID (init site) to be set.
 #
 # Options:
 #   --init        Deploy init site only
 #   --sample      Deploy sample site only
 #   --surge       Deploy to surge.sh only
 #   --cloudflare  Deploy to Cloudflare Pages only
+#   --s3          Deploy to S3/CloudFront only
 #   --dev         Use local 'ddphotos' image (default: dougdonohoe/ddphotos:latest)
-#   --doit        Actually upload to surge/wrangler (default: dry-run, skips upload)
+#   --doit        Actually upload to surge/wrangler/S3 (default: dry-run, skips upload)
 #   --no-photogen Skip the photogen step
 #   --no-build    Skip the build step
 #   --verify      Instead of deploying, verify each site via test-photos-server.sh
@@ -49,6 +57,7 @@ INIT_EXPLICIT=false
 SAMPLE_EXPLICIT=false
 SURGE_EXPLICIT=false
 CLOUDFLARE_EXPLICIT=false
+S3_EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -56,20 +65,22 @@ while [[ $# -gt 0 ]]; do
         --sample)      SAMPLE_EXPLICIT=true;           shift ;;
         --surge)       SURGE_EXPLICIT=true;            shift ;;
         --cloudflare)  CLOUDFLARE_EXPLICIT=true;       shift ;;
+        --s3)          S3_EXPLICIT=true;               shift ;;
         --dev)         IMAGE="ddphotos"; PULL_FLAG=(); shift ;;
         --doit)        DOIT=true;                      shift ;;
         --no-photogen) DO_PHOTOGEN=false;              shift ;;
         --no-build)    DO_BUILD=false;                 shift ;;
         --verify)      VERIFY=true;                    shift ;;
         --help|-h)
-            echo "Usage: bin/deploy-sample-sites.sh [--init] [--sample] [--surge] [--cloudflare] [--dev] [--doit]"
+            echo "Usage: bin/deploy-sample-sites.sh [--init] [--sample] [--surge] [--cloudflare] [--s3] [--dev] [--doit]"
             echo ""
             echo "  --init        Deploy init site only (default: both sites)"
             echo "  --sample      Deploy sample site only (default: both sites)"
             echo "  --surge       Deploy to surge.sh only (default: both providers)"
             echo "  --cloudflare  Deploy to Cloudflare Pages only (default: both providers)"
+            echo "  --s3          Deploy to S3/CloudFront only (default: both providers)"
             echo "  --dev         Use local 'ddphotos' image (default: dougdonohoe/ddphotos:latest)"
-            echo "  --doit        Actually upload to surge/wrangler (default: dry-run, skips upload)"
+            echo "  --doit        Actually upload to surge/wrangler/S3 (default: dry-run, skips upload)"
             echo "  --no-photogen Skip the photogen step"
             echo "  --no-build    Skip the build step"
             echo "  --verify      Instead of deploying, verify each site via test-photos-server.sh"
@@ -88,12 +99,14 @@ else
     DO_SAMPLE=true
 fi
 
-if $SURGE_EXPLICIT || $CLOUDFLARE_EXPLICIT; then
+if $SURGE_EXPLICIT || $CLOUDFLARE_EXPLICIT || $S3_EXPLICIT; then
     DO_SURGE=$SURGE_EXPLICIT
     DO_CLOUDFLARE=$CLOUDFLARE_EXPLICIT
+    DO_S3=$S3_EXPLICIT
 else
     DO_SURGE=true
     DO_CLOUDFLARE=true
+    DO_S3=true
 fi
 
 DEPLOY_DIR="$HOME/junk/ddphotos-deploy"
@@ -103,42 +116,12 @@ mkdir -p "$DEPLOY_DIR"
 
 step() { echo; echo "=== $* ==="; }
 
-# ---------------------------------------------------------------------------
-# Build and deploy one site to one or more targets.
-# Usage: _deploy_site <site> "<wrangler-project>:<surge-domain>" [...]
-#
-# Each target is a colon-separated pair; surge-domain may be empty to skip surge.
-# photogen and build run once, then all targets are deployed.
-# ---------------------------------------------------------------------------
-_deploy_site() {
-    local site="$1"
-    local site_url="$2"
-    shift 2
+# Docker init, config copy, photogen, build — runs once per site before any provider deploy.
+# Usage: _setup_site <site> <site_url>
+#   site_url: passed to photogen -site-url (empty to use config default)
+_setup_site() {
+    local site="$1" site_url="$2"
     local site_dir="$DEPLOY_DIR/$site"
-
-    step "Site: $site"
-
-    if $VERIFY; then
-        for target in "$@"; do
-            local wrangler_project="${target%%:*}"
-            local surge_domain="${target#*:}"
-
-            if $DO_CLOUDFLARE; then
-                local url="https://${wrangler_project}.pages.dev"
-                echo
-                echo "=== Validating $site @ cloudflare: $url ==="
-                "$SCRIPT_DIR/test-photos-server.sh" --remote "$url" --cloudflare
-            fi
-
-            if $DO_SURGE && [ -n "$surge_domain" ]; then
-                local url="https://${surge_domain}"
-                echo
-                echo "=== Validating $site @ surge: $url ==="
-                "$SCRIPT_DIR/test-photos-server.sh" --remote "$url" --surge
-            fi
-        done
-        return
-    fi
 
     mkdir -p "$site_dir"
 
@@ -157,6 +140,13 @@ _deploy_site() {
         # Fix relative base path to absolute so Docker can mount the sample source directory
         sed -i.bak "s|sample: sample/source|sample: $REPO_ROOT/sample/source|" "$site_dir/config/albums.yaml"
         /bin/rm "$site_dir/config/albums.yaml.bak"
+    else
+        # Replace the default placeholder domain written by 'ddphotos init' with the real site URL
+        if [ -n "$site_url" ]; then
+            local domain="${site_url#https://}"
+            sed -i.bak "s/your-ddphotos\.example\.com/$domain/" "$site_dir/config/albums.yaml"
+            /bin/rm "$site_dir/config/albums.yaml.bak"
+        fi
     fi
 
     if $DO_PHOTOGEN; then
@@ -174,59 +164,98 @@ _deploy_site() {
     else
         echo "build: skipping (--no-build set)"
     fi
+}
 
-    # Export once per provider, then deploy to each target
-    local cf_exported=false
-    local surge_exported=false
+# Deploy or verify: S3/CloudFront
+# Usage: _run_s3 <site> <s3_bucket> <s3_cf_id> <s3_url>
+#   s3_cf_id: CloudFront distribution ID (empty skips invalidation)
+_run_s3() {
+    local site="$1" s3_bucket="$2" s3_cf_id="$3" s3_url="$4"
+    local site_dir="$DEPLOY_DIR/$site"
+    if $VERIFY; then
+        echo; echo "=== Validating $site @ s3: $s3_url ==="
+        "$SCRIPT_DIR/test-photos-server.sh" --remote "$s3_url" --s3
+        return
+    fi
+    {
+        printf 'S3_BUCKET=%s\n' "$s3_bucket"
+        [ -n "$s3_cf_id" ] && printf 'CLOUDFRONT_ID=%s\n' "$s3_cf_id"
+    } > "$site_dir/config/site.env"
+    if $DOIT; then
+        echo "s3: deploy $s3_bucket"
+        "$site_dir/ddphotos" deploy
+    else
+        echo "s3: skipping deploy to $s3_bucket (--doit not set)"
+    fi
+}
 
-    for target in "$@"; do
-        local wrangler_project="${target%%:*}"
-        local surge_domain="${target#*:}"
-
-        if $DO_CLOUDFLARE; then
-            if ! $cf_exported; then
-                echo "export: cloudflare"
-                "$site_dir/ddphotos" --show-mounts export --cloudflare --export-site-id cloudflare
-                cf_exported=true
-            fi
-            if $DOIT; then
-                echo "wrangler: deploy $wrangler_project"
-                "$site_dir/ddphotos" --non-interactive wrangler pages deploy --project-name "$wrangler_project" export/cloudflare
-            else
-                echo "wrangler: skipping upload (--doit not set)"
-            fi
+# Deploy or verify: Cloudflare Pages
+# Usage: _run_cloudflare <site> <wrangler_project> [<wrangler_project2> ...]
+_run_cloudflare() {
+    local site="$1"; shift
+    local site_dir="$DEPLOY_DIR/$site"
+    if $VERIFY; then
+        for project in "$@"; do
+            echo; echo "=== Validating $site @ cloudflare: https://${project}.pages.dev ==="
+            "$SCRIPT_DIR/test-photos-server.sh" --remote "https://${project}.pages.dev" --cloudflare
+        done
+        return
+    fi
+    local exported=false
+    for project in "$@"; do
+        if ! $exported; then
+            echo "export: cloudflare"
+            "$site_dir/ddphotos" --show-mounts export --cloudflare --export-site-id cloudflare
+            exported=true
         fi
-
-        if $DO_SURGE && [ -n "$surge_domain" ]; then
-            if ! $surge_exported; then
-                echo "export: surge"
-                "$site_dir/ddphotos" --show-mounts export --copy --export-site-id surge
-                surge_exported=true
-            fi
-            if $DOIT; then
-                echo "surge: deploy $surge_domain"
-                "$site_dir/ddphotos" --non-interactive surge --domain "$surge_domain" export/surge
-            else
-                echo "surge: skipping upload (--doit not set)"
-            fi
+        if $DOIT; then
+            echo "wrangler: deploy $project"
+            "$site_dir/ddphotos" --non-interactive wrangler pages deploy --project-name "$project" export/cloudflare
+        else
+            echo "wrangler: skipping upload to $project (--doit not set)"
         fi
     done
+}
+
+# Deploy or verify: Surge
+# Usage: _run_surge <site> <surge_domain>
+_run_surge() {
+    local site="$1" surge_domain="$2"
+    local site_dir="$DEPLOY_DIR/$site"
+    if $VERIFY; then
+        echo; echo "=== Validating $site @ surge: https://${surge_domain} ==="
+        "$SCRIPT_DIR/test-photos-server.sh" --remote "https://${surge_domain}" --surge
+        return
+    fi
+    echo "export: surge"
+    "$site_dir/ddphotos" --show-mounts export --copy --export-site-id surge
+    if $DOIT; then
+        echo "surge: deploy $surge_domain"
+        "$site_dir/ddphotos" --non-interactive surge --domain "$surge_domain" export/surge
+    else
+        echo "surge: skipping upload to $surge_domain (--doit not set)"
+    fi
 }
 
 ##
 ## Deploy
 ##
 
-INIT_TARGETS=(
-    "ddphotos-init:ddphotos-init.surge.sh"
-)
-SAMPLE_TARGETS=(
-    "ddphotos-sample:ddphotos-sample.surge.sh"
-    "my-unique-site:"
-)
+if $DO_INIT; then
+    step "Site: init"
+    $VERIFY || _setup_site "init" "https://ddphotos-test.donohoe.info"
+    $DO_S3         && _run_s3         "init" "ddphotos-test-donohoe-info" "${DDPHOTOS_TEST_CF_ID:-}" "https://ddphotos-test.donohoe.info"
+    $DO_CLOUDFLARE && _run_cloudflare "init" "ddphotos-init"
+    $DO_SURGE      && _run_surge      "init" "ddphotos-init.surge.sh"
+fi
 
-if $DO_INIT;   then _deploy_site "init"   "https://ddphotos-test.donohoe.info" "${INIT_TARGETS[@]}";   fi
-if $DO_SAMPLE; then _deploy_site "sample" ""                                   "${SAMPLE_TARGETS[@]}"; fi
+if $DO_SAMPLE; then
+    step "Site: sample"
+    $VERIFY || _setup_site "sample" ""
+    $DO_S3         && _run_s3         "sample" "ddphotos-donohoe-info" "${DDPHOTOS_CF_ID:-}" "https://ddphotos.donohoe.info"
+    $DO_CLOUDFLARE && _run_cloudflare "sample" "ddphotos-sample" "my-unique-site"
+    $DO_SURGE      && _run_surge      "sample" "ddphotos-sample.surge.sh"
+fi
 
 echo
 echo "Done."

--- a/bin/deploy-sample-sites.sh
+++ b/bin/deploy-sample-sites.sh
@@ -43,7 +43,6 @@
 #   --help        Show this usage message
 
 set -eo pipefail
-set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -188,7 +187,7 @@ _run_s3() {
     } > "$site_dir/config/site.env"
     if $DOIT; then
         echo "s3: deploy $s3_bucket"
-        "$site_dir/ddphotos" deploy
+        "$site_dir/ddphotos" deploy --no-server-test # server test done by --verify
     else
         echo "s3: skipping deploy to $s3_bucket (--doit not set)"
     fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry.
-# The normal way (npm install -g npm@11.14.0) fails; install via registry tarball instead.
+# The normal way (npm install -g npm@11.14.1) fails; install via registry tarball instead.
 RUN node -e "\
 const https=require('https'),fs=require('fs');\
 function dl(u,cb){https.get(u,r=>{if(r.statusCode>=300&&r.statusCode<400)return dl(r.headers.location,cb);const f=fs.createWriteStream('/tmp/npm.tgz');r.pipe(f);f.on('finish',cb);});}\
-dl('https://registry.npmjs.org/npm/-/npm-11.14.0.tgz',()=>process.exit(0));" \
+dl('https://registry.npmjs.org/npm/-/npm-11.14.1.tgz',()=>process.exit(0));" \
     && tar -xz -C /tmp -f /tmp/npm.tgz \
     && /bin/rm -rf /usr/local/lib/node_modules/npm \
     && mv /tmp/package /usr/local/lib/node_modules/npm \

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -67,6 +67,9 @@ fi
 
 mkdir -p "$CONFIG" "$DDPHOTOS_ALBUMS_DIR" /ddphotos/build /ddphotos/export
 cp /docker/init/* "$CONFIG"
+# umask 0000 makes the directory world-writable, but cp preserves source file permissions (rw-r--r--);
+# make all config files world-writable so the host user can modify them.
+chmod a+w "$CONFIG"/*
 sed -i "s/__SITE_ID__/$SITE_ID/g" "$CONFIG/albums.yaml"
 
 echo "Initialized ddphotos (site-id=$SITE_ID)!"

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -246,7 +246,8 @@ Use `deploy-sample-sites.sh --verify` to run smoke tests against these sites
 ### CI Setup
 
 The `deploy-sample-sites.yml` workflow is triggered when the `docker-release.yml` workflow succeeds.
-It runs `deploy-sample-sites.sh --doit` and then `--verify`.
+It runs `deploy-sample-sites.sh --doit` and then `--verify`.  The following secrets are needed
+for each deployment type:
 
 #### Cloudflare (wrangler)
 
@@ -260,18 +261,35 @@ It runs `deploy-sample-sites.sh --doit` and then `--verify`.
  * `SURGE_LOGIN` — your `surge` email
  * `SURGE_TOKEN` — run `surge token` locally to print it
 
+#### S3 (AWS)
+
+S3 deployment uses GitHub Actions OIDC — no long-lived credentials are stored. The IAM role
+is defined in a private infra repo.
+
+ * `DDPHOTOS_DEPLOY_ROLE_ARN` — IAM role ARN; get from tofu output (see below)
+ * `DDPHOTOS_CF_ID` — CloudFront distribution ID for `ddphotos.donohoe.info`
+ * `DDPHOTOS_TEST_CF_ID` — CloudFront distribution ID for `ddphotos-test.donohoe.info`
+
+#### Secrets
+
+How to set GitHub secrets:
+
 ```bash
 gh secret set CLOUDFLARE_ACCOUNT_ID --body "your-account-id"
 gh secret set CLOUDFLARE_API_TOKEN # paste token
 gh secret set SURGE_LOGIN --body "your@email.com"
 gh secret set SURGE_TOKEN # paste token
+gh secret set DDPHOTOS_DEPLOY_ROLE_ARN --body $(tofu output ddphotos_ci_deploy_role_arn)
+gh secret set DDPHOTOS_CF_ID --body $(tofu output ddphotos_donohoe_cloudfront_id)
+gh secret set DDPHOTOS_TEST_CF_ID --body $(tofu output ddphotos_test_donohoe_cloudfront_id)
 gh secret list
 ```
 
 Manual Trigger
 
 ```bash
-gh workflow run deploy-sample-sites.yml --ref [branch name]
+gh workflow run deploy-sample-sites.yml # main branch
+gh workflow run deploy-sample-sites.yml --ref [branch-name] # on specified branch
 ```
 
 ## Project History


### PR DESCRIPTION
## Summary

- Adds S3/CloudFront as a deployment target in `bin/deploy-sample-sites.sh` alongside the existing Cloudflare and Surge providers (`--s3` flag; all three run by default)
- Refactors the deploy dispatch into clear per-site/per-provider function calls (`_setup_site`, `_run_s3`, `_run_cloudflare`, `_run_surge`)
- Wires up GitHub Actions OIDC authentication in the workflow so CI can deploy to S3 without long-lived credentials
- Fixes a permission error in CI: Docker init creates `config/` files as root-owned `rw-r--r--`; `do-init.sh` now runs `chmod a+w` on them inside the container (permanent fix), and `_run_s3` removes the pre-existing `site.env` before writing (temp workaround until a new image is released)
- Updates `docs/DEV.md` CI Setup section with S3/OIDC instructions

## AWS infrastructure (private infra repo)

Companion changes in `~/work/infra`:
- `aws/iam.tf` — GitHub OIDC provider + `ddphotos-ci-deploy` IAM role scoped to the two ddphotos S3 buckets and CloudFront distributions
- `aws/outputs.tf` — exports role ARN and CloudFront distribution IDs for use in `gh secret set`
- Trust policy uses a wildcard (`repo:dougdonohoe/ddphotos:*`) to allow branch testing; safe because `workflow_dispatch` requires repo write access

## GitHub secrets required

```bash
gh secret set DDPHOTOS_DEPLOY_ROLE_ARN --body $(tofu output ddphotos_ci_deploy_role_arn)
gh secret set DDPHOTOS_CF_ID --body $(tofu output ddphotos_donohoe_cloudfront_id)
gh secret set DDPHOTOS_TEST_CF_ID --body $(tofu output ddphotos_test_donohoe_cloudfront_id)
```

## Test plan

- [x] Manual `gh workflow run deploy-sample-sites.yml --ref s3-deploy-ci` succeeded
- [ ] Merge and confirm workflow runs cleanly on main after release