### PR TITLE
Address #71 - document base better; reject container paths

### DIFF
--- a/config/albums.example.yaml
+++ b/config/albums.example.yaml
@@ -83,13 +83,15 @@ settings:
   # default_theme: dark
 
 # Named source base paths. Albums reference these by name via the 'base' key.
-# Defining bases here lets you swap root paths between configs (e.g., prod vs.
-# laptop) without touching individual album entries.
+# Defining bases here makes your album definitions shorter.  They can refer
+# to an absolute path or a relative path to the root DD Photos folder.
 bases:
   # Example: photos on an external drive
   drive: /Volumes/MyDrive/Photos
   # Example: photos in a cloud-synced folder
   cloud: /Users/me/Dropbox/Photos
+  # Example: folder under the root DD Photos folder (i.e., a sibling to 'config')
+  local: photos
 
 albums:
   # ------------------------------------------------------------------

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -159,6 +159,14 @@ build_config_bases_mounts() {
             path="${path#"${path%%[^[:space:]]*}"}"
             # Expand leading ~ to $HOME
             path="${path/#\~/$HOME}"
+            # Reject container-internal paths. /ddphotos* and /docker* are mount points
+            # inside the Docker image (e.g. the bundled sample data), not real folders on
+            # this machine — using one as a base never works the way the user expects.
+            if [[ "$path" == /ddphotos* ]] || [[ "$path" == /docker* ]]; then
+                echo "Error: base path '$path' in $config is a container-internal path." >&2
+                echo "       A base must be a folder that exists on this machine." >&2
+                exit 1
+            fi
             # Only mount absolute paths that fall outside DDPHOTOS_DIR (which is already mounted)
             if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
                 add_mount "$path" "$path" ro

--- a/docker/init/albums.yaml
+++ b/docker/init/albums.yaml
@@ -2,27 +2,32 @@
 #
 # See https://github.com/dougdonohoe/ddphotos/blob/main/docs/DOCKER.md for full documentation.
 # See https://github.com/dougdonohoe/ddphotos/blob/main/config/albums.example.yaml for
-#     specification of this file.
+#     the full documentation and specification of this 'albums.yaml' file.
 #
-# Define bases pointing to where your source photos live. The ddphotos wrapper
-# script reads these paths and mounts them automatically into Docker.
 #
 # NOTE: paths starting with /ddphotos are container-internal — they point to
 # sample data bundled in the Docker image, not directories on your machine.
+# They are only meant to be used with this example starter site - your bases,
+# album sources and hero image paths should all be paths on your machine.
+#
+# Define bases pointing to where your source photos live. The ddphotos wrapper
+# script reads these paths and mounts them automatically into Docker.  Bases
+# can be absolute paths or relative (if underneath the root DD Photos folder).
 #
 # Examples:
 #
 #   bases:
 #     dropbox: /Users/anseladams/Dropbox/Vacations   # Dropbox or iCloud folder
 #     t7: /T7/Photos                                 # external drive
+#     local: photos                                  # A folder under the DD Photos folder
 #
 # Then reference a base in each album:
 #
 #   albums:
 #     - slug: hawaii-2024
 #       title: Hawaii 2024
-#       base: dropbox
-#       source: hawaii-2024   # subfolder under the base path
+#       base: t7
+#       source: hawaii-2024   # subfolder under the base path - this is /T7/Photos/hawaii-2024
 #
 # Once you have edited this file, run:
 #   ./ddphotos photogen
@@ -50,7 +55,7 @@ settings:
     image: /ddphotos-hero/hero.webp
     crop: center
 
-# Uncomment and edit bases to point to your photo directories.
+# Uncomment and edit bases to point to your root photo directories.
 # Here are two examples:
 #
 #bases:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,19 +48,45 @@ settings:
   site_overview_html: "Welcome!"         # optional HTML above album cards
 ```
 
-| Setting              | Required | Description                                                                                       |
-|----------------------|----------|---------------------------------------------------------------------------------------------------|
-| `id`                 | yes      | Names the output directory; must be lowercase letters, digits, and hyphens                        |
-| `site_name`          | yes      | Site title shown in the browser tab and OG tags                                                   |
-| `site_url`           | yes      | Canonical base URL (e.g. `https://photos.example.com`); used in sitemap and OG tags               |
-| `site_description`   | yes      | Meta description and OG description for the home page                                             |
-| `copyright_owner`    | yes      | Name shown in the footer copyright line                                                           |
-| `copyright_year`     | yes      | Start year shown in the footer copyright line                                                     |
-| `descriptions`       | no       | Path to a [descriptions file](#descriptionstext), relative to the config dir; see that section for details |
-| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`)          |
-| `site_title_html`    | no       | HTML for the site title on the home page; falls back to `site_name` when omitted                  |
-| `site_subtitle_html` | no       | HTML rendered below the site title in a smaller font                                              |
-| `site_overview_html` | no       | HTML rendered above the album cards (slightly larger than album descriptions)                     |
+| Setting              | Required | Description                                                                                                  |
+|----------------------|----------|--------------------------------------------------------------------------------------------------------------|
+| `id`                 | yes      | Names the output directory; must be lowercase letters, digits, and hyphens                                   |
+| `site_name`          | yes      | Site title shown in the browser tab and OG tags                                                              |
+| `site_url`           | yes      | Canonical base URL (e.g. `https://photos.example.com`); used in sitemap and OG tags                          |
+| `site_description`   | yes      | Meta description and OG description for the home page                                                        |
+| `copyright_owner`    | yes      | Name shown in the footer copyright line                                                                      |
+| `copyright_year`     | yes      | Start year shown in the footer copyright line                                                                |
+| `descriptions`       | no       | Path to a [descriptions file](#album-descriptions), relative to the config dir; see that section for details |
+| `allow_crawling`     | no       | Set to `true` to allow search engine crawling; adds `Sitemap:` to `robots.txt` (default: `false`)            |
+| `site_title_html`    | no       | HTML for the site title on the home page; falls back to `site_name` when omitted                             |
+| `site_subtitle_html` | no       | HTML rendered below the site title in a smaller font                                                         |
+| `site_overview_html` | no       | HTML rendered above the album cards (slightly larger than album descriptions)                                |
+
+### Source Bases
+
+The `bases:` block defines named paths to where your source photos live. Albums (and
+the hero image) reference a base by name via the `base:` key, so you can keep album
+entries short and change a root path in one place:
+
+```yaml
+bases:
+  drive: /Volumes/MyDrive/Photos   # absolute path (e.g. an external drive)
+  cloud: /Users/me/Dropbox/Photos  # absolute path (e.g. a cloud-synced folder)
+  local: photos                    # relative to the root DD Photos folder (sibling of config/)
+
+albums:
+  - slug: patagonia
+    name: Patagonia
+    base: drive                    # references bases.drive
+    source: 2026-Patagonia         # joined to the base path -> /Volumes/MyDrive/Photos/2026-Patagonia
+```
+
+Each base value is either an absolute path or a path relative to the root DD Photos
+folder. An album's `source:` is joined to its named base; an album with no `base:` must
+give an absolute path in `source:`.
+
+In **Docker mode**, the `ddphotos` wrapper script reads these base paths and mounts them
+into the container automatically, so the paths you list must exist on your machine.
 
 ### How Config Reaches the Frontend
 


### PR DESCRIPTION
Fixes #71.

## Background

When using the Docker `ddphotos` wrapper, a `bases:` entry pointing at a container-internal `/ddphotos/...` path was treated as an external host path and added as an extra read-only bind mount. That mount (`/ddphotos/source -> /ddphotos/source`) masked the real source directory already available through the main `/ddphotos` project mount, so `photogen` failed with `path "..." does not exist`.

The root confusion is that `/ddphotos*` (and `/docker*`) paths only make sense *inside* the image (they point at bundled sample data), not on the user's machine. A real base must be a folder that exists on the host.

## Changes

- **`docker/ddphotos`** — `build_config_bases_mounts()` now rejects `bases:` values that begin with `/ddphotos` or `/docker`, printing a clear error ("A base must be a folder that exists on this machine.") and exiting instead of silently adding a masking mount. This mirrors the existing skip logic already applied to absolute `source:` and `image:` entries, but fails loud rather than silently for bases since such a value is always a mistake.
- **`config/albums.example.yaml`** — clarify that bases can be absolute *or* relative to the root DD Photos folder; add a `local: photos` relative-path example.
- **`docker/init/albums.yaml`** — reword the bases guidance, note that `/ddphotos` paths are container-internal sample data only, and make the example reference/source mapping explicit.
- **`docs/CONFIGURATION.md`** — add a new **Source Bases** section under `## albums.yaml` documenting `bases:`, absolute vs. relative values, how `source:` joins to a base, and the Docker auto-mount behavior. Also fix the `descriptions` anchor link (`#descriptionstext` -> `#album-descriptions`).

## Notes

`bash -n` passes on the updated script. The new guard fires on the `photogen` path (where `build_config_bases_mounts` is called), which is where issue #71 surfaced.
