### PR TITLE
Use cwd as DDPHOTOS_DIR if script dir doesn't have config

### DIFF
--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -38,8 +38,16 @@ CURRENT_VERSION="${IMAGE##*:}"
 cmd="${1:-help}"
 shift 2>/dev/null || true
 
-# DDPHOTOS_DIR: directory mounted as /ddphotos; defaults to script location
-DDPHOTOS_DIR="${DDPHOTOS_DIR:-$SCRIPT_DIR}"
+# DDPHOTOS_DIR: directory mounted as /ddphotos.
+# Default: script location if it contains config/albums.yaml (in-repo usage, or ddphotos init setup),
+# otherwise current working directory (installed standalone in e.g. ~/.local/bin).
+if [ -z "$DDPHOTOS_DIR" ]; then
+    if [ -f "$SCRIPT_DIR/config/albums.yaml" ]; then
+        DDPHOTOS_DIR="$SCRIPT_DIR"
+    else
+        DDPHOTOS_DIR="$(pwd)"
+    fi
+fi
 
 # CONFIG_HOST_DIR: host path to config directory (normalized)
 if [ -n "$OPT_CONFIG_DIR" ]; then
@@ -509,7 +517,7 @@ case "$cmd" in
         echo "Usage: ddphotos [options] [command] [args]"
         echo ""
         echo "Options (before command):"
-        echo "  --dir DIR          Directory to mount as /ddphotos (default: script location)"
+        echo "  --dir DIR          Directory to mount as /ddphotos (default: current directory, or script location if it contains config/albums.yaml)"
         echo "  --site-id ID       Site ID override (default: settings.id from albums.yaml)"
         echo "  --config-dir DIR   Config directory override (default: albums-dir/config)"
         echo "  --site-env FILE    Path to site.env for deploy (default: config-dir/site.env)"

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -44,7 +44,7 @@ if [ -n "$COPY" ]; then
     DDPHOTOS_SITE_ID=$SITE_ID \
     /docker/setup-htdocs.sh "$LINK_DIR"
     mkdir -p "$EXPORT_DIR"
-    rsync -rLtv --delete "$LINK_DIR/" "$EXPORT_DIR/"
+    rsync -rLtv --delete --inplace "$LINK_DIR/" "$EXPORT_DIR/"
     /bin/rm -rf "$LINK_DIR"
 else
     /bin/rm -rf "$EXPORT_DIR"


### PR DESCRIPTION
Default --dir to cwd when installed standalone; fix rsync on macOS Docker

When the ddphotos script is installed in `~/.local/bin` (no `config/albums.yaml`
next to it), default DDPHOTOS_DIR to the current working directory instead of
the script location, so running from a project dir just works.

Add `--inplace` to rsync in `export --copy` to work around a macOS Docker Desktop
VirtioFS bug where stat() fails on rsync temp files in bind-mounted directories.