### PR TITLE
Support inline album descriptions in albums.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ define captions for each photo.  This file can also be used to define the
 album's sort order, if order-by-date isn't sufficient.
 
 With DD Photos, you define where your albums live in an `albums.yaml` file.
-In a separate `descriptions.txt` you provide a short description of each album.
+Each album entry can include a short `description:` field shown on the home page.
 
 Once you have defined where your photos live, you run the `photogen` tool,
 which resizes the photos for web viewing and generates index files that

--- a/config/albums.example.yaml
+++ b/config/albums.example.yaml
@@ -45,10 +45,13 @@ settings:
   # Optional HTML rendered above the album cards.
   # site_overview_html: "Browse our adventures below."
 
-  # Descriptions file (relative to this config dir). Each line:
+  # Descriptions file (relative to this config dir) — an alternative to setting
+  # 'description:' inline on each album entry (see below). Useful when sharing
+  # one descriptions file across multiple config files. Each line:
   #   slug<whitespace>description
   # Blank lines and lines starting with # are ignored.
-  descriptions: descriptions.txt
+  # When both are set, the inline 'description:' takes precedence.
+  # descriptions: descriptions.txt
 
   # Passwords file (relative to this config dir). When set, enables encryption
   # of JSON index files. The -passwords CLI flag overrides this at run time.
@@ -97,6 +100,8 @@ albums:
     base: drive                   # References bases.drive above
     source: 2026-Patagonia        # Joined to base path
     cover: Patagonia-042.jpg      # Optional: filename of cover photo (defaults to first)
+    description: >-               # Optional short description shown on the home page
+      Two weeks hiking the Torres del Paine circuit and kayaking among glaciers.
     manual_sort_order: true       # If true, order follows photogen.txt in the source directory
     recurse: false                # If true, collect photos from subdirectories recursively (default: false)
 

--- a/docker/init/albums.yaml
+++ b/docker/init/albums.yaml
@@ -38,7 +38,6 @@ settings:
   copyright_owner: Your Name
   copyright_year: 2026
   allow_crawling: false
-  descriptions: descriptions.txt
   css: custom.css
   passwords: passwords.yaml
   site_title_html: >-
@@ -63,11 +62,14 @@ albums:
     name: Replace Me
     source: /ddphotos-init
     cover: 2024-The-Way-14.jpg
+    description: Edit config/albums.yaml to replace this placeholder with your own albums (also update the site settings). Then run 'ddphotos photogen' and 'ddphotos run' again.
 
   - slug: secret
     name: Secret
     source: /ddphotos-secret
+    description: This album has a password.
 
   - slug: empty
     name: Empty
     source: /ddphotos-empty
+    description: This album doesn't have any photos in it.

--- a/docker/init/descriptions.txt
+++ b/docker/init/descriptions.txt
@@ -1,3 +1,0 @@
-temporary Edit config/albums.yaml to replace this placeholder with your own albums (also update the site settings). Then run 'ddphotos photogen' and 'ddphotos run' again.
-secret This album has a password.
-empty This album doesn't have any photos in it.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,22 +3,20 @@
 A DD Photos site is driven by three config files. Both Docker and developer modes
 use the same files — only the path conventions differ.
 
-| File               | Required | Purpose                                       |
-|--------------------|----------|-----------------------------------------------|
-| `albums.yaml`      | yes      | Albums, site settings, photo base paths       |
-| `descriptions.txt` | no       | Per-album descriptions shown on the home page |
-| `site.env`         | no       | Deploy credentials                            |
+| File               | Required | Purpose                                 |
+|--------------------|----------|-----------------------------------------|
+| `albums.yaml`      | yes      | Albums, site settings, photo base paths |
+| `site.env`         | no       | Deploy credentials                      |
 
-**Docker mode:** `ddphotos init` creates a `config/` directory with starter versions of
-the first two, ready to edit directly — no copying needed (you'll create a `site.env` when
-you are ready to deploy).
+**Docker mode:** `ddphotos init` creates a `config/` directory with a starter `albums.yaml`,
+ready to edit directly — no copying needed (you'll create a `site.env` when you are ready
+to deploy).
 
 **Developer mode:** The repo's `config/` directory contains example files. Copy and edit
 them to get started:
 
 ```bash
 cp config/albums.example.yaml config/albums.yaml
-cp config/descriptions.example.txt config/descriptions.txt
 cp config/site.example.env config/site.env
 ```
 
@@ -44,7 +42,6 @@ settings:
   site_description: "My photos"          # required
   copyright_owner: "Your Name"           # required
   copyright_year: 2020                   # required
-  descriptions: descriptions.txt         # path to descriptions file (relative to config dir)
   allow_crawling: false                  # set true to allow search engine indexing
   site_title_html: "<b>My Photos</b>"    # optional HTML for home page title
   site_subtitle_html: "Since 2010"       # optional HTML below the title
@@ -59,8 +56,8 @@ settings:
 | `site_description`   | yes      | Meta description and OG description for the home page                                             |
 | `copyright_owner`    | yes      | Name shown in the footer copyright line                                                           |
 | `copyright_year`     | yes      | Start year shown in the footer copyright line                                                     |
-| `descriptions`       | no       | Path to the descriptions file, relative to the config dir (default: `descriptions.txt`)           |
-| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`) |
+| `descriptions`       | no       | Path to a [descriptions file](#descriptionstext), relative to the config dir; see that section for details |
+| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`)          |
 | `site_title_html`    | no       | HTML for the site title on the home page; falls back to `site_name` when omitted                  |
 | `site_subtitle_html` | no       | HTML rendered below the site title in a smaller font                                              |
 | `site_overview_html` | no       | HTML rendered above the album cards (slightly larger than album descriptions)                     |
@@ -223,11 +220,35 @@ HMAC keys and produce different filenames) automatically invalidates stale cache
 
 ---
 
-## descriptions.txt
+## Album Descriptions
 
-Per-album descriptions shown on the home page album cards. Referenced from `albums.yaml`
-via `settings.descriptions`. See [config/descriptions.example.txt](../config/descriptions.example.txt)
-for the format.
+Per-album descriptions are shown on the home page album cards and on each album page.
+The preferred way to set them is inline in `albums.yaml`:
+
+```yaml
+albums:
+  - slug: patagonia
+    name: Patagonia
+    source: /photos/patagonia
+    description: Two weeks hiking the Torres del Paine circuit.
+```
+
+### descriptions.txt
+
+As an alternative, descriptions can be kept in a separate file and referenced from
+`albums.yaml` via `settings.descriptions`:
+
+```yaml
+settings:
+  descriptions: descriptions.txt
+```
+
+This is useful when you want to share one descriptions file across multiple config
+files. See [config/descriptions.example.txt](../config/descriptions.example.txt) for
+the format.
+
+When both an inline `description:` and a `descriptions.txt` entry exist for the same
+album, the inline value takes precedence.
 
 ---
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -257,7 +257,7 @@ The script uses `set -eo pipefail` — any failure aborts before deployment.
 | `--no-pre-deploy-tests` | Skip pre-deploy Docker/Apache test and Playwright (rsync mode only); post-deploy tests still run                        |
 | `--no-server-test`      | Skip both the local and post-deploy server routing tests                                                                |
 | `--no-playwright`       | Skip Playwright tests (both local and production)                                                                       |
-| `--config-dir`          | Directory containing `albums.yaml`, `descriptions.txt`, and (by default) `site.env`                                     |
+| `--config-dir`          | Directory containing `albums.yaml` and (by default) `site.env`                                                          |
 | `--site-id`             | Site ID (overrides albums.yaml)                                                                                         |
 | `--site-env`            | Path to `site.env` — overrides `--config-dir/site.env` when the two live in different locations                         |
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -365,9 +365,8 @@ After `init`, your ddphotos directory looks like this:
 my-ddphotos/
   ddphotos           ← wrapper script
   config/
-    albums.yaml      ← album definitions and site settings
+    albums.yaml      ← album definitions, site settings, and descriptions
     custom.css       ← optional CSS overrides
-    descriptions.txt ← per-album descriptions
     passwords.yaml   ← optional password protection
     site.env         ← deploy credentials
   albums/            ← photogen output (generated, not edited)

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -29,7 +29,7 @@ bin/photogen -resize -index -clean -doit  # developer mode
 
 | Flag          | Default       | Description                                                                                                                          |
 |---------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `-config-dir` | `config`      | Directory containing the albums YAML and descriptions files                                                                          |
+| `-config-dir` | `config`      | Directory containing `albums.yaml` and optional supporting files                                                                     |
 | `-doit`       | `false`       | Write files; without this, runs in dry-run mode                                                                                      |
 | `-resize`     | `false`       | Generate resized WebP image variants                                                                                                 |
 | `-index`      | `false`       | Generate JSON index files and sitemap.xml                                                                                            |

--- a/pkg/photogen/albums_config.go
+++ b/pkg/photogen/albums_config.go
@@ -50,9 +50,10 @@ type HeroEntry struct {
 type AlbumEntry struct {
 	Slug            string `yaml:"slug"`
 	Name            string `yaml:"name"`
-	Base            string `yaml:"base"`   // optional key into Bases map
-	Source          string `yaml:"source"` // path joined to base, or absolute/configDir-relative
-	Cover           string `yaml:"cover"`  // optional cover photo filename override
+	Base            string `yaml:"base"`        // optional key into Bases map
+	Source          string `yaml:"source"`      // path joined to base, or absolute/configDir-relative
+	Cover           string `yaml:"cover"`       // optional cover photo filename override
+	Description     string `yaml:"description"` // optional inline description; takes precedence over descriptions file
 	ManualSortOrder bool   `yaml:"manual_sort_order"`
 	Recurse         bool   `yaml:"recurse"` // if true, collect photos from subdirectories recursively
 }
@@ -128,6 +129,10 @@ func (af *AlbumsFile) ToAlbumConfigs(configDir string) ([]*AlbumConfig, error) {
 		if err != nil {
 			return nil, err
 		}
+		desc := a.Description
+		if desc == "" {
+			desc = descriptions[a.Slug]
+		}
 		configs = append(configs, &AlbumConfig{
 			Slug:            a.Slug,
 			Name:            a.Name,
@@ -135,7 +140,7 @@ func (af *AlbumsFile) ToAlbumConfigs(configDir string) ([]*AlbumConfig, error) {
 			Cover:           a.Cover,
 			ManualSortOrder: a.ManualSortOrder,
 			Recurse:         a.Recurse,
-			Description:     descriptions[a.Slug],
+			Description:     desc,
 		})
 	}
 

--- a/pkg/photogen/albums_config_test.go
+++ b/pkg/photogen/albums_config_test.go
@@ -245,6 +245,72 @@ albums:
 		require.ErrorContains(t, err, "does not exist")
 	})
 
+	t.Run("inline description used when no descriptions file", func(t *testing.T) {
+		configDir := t.TempDir()
+		photoDir := t.TempDir()
+
+		af := parseYAML(t, configDir, fmt.Sprintf(`
+albums:
+  - slug: myalbum
+    name: My Album
+    source: %s
+    description: Inline description here.
+`, photoDir))
+
+		configs, err := af.ToAlbumConfigs(configDir)
+		require.NoError(t, err)
+		assert.Equal(t, "Inline description here.", configs[0].Description)
+	})
+
+	t.Run("inline description takes precedence over descriptions file", func(t *testing.T) {
+		configDir := t.TempDir()
+		photoDir := t.TempDir()
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(configDir, "descriptions.txt"),
+			[]byte("myalbum  From the file.\n"),
+			0o644,
+		))
+
+		af := parseYAML(t, configDir, fmt.Sprintf(`
+settings:
+  descriptions: descriptions.txt
+albums:
+  - slug: myalbum
+    name: My Album
+    source: %s
+    description: Inline wins.
+`, photoDir))
+
+		configs, err := af.ToAlbumConfigs(configDir)
+		require.NoError(t, err)
+		assert.Equal(t, "Inline wins.", configs[0].Description)
+	})
+
+	t.Run("descriptions file used when inline description is absent", func(t *testing.T) {
+		configDir := t.TempDir()
+		photoDir := t.TempDir()
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(configDir, "descriptions.txt"),
+			[]byte("myalbum  From the file.\n"),
+			0o644,
+		))
+
+		af := parseYAML(t, configDir, fmt.Sprintf(`
+settings:
+  descriptions: descriptions.txt
+albums:
+  - slug: myalbum
+    name: My Album
+    source: %s
+`, photoDir))
+
+		configs, err := af.ToAlbumConfigs(configDir)
+		require.NoError(t, err)
+		assert.Equal(t, "From the file.", configs[0].Description)
+	})
+
 	t.Run("album with no description gets empty string", func(t *testing.T) {
 		configDir := t.TempDir()
 		photoDir := t.TempDir()

--- a/sample/config/albums.yaml
+++ b/sample/config/albums.yaml
@@ -38,6 +38,9 @@ albums:
     cover: subfolder_img_840_d.jpg
     manual_sort_order: true
     recurse: true
+    description: >-
+      Tracking mountain gorillas deep in the jungle and spotting tree-climbing lions, elephants, and hippos on safari
+      on our first visit to Africa.
 
   - slug: antarctica
     name: Antarctica

--- a/sample/config/descriptions.txt
+++ b/sample/config/descriptions.txt
@@ -3,5 +3,4 @@
 # Blank lines and lines starting with # are ignored.
 
 the-way      A life-changing 530 miles and 37 days to walk El Camino del Norte, the rugged coastal route of El Camino de Santiago.
-uganda       Tracking mountain gorillas deep in the jungle and spotting tree-climbing lions, elephants, and hippos on safari on our first visit to Africa.
 antarctica   Surviving the Drake Passage to reach the bottom of the world: a cruise through Antarctica and the Falkland Islands with epic encounters with penguins, icebergs, albatross, and whales.


### PR DESCRIPTION
## Summary

- Adds a `description:` field directly on each album entry in `albums.yaml`, as the preferred way to set per-album descriptions
- Inline `description:` takes precedence over a matching entry in `descriptions.txt`; the `descriptions.txt` mechanism is fully preserved for anyone already using it
- Migrates the docker `init` site templates to use inline descriptions (removes `docker/init/descriptions.txt`)
- Moves the Uganda description in the sample config from `descriptions.txt` to an inline field, as a worked example
- Updates `config/albums.example.yaml`, `docs/CONFIGURATION.md`, `README.md`, and minor doc updates across `DOCKER.md`, `DEPLOY.md`, `PHOTOGEN.md`

## Test plan

- [x] `make build test vet` passes (3 new test cases cover inline-only, inline-beats-file, and file-fallback)
- [x] `make sample-build` succeeds and Uganda description renders correctly
- [x] `make web-sanity-test` passes (no-passwords + all-passwords)