### PR TITLE
Bump npm 11.14.1 to 11.15.0; minor improvements

### DIFF
--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -62,7 +62,7 @@ fi
 cd "$REPO_ROOT"
 
 # Verify CONFIG_DIR exists
-[ -d "$CONFIG_DIR" ] || { echo "Error: config dir '$CONFIG_DIR' not found"; exit 1; }
+[ -d "$CONFIG_DIR" ] || { echo "Error: config dir '$CONFIG_DIR' not found" >&2; exit 1; }
 
 # Resolve CONFIG_DIR and SITE_ENV_ARG to absolute paths (relative paths break after subsequent cd's)
 CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)"
@@ -74,7 +74,7 @@ if [ -n "$SITE_ENV_ARG" ]; then
 else
     SITE_ENV="$CONFIG_DIR/site.env"
 fi
-[ -f "$SITE_ENV" ] || { echo "Error: site environment file '$SITE_ENV' not found"; exit 1; }
+[ -f "$SITE_ENV" ] || { echo "Error: site environment file '$SITE_ENV' not found" >&2; exit 1; }
 source "$SITE_ENV"
 
 # Determine <site-id>
@@ -103,8 +103,8 @@ fi
 # These must be set:
 #   DDPHOTOS_ALBUMS_DIR from environment or defaults.env
 #   SITE_ID from --site-id or albums.yaml
-[ -n "$DDPHOTOS_ALBUMS_DIR" ] || { echo "Error: DDPHOTOS_ALBUMS_DIR not set (not in environment or config/defaults.env)"; exit 1; }
-[ -n "$SITE_ID" ]    || { echo "Error: <site id> not set (not in --site-id or $CONFIG_DIR/albums.yaml)"; exit 1; }
+[ -n "$DDPHOTOS_ALBUMS_DIR" ] || { echo "Error: DDPHOTOS_ALBUMS_DIR not set (not in environment or config/defaults.env)" >&2; exit 1; }
+[ -n "$SITE_ID" ]    || { echo "Error: <site id> not set (not in --site-id or $CONFIG_DIR/albums.yaml)" >&2; exit 1; }
 
 # Resolve DDPHOTOS_ALBUMS_DIR to absolute path
 DDPHOTOS_ALBUMS_DIR="$(cd "$DDPHOTOS_ALBUMS_DIR" && pwd)"
@@ -112,10 +112,10 @@ DDPHOTOS_ALBUMS_DIR="$(cd "$DDPHOTOS_ALBUMS_DIR" && pwd)"
 # These must be set in site.env — guard early so a missing value can't
 # cause rsync --delete to target the wrong (or empty) remote path.
 if [ "$S3_MODE" = true ]; then
-    [ -n "$S3_BUCKET" ] || { echo "Error: S3_BUCKET not set in $SITE_ENV"; exit 1; }
+    [ -n "$S3_BUCKET" ] || { echo "Error: S3_BUCKET not set in $SITE_ENV" >&2; exit 1; }
 else
-    [ -n "$RSYNC_HOST" ]  || { echo "Error: RSYNC_HOST not set in $SITE_ENV"; exit 1; }
-    [ -n "$RSYNC_DEST" ]  || { echo "Error: RSYNC_DEST not set in $SITE_ENV"; exit 1; }
+    [ -n "$RSYNC_HOST" ]  || { echo "Error: RSYNC_HOST not set in $SITE_ENV" >&2; exit 1; }
+    [ -n "$RSYNC_DEST" ]  || { echo "Error: RSYNC_DEST not set in $SITE_ENV" >&2; exit 1; }
     # Ensure RSYNC_DEST ends with / so rsync targets an explicit directory path,
     # never a bare or empty string that could default to the remote home directory.
     [[ "$RSYNC_DEST" == */ ]] || RSYNC_DEST="${RSYNC_DEST}/"
@@ -142,13 +142,13 @@ fi
 
 # Read site URL from config.json (written by photogen)
 CONFIG_JSON="$DDPHOTOS_ALBUMS_DIR/$SITE_ID/config.json"
-[ -f "$CONFIG_JSON" ] || { echo "Error: $CONFIG_JSON not found — run photogen first"; exit 1; }
+[ -f "$CONFIG_JSON" ] || { echo "Error: $CONFIG_JSON not found — run photogen first" >&2; exit 1; }
 SITE_URL=$(python3 -c "import json; print(json.load(open('$CONFIG_JSON'))['siteUrl'])")
-[ -n "$SITE_URL" ] || { echo "Error: siteUrl not found in $CONFIG_JSON"; exit 1; }
+[ -n "$SITE_URL" ] || { echo "Error: siteUrl not found in $CONFIG_JSON" >&2; exit 1; }
 DEFAULT_URL="https://your-ddphotos.example.com"
 [ "$SITE_URL" = "$DEFAULT_URL" ] && {
-    echo "Error: 'site_url' in albums.yaml is still the default '$DEFAULT_URL'."
-    echo "       Set it to your actual site URL before deploying or pass -site-url [ur] to photogen"
+    echo "Error: 'site_url' in albums.yaml is still the default '$DEFAULT_URL'." >&2
+    echo "       Set it to your actual site URL before deploying or pass -site-url [ur] to photogen" >&2
     exit 1
 }
 

--- a/bin/search-cover.sh
+++ b/bin/search-cover.sh
@@ -109,6 +109,6 @@ for p in photos:
         print('  cover: ' + cover_path)
         print('')
         sys.exit(0)
-print('WARN: ' + src + ' not found in index', file=sys.stderr)
+print('Warning: ' + src + ' not found in index', file=sys.stderr)
 sys.exit(1)
 " "$src_path"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # npm 10.9.7 (bundled with node:22) can't self-upgrade due to missing promise-retry.
-# The normal way (npm install -g npm@11.14.1) fails; install via registry tarball instead.
+# The normal way (npm install -g npm@11.15.0) fails; install via registry tarball instead.
 RUN node -e "\
 const https=require('https'),fs=require('fs');\
 function dl(u,cb){https.get(u,r=>{if(r.statusCode>=300&&r.statusCode<400)return dl(r.headers.location,cb);const f=fs.createWriteStream('/tmp/npm.tgz');r.pipe(f);f.on('finish',cb);});}\
-dl('https://registry.npmjs.org/npm/-/npm-11.14.1.tgz',()=>process.exit(0));" \
+dl('https://registry.npmjs.org/npm/-/npm-11.15.0.tgz',()=>process.exit(0));" \
     && tar -xz -C /tmp -f /tmp/npm.tgz \
     && /bin/rm -rf /usr/local/lib/node_modules/npm \
     && mv /tmp/package /usr/local/lib/node_modules/npm \

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -247,16 +247,16 @@ case "$cmd" in
     init|upgrade|help|version|wrangler|surge) ;;
     *)
         if [ ! -f "$CONFIG_HOST_DIR/albums.yaml" ]; then
-            echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml"
-            echo
+            echo "Error: no config found at $CONFIG_HOST_DIR/albums.yaml" >&2
+            echo >&2
             if [ "$DDPHOTOS_DIR" = "$SCRIPT_DIR" ]; then
-                echo "'ddphotos' is installed in $SCRIPT_DIR."
-                echo "Since you are running 'ddphotos' standalone, you must specify the"
-                echo "DD Photos site directory (the one containing your 'config' dir):"
-                echo "  ddphotos --dir ~/my-ddphotos $cmd"
+                echo "'ddphotos' is installed in $SCRIPT_DIR." >&2
+                echo "Since you are running 'ddphotos' standalone, you must specify the" >&2
+                echo "DD Photos site directory (the one containing your 'config' dir):" >&2
+                echo "  ddphotos --dir ~/my-ddphotos $cmd" >&2
             else
-                echo "Run init to initialize the DD Photos site:"
-                echo "  ddphotos --dir $DDPHOTOS_DIR init"
+                echo "Run init to initialize the DD Photos site:" >&2
+                echo "  ddphotos --dir $DDPHOTOS_DIR init" >&2
             fi
             exit 1
         fi

--- a/docker/do-build.sh
+++ b/docker/do-build.sh
@@ -10,7 +10,7 @@ fi
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
-    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first." >&2
     exit 1
 fi
 

--- a/docker/do-deploy.sh
+++ b/docker/do-deploy.sh
@@ -6,8 +6,8 @@ CONFIG_DIR="${DDPHOTOS_CONFIG_DIR:-/ddphotos/config}"
 SITE_ENV="${DDPHOTOS_SITE_ENV:-$CONFIG_DIR/site.env}"
 
 if [ ! -f "$SITE_ENV" ]; then
-    echo "Error: $SITE_ENV not found."
-    echo "Create it with RSYNC_HOST, RSYNC_DEST (rsync) or S3_BUCKET (S3) and optional CLOUDFRONT_ID."
+    echo "Error: $SITE_ENV not found." >&2
+    echo "Create it with RSYNC_HOST, RSYNC_DEST (rsync) or S3_BUCKET (S3) and optional CLOUDFRONT_ID." >&2
     exit 1
 fi
 
@@ -24,22 +24,22 @@ ALBUMS_CONFIG="$DDPHOTOS_ALBUMS_DIR/$SITE_ID/config.json"
 BUILD_INDEX="/ddphotos/build/$SITE_ID/index.html"
 
 if [ ! -f "$ALBUMS_CONFIG" ]; then
-    echo "Error: album data not found at $ALBUMS_CONFIG. Run 'photogen' first."
+    echo "Error: album data not found at $ALBUMS_CONFIG. Run 'photogen' first." >&2
     exit 1
 fi
 
 if [ -n "$(find "$CONFIG_DIR" -maxdepth 1 -type f -newer "$ALBUMS_CONFIG" ! -name "site.env" 2>/dev/null)" ]; then
-    echo "Error: config is newer than album data. Run 'photogen' before 'deploy'."
+    echo "Error: config is newer than album data. Run 'photogen' before 'deploy'." >&2
     exit 1
 fi
 
 if [ ! -f "$BUILD_INDEX" ]; then
-    echo "Error: build output not found. Run 'build' first."
+    echo "Error: build output not found. Run 'build' first." >&2
     exit 1
 fi
 
 if [ -n "$(find "$ALBUMS_CONFIG" -newer "$BUILD_INDEX" 2>/dev/null)" ]; then
-    echo "Error: album data is newer than build output. Run 'build' before 'deploy'."
+    echo "Error: album data is newer than build output. Run 'build' before 'deploy'." >&2
     exit 1
 fi
 

--- a/docker/do-export.sh
+++ b/docker/do-export.sh
@@ -27,12 +27,12 @@ done
 EXPORT_DIR="/ddphotos/export/$EXPORT_SITE_ID"
 
 if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
-    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first." >&2
     exit 1
 fi
 
 if [ ! -d "/ddphotos/build/$SITE_ID" ]; then
-    echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first."
+    echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first." >&2
     exit 1
 fi
 

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ ! -d "/ddphotos" ]; then
-    echo "Error: /ddphotos is not mounted. Add: -v ~/my-ddphotos:/ddphotos"
+    echo "Error: /ddphotos is not mounted. Add: -v ~/my-ddphotos:/ddphotos" >&2
     exit 1
 fi
 
@@ -61,7 +61,7 @@ fi
 CONFIG="/ddphotos/config"
 
 if [ -f "$CONFIG/albums.yaml" ]; then
-    echo "Error: $CONFIG/albums.yaml already exists. Remove it to re-initialize."
+    echo "Error: $CONFIG/albums.yaml already exists. Remove it to re-initialize." >&2
     exit 1
 fi
 

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -10,7 +10,7 @@ fi
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 if [ ! -d "$DDPHOTOS_ALBUMS_DIR/$SITE_ID" ]; then
-    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first."
+    echo "Error: $DDPHOTOS_ALBUMS_DIR/$SITE_ID not found. Run 'photogen' first." >&2
     exit 1
 fi
 

--- a/docker/do-serve.sh
+++ b/docker/do-serve.sh
@@ -10,7 +10,7 @@ fi
 SITE_ID="${DDPHOTOS_SITE_ID:-site-id-undefined}"
 
 if [ ! -d "/ddphotos/build/$SITE_ID" ]; then
-    echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first."
+    echo "Error: /ddphotos/build/$SITE_ID not found. Run 'build' first." >&2
     exit 1
 fi
 

--- a/docker/do-surge.sh
+++ b/docker/do-surge.sh
@@ -23,10 +23,10 @@ done
 # Bare words like 'list', 'whoami', 'login' are surge subcommands, not directories.
 if [ -n "$DEPLOY_DIR" ] && [[ "$DEPLOY_DIR" == */* || "$DEPLOY_DIR" == "." || "$DEPLOY_DIR" == ".." ]]; then
     if [ ! -d "$DEPLOY_DIR" ]; then
-        echo "Error: $DEPLOY_DIR not found. Run 'ddphotos export --copy' first."
+        echo "Error: $DEPLOY_DIR not found. Run 'ddphotos export --copy' first." >&2
         exit 1
     elif [ -L "$DEPLOY_DIR/index.html" ]; then
-        echo "Error: $DEPLOY_DIR contains symlinks. Run 'ddphotos export --copy' (not just 'export') — Surge does not follow symlinks."
+        echo "Error: $DEPLOY_DIR contains symlinks. Run 'ddphotos export --copy' (not just 'export') — Surge does not follow symlinks." >&2
         exit 1
     fi
 fi

--- a/docker/do-wrangler.sh
+++ b/docker/do-wrangler.sh
@@ -23,10 +23,10 @@ if [[ "${1:-}" == "pages" && "${2:-}" == "deploy" ]]; then
     done
     if [ -n "$DEPLOY_DIR" ]; then
         if [ ! -d "$DEPLOY_DIR" ]; then
-            echo "Error: $DEPLOY_DIR not found. Run 'export --cloudflare' first."
+            echo "Error: $DEPLOY_DIR not found. Run 'export --cloudflare' first." >&2
             exit 1
         elif [ ! -f "$DEPLOY_DIR/_worker.js" ]; then
-            echo "Error: $DEPLOY_DIR/_worker.js not found. Run 'export --cloudflare' (not just 'export')."
+            echo "Error: $DEPLOY_DIR/_worker.js not found. Run 'export --cloudflare' (not just 'export')." >&2
             exit 1
         fi
     fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,7 @@ if [ "$#" -gt 0 ]; then shift; fi
 case "$cmd" in
     photogen|decode|search-cover|build|serve|run|export|deploy|wrangler|surge)
         if [ -f /ddphotos-script-dir/ddphotos ] && ! diff -q /docker/ddphotos /ddphotos-script-dir/ddphotos > /dev/null 2>&1; then
-            echo "WARNING:  The local 'ddphotos' script does not match the image." >&2
+            echo "Warning:  The local 'ddphotos' script does not match the image." >&2
             echo "          Run: 'ddphotos upgrade' to fix this." >&2
             echo "" >&2
         fi

--- a/docker/init/site.env
+++ b/docker/init/site.env
@@ -6,4 +6,4 @@
 #S3_BUCKET=your-s3-bucket
 
 # Uncomment and set to your values if using CloudFront (invalidates cache after deploy)
-#CLOUDFRONT_ID=YOUR_CLOUDFRONT_DISTRIBUTION_ID   # optional;
+#CLOUDFRONT_ID=YOUR_CLOUDFRONT_DISTRIBUTION_ID


### PR DESCRIPTION
Version bump:
+ npm 11.14.1 to 11.15.0

Minor improvements:
 + Fix init `site.env` comment
 + Route `ddphotos` errors to `stderr` consistently