### PR TITLE
Use source path to specify cover (better for sub-dir case)

### DIFF
--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -102,10 +102,11 @@ for p in photos:
         sp = p.get('sourcePath', '')
         if sp:
             print('  sourcePath: ' + sp)
-        print('  fileName:   ' + p.get('fileName', '') + '')
         print('')
         print('Use for cover:')
-        print('  cover: ' + p.get('fileName', ''))
+        # sourcePath is relative to the base dir (includes album dir prefix); strip it
+        cover_path = sp.split('/', 1)[1] if '/' in sp else sp
+        print('  cover: ' + cover_path)
         print('')
         sys.exit(0)
 print('WARN: ' + src + ' not found in index', file=sys.stderr)

--- a/config/albums.example.yaml
+++ b/config/albums.example.yaml
@@ -99,7 +99,7 @@ albums:
     name: Patagonia               # Human-readable album title
     base: drive                   # References bases.drive above
     source: 2026-Patagonia        # Joined to base path
-    cover: Patagonia-042.jpg      # Optional: filename of cover photo (defaults to first)
+    cover: Patagonia-042.jpg      # Optional: source-relative path of cover photo (defaults to first)
     description: >-               # Optional short description shown on the home page
       Two weeks hiking the Torres del Paine circuit and kayaking among glaciers.
     manual_sort_order: true       # If true, order follows photogen.txt in the source directory

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -112,10 +112,10 @@ Subfolders not listed in `photogen.txt` are appended alphabetically at the end w
 a warning. Photos not listed are date-sorted and appended at the end of their group
 with a warning.
 
-**Cover photo**: when `cover` is set on a recursive album, use the prefixed filename
-(e.g. `cover: craigs_img001.jpg`). If omitted, the first collected photo is used.
-The prefixed filename is in the `fileName` field of `index.json`. To find it from an
-original filename, use `sourcePath` (see below) or grep the decoded index.
+**Cover photo**: when `cover` is set on a recursive album, use the source-relative path
+(e.g. `cover: craigs/img001.jpg`). If omitted, the first collected photo is used.
+The source-relative path is in the `sourcePath` field of `index.json`. To find it from an
+original filename, grep the decoded index or use `bin/search-cover.sh` (see below).
 
 **Working example**: the sample Uganda album (`sample/source/uganda/`) uses `recurse: true`
 with a `subfolder/` subdirectory. Its root `photogen.txt` uses `subfolder` as a placeholder
@@ -173,7 +173,7 @@ The correct password is selected automatically from the filename:
 ## Finding a Cover Photo (`search-cover.sh`)
 
 When browsing the site, and you want to set a photo as an album cover, you need its
-`fileName` value for the `cover:` field in `albums.yaml`. The easiest way to get it is
+source-relative path for the `cover:` field in `albums.yaml`. The easiest way to get it is
 to right-click the photo, copy the image URL, and pass it to `bin/search-cover.sh`:
 
 ```bash
@@ -182,8 +182,7 @@ bin/search-cover.sh <url>
 
 The script parses the album slug and image path from the URL, locates the album's
 `index.json` (or `index.enc.json` for encrypted albums — decoded automatically via
-`cmd/decode`), and searches for the matching `src` entry to print the `fileName`, `id`,
-and `sourcePath`.
+`cmd/decode`), and searches for the matching `src` entry to print the `id` and `sourcePath`.
 
 The search is scoped to `DDPHOTOS_ALBUMS_DIR/DDPHOTOS_SITE_ID` (defaults from
 `config/defaults.env`). Override to search a different site:
@@ -203,8 +202,7 @@ Searching...
 Found:
   id:         subfolder_img_840_d
   sourcePath: uganda/subfolder/img_840_d.jpg
-  fileName:   subfolder_img_840_d.jpg
 
 Use for cover:
-  cover: subfolder_img_840_d.jpg
+  cover: subfolder/img_840_d.jpg
 ```

--- a/pkg/photogen/album.go
+++ b/pkg/photogen/album.go
@@ -107,15 +107,16 @@ func (ap *AlbumProcessor) Process(index, total int) error {
 
 	// warn once if configured cover is not found
 	if ap.AlbumConfig.Cover != "" {
+		fullCover := filepath.ToSlash(filepath.Join(filepath.Base(ap.AlbumConfig.Path), ap.AlbumConfig.Cover))
 		found := false
 		for _, p := range ap.Photos {
-			if p.FileName == ap.AlbumConfig.Cover {
+			if p.SourcePath == fullCover {
 				found = true
 				break
 			}
 		}
 		if !found {
-			ap.warnf("  WARN: cover %q not found in album, using first photo\n", ap.AlbumConfig.Cover)
+			ap.warnf("  WARN: cover source path %q not found in album, using first photo\n", ap.AlbumConfig.Cover)
 		}
 	}
 
@@ -481,8 +482,9 @@ func (ap *AlbumProcessor) coverPhoto() *Photo {
 		return nil
 	}
 	if ap.AlbumConfig.Cover != "" {
+		fullCover := filepath.ToSlash(filepath.Join(filepath.Base(ap.AlbumConfig.Path), ap.AlbumConfig.Cover))
 		for _, p := range ap.Photos {
-			if p.FileName == ap.AlbumConfig.Cover {
+			if p.SourcePath == fullCover {
 				return p
 			}
 		}

--- a/pkg/photogen/albums_config.go
+++ b/pkg/photogen/albums_config.go
@@ -52,7 +52,7 @@ type AlbumEntry struct {
 	Name            string `yaml:"name"`
 	Base            string `yaml:"base"`        // optional key into Bases map
 	Source          string `yaml:"source"`      // path joined to base, or absolute/configDir-relative
-	Cover           string `yaml:"cover"`       // optional cover photo filename override
+	Cover           string `yaml:"cover"`       // optional cover photo source-relative path (e.g. "subfolder/photo.jpg")
 	Description     string `yaml:"description"` // optional inline description; takes precedence over descriptions file
 	ManualSortOrder bool   `yaml:"manual_sort_order"`
 	Recurse         bool   `yaml:"recurse"` // if true, collect photos from subdirectories recursively

--- a/pkg/photogen/config.go
+++ b/pkg/photogen/config.go
@@ -78,7 +78,8 @@ type AlbumConfig struct {
 	Name string
 	// Path is the absolute or repo-relative directory containing original photos.
 	Path string
-	// Cover is the filename of the cover photo (optional, defaults to first photo).
+	// Cover is the source-relative path of the cover photo (e.g. "subfolder/photo.jpg"),
+	// optional — defaults to the first photo.
 	Cover string
 	// ManualSortOrder, if true, uses the order from photogen.txt (if present)
 	// instead of sorting photos by EXIF date.

--- a/sample/config/albums.yaml
+++ b/sample/config/albums.yaml
@@ -35,7 +35,7 @@ albums:
     name: Uganda
     base: sample
     source: uganda
-    cover: subfolder_img_840_d.jpg
+    cover: subfolder/img_840_d.jpg
     manual_sort_order: true
     recurse: true
     description: >-


### PR DESCRIPTION
## What

Changes the `cover:` field in `albums.yaml` to use a **source-relative path** instead of the output filename.

Before (recursive album with a subdirectory photo):
```yaml
cover: subfolder_img_840_d.jpg   # prefixed output filename
```

After:
```yaml
cover: subfolder/img_840_d.jpg   # path relative to album source dir
```

For flat (non-recursive) albums the value is unchanged — it's still just the bare filename, since no prefix was ever generated.

## Why

The old format used photogen's internal output filename, which mangled subdirectory paths into an underscore-prefixed flat name (`subfolder_img_840_d.jpg`). This was unintuitive and made it hard to know which file you were actually pointing at.

The new format is the literal path a file chooser would return when rooted at the album's `source` directory, which is what an upcoming config editor needs.

## Changes

- **`pkg/photogen/album.go`** — cover matching now compares against `SourcePath` (prefixed with the album dir name internally) instead of `FileName`
- **`bin/search-cover.sh`** — "Use for cover:" output now strips the album-dir prefix from `sourcePath`, drops the `fileName` line
- **`sample/config/albums.yaml`** — updated Uganda cover to new format (`subfolder/img_840_d.jpg`)
- **`config/albums.example.yaml`**, **`pkg/photogen/config.go`**, **`pkg/photogen/albums_config.go`** — comments updated
- **`docs/PHOTOGEN.md`** — updated recursive-album cover guidance and `search-cover.sh` example output