### PR TITLE
Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalize text line endings. Files are stored LF in the repo; the rules
+# below control what gets written to the working tree on checkout, regardless
+# of OS, editor, or core.autocrlf.
+* text=auto
+
+# Windows batch launchers must be CRLF.
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+# Shell scripts and the extensionless 'ddphotos' wrapper must stay LF
+# (they run under Git Bash / the Linux container; a stray CR breaks them).
+*.sh            text eol=lf
+docker/ddphotos text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ memory/
 
 # Cloudflare
 .wrangler
+
+# IDE
+.idea

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -21,6 +21,8 @@ TEMP_DECODE_DIR=""
 EXT_CONFIG_DIR=""
 ABS_CONFIG_DIR=""
 SC_TEST_DIR=""
+WIN_CONFIG_DIR=""
+WIN_OUT_DIR=""
 RUN_PID=""
 SERVE_PID=""
 
@@ -51,6 +53,8 @@ cleanup() {
     if [ -n "$EXT_CONFIG_DIR" ]; then /bin/rm -rf "$EXT_CONFIG_DIR"; fi
     if [ -n "$ABS_CONFIG_DIR" ]; then /bin/rm -rf "$ABS_CONFIG_DIR"; fi
     if [ -n "$SC_TEST_DIR" ];   then /bin/rm -rf "$SC_TEST_DIR";   fi
+    if [ -n "$WIN_CONFIG_DIR" ]; then /bin/rm -rf "$WIN_CONFIG_DIR"; fi
+    if [ -n "$WIN_OUT_DIR" ];    then /bin/rm -rf "$WIN_OUT_DIR";    fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -177,6 +181,41 @@ sed "s|_REPO_ROOT_|$REPO_ROOT|g" "$REPO_ROOT/web/testdata/albums.abspath.yaml" >
 [ -d "$TEST_DIR/albums/$ABS_SITE_ID/the-way" ] || fail "albums/$ABS_SITE_ID/the-way not created"
 [ -f "$TEST_DIR/albums/$ABS_SITE_ID/hero.jpg" ] || fail "albums/$ABS_SITE_ID/hero.jpg not created"
 pass "photogen with absolute source paths OK (album dir and hero.jpg created)"
+
+# ── 5b. Photogen: Windows-style C:\ path mapping ───────────────────────────────
+# A Windows drive path (C:\Users\...) in albums.yaml must map to the container
+# location /mnt/c/Users/... — the shared convention between bash to_container_path
+# (docker/ddphotos) and Go winToUnixPath (pkg/photogen/winpath.go). A real mount of
+# a C:\ host path is impossible on macOS/Linux (cygpath host-side translation is
+# Windows-only), so the two translation halves are validated separately.
+
+step "Photogen: Windows path mapping (bash host side)"
+WIN_CONFIG_DIR=$(mktemp -d)
+/bin/cp "$REPO_ROOT/web/testdata/albums.winpath.yaml" "$WIN_CONFIG_DIR/albums.yaml"
+# --show-mounts prints the mount table before the (expected-to-fail) docker run,
+# so we capture that output and ignore the failure.
+win_out=$("${DDPHOTOS[@]}" --config-dir "$WIN_CONFIG_DIR" photogen 2>&1) || true
+echo "$win_out" | grep -qF 'C:\Users\test\photos -> /mnt/c/Users/test/photos' \
+    || (echo "$win_out" && fail "windows path: base not mapped to /mnt/c/Users/test/photos")
+pass "windows path: bash maps C:\\Users\\test\\photos -> /mnt/c/Users/test/photos"
+
+step "Photogen: Windows path mapping (container side, real photos)"
+# Simulate what the Windows wrapper sets up on a real Windows host: the sample album
+# mounted at the translated container location, and the config dir whose base is
+# C:\Users\test\photos. photogen's winToUnixPath must translate that base to
+# /mnt/c/Users/test/photos and read the real photos mounted there.
+WIN_OUT_DIR=$(mktemp -d)
+chmod 755 "$WIN_OUT_DIR"
+docker run --rm \
+    -v "$WIN_OUT_DIR":/ddphotos \
+    -v "$WIN_CONFIG_DIR":/ddphotos-config:ro \
+    -v "$REPO_ROOT/sample/source/theway":/mnt/c/Users/test/photos/theway:ro \
+    -e DDPHOTOS_CONFIG_DIR=/ddphotos-config \
+    -e DDPHOTOS_SITE_ID=test-winpath \
+    "$IMAGE" photogen
+[ -d "$WIN_OUT_DIR/albums/test-winpath/the-way" ] \
+    || fail "windows path: albums/test-winpath/the-way not created"
+pass "windows path: photogen read photos via C:\\ base mapped to /mnt/c/..."
 
 # ── 6. Decode ──────────────────────────────────────────────────────────────────
 step "Decode"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ COPY --from=node-builder /app/web/node_modules /app/web/node_modules
 COPY docker/entrypoint.sh docker/do-init.sh docker/do-photogen.sh \
      docker/do-build.sh docker/do-serve.sh docker/do-run.sh docker/do-export.sh docker/do-deploy.sh \
      docker/do-decode.sh docker/do-search-cover.sh docker/do-wrangler.sh docker/do-surge.sh \
-     docker/ddphotos docker/cloudflare-worker.js \
+     docker/ddphotos docker/ddphotos.cmd docker/cloudflare-worker.js \
      web/setup-htdocs.sh bin/deploy-photos.sh bin/test-photos-server.sh /docker/
 RUN chmod +x /docker/*.sh
 

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -255,6 +255,11 @@ SERVE_PORT="${SERVE_PORT:-8000}"
 RUN_PORT="${RUN_PORT:-5173}"
 IT_FLAGS=(); $NON_INTERACTIVE || IT_FLAGS=(-it)
 
+# A frontend (e.g. the GUI) can set DDPHOTOS_CONTAINER_NAME so the long-running serve/run
+# containers get a deterministic --name, letting it later 'docker stop'/'docker kill' them by
+# name instead of trying to discover the container from the process tree. Empty when unset.
+NAME_FLAGS=(); [ -n "${DDPHOTOS_CONTAINER_NAME:-}" ] && NAME_FLAGS=(--name "$DDPHOTOS_CONTAINER_NAME")
+
 # Command prefix that disables Git Bash/MSYS automatic POSIX->Windows path conversion.
 # MSYS rewrites a bare container path argument such as `-w /ddphotos` into
 # `C:/Program Files/Git/ddphotos` (the MSYS install root + the path), which Docker then
@@ -513,7 +518,7 @@ case "$cmd" in
     serve)
         print_mounts
         publish_flags "$SERVE_PORT:80"
-        "$DOCKER" run --rm "${IT_FLAGS[@]}" \
+        "$DOCKER" run --rm "${IT_FLAGS[@]}" "${NAME_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e SERVE_PORT="$SERVE_PORT" \
             "${MOUNT_FLAGS[@]}" \
@@ -524,7 +529,7 @@ case "$cmd" in
     run)
         print_mounts
         publish_flags "$RUN_PORT:5173"
-        "$DOCKER" run --rm "${IT_FLAGS[@]}" \
+        "$DOCKER" run --rm "${IT_FLAGS[@]}" "${NAME_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e RUN_PORT="$RUN_PORT" \
             "${MOUNT_FLAGS[@]}" \

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -255,6 +255,17 @@ SERVE_PORT="${SERVE_PORT:-8000}"
 RUN_PORT="${RUN_PORT:-5173}"
 IT_FLAGS=(); $NON_INTERACTIVE || IT_FLAGS=(-it)
 
+# Command prefix that disables Git Bash/MSYS automatic POSIX->Windows path conversion.
+# MSYS rewrites a bare container path argument such as `-w /ddphotos` into
+# `C:/Program Files/Git/ddphotos` (the MSYS install root + the path), which Docker then
+# rejects with "the working directory '...' is invalid". Use this prefix on docker runs
+# that pass container paths as standalone args (e.g. -w); the -v mounts are unaffected
+# because their host side is already a Windows path from cygpath. Empty on macOS/Linux.
+DOCKER_NOPATHCONV=()
+case "$OSTYPE" in
+    msys|cygwin) DOCKER_NOPATHCONV=(env MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*') ;;
+esac
+
 # Resolve a path to absolute. Relative paths are anchored to DDPHOTOS_DIR.
 abs_path() {
     local p="$1"
@@ -540,7 +551,7 @@ case "$cmd" in
             print_mounts
             # No -it: wrangler login needs no terminal input; piping requires it off.
             # Merge stderr into stdout (2>&1) so the URL line is visible to the while loop.
-            "$DOCKER" run --rm \
+            "${DOCKER_NOPATHCONV[@]}" "$DOCKER" run --rm \
                 -w /ddphotos \
                 -v ddphotos-npm-cache:/root/.npm \
                 -v ddphotos-wrangler-config:/root/.config/.wrangler \
@@ -564,7 +575,7 @@ case "$cmd" in
             # Working dir is /ddphotos so relative paths like export/<site-id> resolve correctly.
             # Credentials are read from the ddphotos-wrangler-config volume (populated by login).
             print_mounts
-            "$DOCKER" run --rm "${IT_FLAGS[@]}" \
+            "${DOCKER_NOPATHCONV[@]}" "$DOCKER" run --rm "${IT_FLAGS[@]}" \
                 -w /ddphotos \
                 -v ddphotos-npm-cache:/root/.npm \
                 -v ddphotos-wrangler-config:/root/.config/.wrangler \
@@ -586,7 +597,7 @@ case "$cmd" in
         add_mount "$HOME/.netrc" /root/.netrc
         print_mounts
         # Working dir is /ddphotos so relative paths like export/<site-id> resolve correctly.
-        "$DOCKER" run --rm "${IT_FLAGS[@]}" \
+        "${DOCKER_NOPATHCONV[@]}" "$DOCKER" run --rm "${IT_FLAGS[@]}" \
             -w /ddphotos \
             -v ddphotos-npm-cache:/root/.npm \
             "${MOUNT_FLAGS[@]}" \

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -89,13 +89,36 @@ MOUNT_FLAGS=()  # -v args, kept in sync by add_mount
 MOUNT_SEQ=0     # used when passing mounts as args
 
 add_mount() {
-    MOUNT_FROM+=("$1")
+    # Docker Desktop's -v wants the host (left) side in Windows form (C:\Users\...).
+    # Under Git Bash/MSYS our paths are Unix form (/c/Users/...), so normalize the host
+    # side with cygpath -w, which also leaves an already-Windows path untouched. Only the
+    # host side is translated; $2 is always a container path chosen by the caller.
+    local from="$1"
+    case "$OSTYPE" in msys|cygwin) from="$(cygpath -w "$from")" ;; esac
+    MOUNT_FROM+=("$from")
     MOUNT_TO+=("$2")
     MOUNT_OPTS+=("${3:-}")
     if [ -n "${3:-}" ]; then
-        MOUNT_FLAGS+=(-v "$1:$2:$3")
+        MOUNT_FLAGS+=(-v "$from:$2:$3")
     else
-        MOUNT_FLAGS+=(-v "$1:$2")
+        MOUNT_FLAGS+=(-v "$from:$2")
+    fi
+}
+
+# True if $1 is an absolute path: a Unix path (/...) or a Windows drive path (C:\... or C:/...).
+is_abs_path() { [[ "$1" == /* ]] || [[ "$1" =~ ^[A-Za-z]:[\\/] ]]; }
+
+# Map a host folder to its container mount point. A Windows base from albums.yaml
+# (C:\Users\name\Dropbox) is invalid as a container target, so translate it to
+# /mnt/<drive>/... (mirrors winToUnixPath in pkg/photogen/winpath.go). Unix paths
+# (macOS/Linux) are returned unchanged.
+to_container_path() {
+    local p="$1"
+    if [[ "$p" =~ ^([A-Za-z]):[\\/](.*)$ ]]; then
+        local d="${BASH_REMATCH[1]}" rest="${BASH_REMATCH[2]//\\//}"
+        echo "/mnt/${d,,}/$rest"
+    else
+        echo "$p"
     fi
 }
 
@@ -177,8 +200,8 @@ build_config_bases_mounts() {
                 exit 1
             fi
             # Only mount absolute paths that fall outside DDPHOTOS_DIR (which is already mounted)
-            if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
-                add_mount "$path" "$path" ro
+            if is_abs_path "$path" && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
+                add_mount "$path" "$(to_container_path "$path")" ro
             fi
         else
             # Outside bases: — look for album source: or hero image: with absolute paths.
@@ -192,8 +215,8 @@ build_config_bases_mounts() {
                 path="${path/#\~/$HOME}"
                 # Skip /ddphotos* and /docker* paths — container-internal placeholders
                 # used in the init template (e.g. /ddphotos-init) and older templates.
-                if [[ "$path" == /* ]] && [[ "$path" != "$DDPHOTOS_DIR"* ]] && [[ "$path" != /ddphotos* ]] && [[ "$path" != /docker* ]]; then
-                    add_mount "$path" "$path" ro
+                if is_abs_path "$path" && [[ "$path" != "$DDPHOTOS_DIR"* ]] && [[ "$path" != /ddphotos* ]] && [[ "$path" != /docker* ]]; then
+                    add_mount "$path" "$(to_container_path "$path")" ro
                 fi
             fi
         fi

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -266,6 +266,37 @@ case "$OSTYPE" in
     msys|cygwin) DOCKER_NOPATHCONV=(env MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*') ;;
 esac
 
+# Build docker -p publish flags for a HOST:CONTAINER port mapping into PUBLISH_FLAGS.
+# The default IPv4 publish (-p HOST:CONTAINER, i.e. 0.0.0.0) is what macOS/Linux use and
+# also keeps LAN access working. On Windows, "localhost" resolves to IPv6 ::1 first, but
+# Docker Desktop only publishes on the IPv4 stack, so localhost:PORT fails in the browser
+# (127.0.0.1 works). Adding a second publish on the IPv6 loopback ([::1]) makes localhost
+# reach the container regardless of how Windows resolves it — needed because the Vite dev
+# server and especially `wrangler login` (which always redirects to
+# http://localhost:8976/oauth/callback) hand the user a localhost URL we cannot rewrite.
+publish_flags() {
+    local map="$1"
+    PUBLISH_FLAGS=(-p "$map")
+    case "$OSTYPE" in msys|cygwin) PUBLISH_FLAGS+=(-p "[::1]:$map") ;; esac
+}
+
+# Open a URL in the host's default browser across macOS (open), Linux (xdg-open) and
+# Windows/Git Bash (no open/xdg-open — fall back to PowerShell's Start-Process, then
+# cmd's start). Best-effort: does nothing if no opener is found, since callers also print
+# the URL. MSYS_NO_PATHCONV stops Git Bash mangling the URL passed to the native opener.
+open_url() {
+    local url="$1"
+    if command -v open >/dev/null 2>&1; then
+        open "$url"
+    elif command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "$url" >/dev/null 2>&1 &
+    elif command -v powershell.exe >/dev/null 2>&1; then
+        MSYS_NO_PATHCONV=1 powershell.exe -NoProfile -Command "Start-Process '$url'" >/dev/null 2>&1
+    elif command -v cmd.exe >/dev/null 2>&1; then
+        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' cmd.exe /c start "" "$url" >/dev/null 2>&1
+    fi
+}
+
 # Resolve a path to absolute. Relative paths are anchored to DDPHOTOS_DIR.
 abs_path() {
     local p="$1"
@@ -481,21 +512,23 @@ case "$cmd" in
 
     serve)
         print_mounts
+        publish_flags "$SERVE_PORT:80"
         "$DOCKER" run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e SERVE_PORT="$SERVE_PORT" \
             "${MOUNT_FLAGS[@]}" \
-            -p "$SERVE_PORT":80 \
+            "${PUBLISH_FLAGS[@]}" \
             "$IMAGE" serve "$@"
         ;;
 
     run)
         print_mounts
+        publish_flags "$RUN_PORT:5173"
         "$DOCKER" run --rm "${IT_FLAGS[@]}" \
             -e DDPHOTOS_SITE_ID="$DDPHOTOS_SITE_ID" \
             -e RUN_PORT="$RUN_PORT" \
             "${MOUNT_FLAGS[@]}" \
-            -p "$RUN_PORT":5173 \
+            "${PUBLISH_FLAGS[@]}" \
             "$IMAGE" run "$@"
         ;;
 
@@ -543,31 +576,31 @@ case "$cmd" in
             # Running inside Docker complicates steps 1 and 2:
             #   - --callback-host 0.0.0.0 makes wrangler bind on all interfaces (not just 127.0.0.1)
             #     so Docker's port forwarding can reach it
-            #   - -p 8976:8976 forwards localhost:8976 on the host into the container
+            #   - -p 8976:8976 forwards localhost:8976 on the host into the container. On Windows
+            #     publish_flags adds an IPv6 loopback ([::1]) publish too, because Cloudflare always
+            #     redirects to http://localhost:8976/oauth/callback and Windows resolves localhost
+            #     to ::1 first — without it the post-login callback never reaches the container.
             #   - --browser false suppresses wrangler's own browser-open attempt (no display in container)
             #   - we pipe docker output through the host, detect the https:// URL, and open it ourselves
             [[ " $* " != *" --callback-host "* ]] && set -- "$@" --callback-host 0.0.0.0
             [[ " $* " != *" --browser "* ]]       && set -- "$@" --browser false
             print_mounts
+            publish_flags "8976:8976"
             # No -it: wrangler login needs no terminal input; piping requires it off.
             # Merge stderr into stdout (2>&1) so the URL line is visible to the while loop.
             "${DOCKER_NOPATHCONV[@]}" "$DOCKER" run --rm \
                 -w /ddphotos \
                 -v ddphotos-npm-cache:/root/.npm \
                 -v ddphotos-wrangler-config:/root/.config/.wrangler \
-                -p 8976:8976 \
+                "${PUBLISH_FLAGS[@]}" \
                 "${MOUNT_FLAGS[@]}" \
                 "${WRANGLER_ENV[@]}" \
                 "$IMAGE" wrangler "$@" 2>&1 | \
             while IFS= read -r line; do
                 printf '%s\n' "$line"
-                # Auto-open the Cloudflare auth URL in the host browser (open=Mac, xdg-open=Linux)
+                # Auto-open the Cloudflare auth URL in the host browser (macOS/Linux/Windows).
                 if [[ "$line" =~ (https://[^[:space:]]+) ]]; then
-                    if command -v open >/dev/null 2>&1; then
-                        open "${BASH_REMATCH[1]}"
-                    elif command -v xdg-open >/dev/null 2>&1; then
-                        xdg-open "${BASH_REMATCH[1]}" 2>/dev/null &
-                    fi
+                    open_url "${BASH_REMATCH[1]}"
                 fi
             done
         else

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -351,7 +351,13 @@ fi
 
 case "$cmd" in
     init)
-        "$DOCKER" run --rm "${MOUNT_FLAGS[@]}" "$IMAGE" init "$@"
+        # Under Git Bash/Cygwin, also install the ddphotos.cmd Windows launcher.
+        # (The container can't detect the host OS, so we signal it with --windows.)
+        INIT_ARGS=("$@")
+        if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && [[ " $* " != *" --windows "* ]]; then
+            INIT_ARGS+=(--windows)
+        fi
+        "$DOCKER" run --rm "${MOUNT_FLAGS[@]}" "$IMAGE" init "${INIT_ARGS[@]}"
         ;;
 
     decode)

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -3,6 +3,15 @@
 # https://github.com/dougdonohoe/ddphotos
 set -eo pipefail
 
+# On Windows (Git Bash/MSYS or Cygwin), a bash started from cmd/PowerShell or a
+# .cmd wrapper may inherit only the Windows PATH, leaving the Unix coreutils
+# (dirname, awk, sed, ...) unreachable. Under MSYS/Cygwin they live at /usr/bin,
+# which is mapped independently of PATH, so restoring it here is safe. Uses only
+# builtins so it runs before the first external command (dirname, just below).
+case "$OSTYPE" in
+    msys|cygwin) command -v dirname >/dev/null 2>&1 || PATH="/usr/bin:/bin:$PATH" ;;
+esac
+
 # IMAGE is replaced at docker build time (see Dockerfile).  In a production
 # build it will be something like dougdonohoe/ddphotos:v.1.##.0.
 IMAGE="ddphotos"

--- a/docker/ddphotos.cmd
+++ b/docker/ddphotos.cmd
@@ -5,49 +5,38 @@ rem https://github.com/dougdonohoe/ddphotos
 rem
 rem ddphotos.cmd - Windows launcher for the 'ddphotos' bash wrapper.
 rem
-rem Git\bin\bash.exe, when run from cmd/Explorer, inherits the Windows PATH,
-rem which does not include Git's Unix tools (dirname, awk, sed, grep, find,
-rem sort, curl, ...). This launcher locates Git for Windows, prepends its
-rem usr\bin and bin to PATH, then runs the 'ddphotos' bash script that lives
-rem next to this file.
+rem Finds a Git for Windows bash.exe and uses it to run the 'ddphotos' bash
+rem script next to this file. (ddphotos repairs its own PATH for the Unix tools.)
 rem
-rem To skip the search, set DDPHOTOS_BASH to the full path of bash.exe (e.g.
-rem the path a frontend already confirmed with the user). If it points to a
-rem real file it is used directly; otherwise the search below runs as a fallback.
+rem Set DDPHOTOS_BASH to a bash.exe full path to skip the search.
 
 set "BASH="
 
-rem 1. Caller-supplied bash.exe via DDPHOTOS_BASH (skips the search).
-if defined DDPHOTOS_BASH (
-    if exist "%DDPHOTOS_BASH%" (
-        set "BASH=%DDPHOTOS_BASH%"
-    ) else (
-        echo Warning: DDPHOTOS_BASH "%DDPHOTOS_BASH%" not found; searching for Git Bash. 1>&2
-    )
-)
+rem 1. Caller-supplied bash.exe (e.g. a frontend already confirmed the path).
+if defined DDPHOTOS_BASH if exist "%DDPHOTOS_BASH%" set "BASH=%DDPHOTOS_BASH%"
 
-rem 2. Search standard Git for Windows install locations.
+rem 2. Standard Git for Windows locations. Literal C:\ paths cover callers with a
+rem    reduced environment (e.g. a JVM) that lacks %ProgramFiles% / %LOCALAPPDATA%.
 if not defined BASH (
-    for %%G in ("%ProgramFiles%\Git" "%ProgramFiles(x86)%\Git" "%LOCALAPPDATA%\Programs\Git") do (
+    for %%G in (
+        "%ProgramFiles%\Git"
+        "%ProgramFiles(x86)%\Git"
+        "%LOCALAPPDATA%\Programs\Git"
+        "C:\Program Files\Git"
+        "C:\Program Files (x86)\Git"
+    ) do (
         if not defined BASH if exist "%%~G\bin\bash.exe" set "BASH=%%~G\bin\bash.exe"
     )
 )
 
 rem 3. Fall back to bash.exe on PATH.
-if not defined BASH (
-    for %%B in (bash.exe) do set "BASH=%%~$PATH:B"
-)
+if not defined BASH for %%B in (bash.exe) do if not defined BASH if exist "%%~$PATH:B" set "BASH=%%~$PATH:B"
 
 if not defined BASH (
     echo Error: Git Bash not found. Install Git for Windows: https://git-scm.com/download/win 1>&2
     echo        Or set DDPHOTOS_BASH to the full path of bash.exe. 1>&2
     exit /b 1
 )
-
-rem Prepend the Git Unix tools (usr\bin and bin, relative to bash.exe) to PATH
-rem so dirname/awk/sed/etc. resolve.
-for %%B in ("%BASH%") do set "BINDIR=%%~dpB"
-set "PATH=%BINDIR%..\usr\bin;%BINDIR%;%PATH%"
 
 "%BASH%" "%~dp0ddphotos" %*
 exit /b %ERRORLEVEL%

--- a/docker/ddphotos.cmd
+++ b/docker/ddphotos.cmd
@@ -1,0 +1,53 @@
+@echo off
+setlocal EnableExtensions
+rem SPDX-License-Identifier: AGPL-3.0-only
+rem https://github.com/dougdonohoe/ddphotos
+rem
+rem ddphotos.cmd - Windows launcher for the 'ddphotos' bash wrapper.
+rem
+rem Git\bin\bash.exe, when run from cmd/Explorer, inherits the Windows PATH,
+rem which does not include Git's Unix tools (dirname, awk, sed, grep, find,
+rem sort, curl, ...). This launcher locates Git for Windows, prepends its
+rem usr\bin and bin to PATH, then runs the 'ddphotos' bash script that lives
+rem next to this file.
+rem
+rem To skip the search, set DDPHOTOS_BASH to the full path of bash.exe (e.g.
+rem the path a frontend already confirmed with the user). If it points to a
+rem real file it is used directly; otherwise the search below runs as a fallback.
+
+set "BASH="
+
+rem 1. Caller-supplied bash.exe via DDPHOTOS_BASH (skips the search).
+if defined DDPHOTOS_BASH (
+    if exist "%DDPHOTOS_BASH%" (
+        set "BASH=%DDPHOTOS_BASH%"
+    ) else (
+        echo Warning: DDPHOTOS_BASH "%DDPHOTOS_BASH%" not found; searching for Git Bash. 1>&2
+    )
+)
+
+rem 2. Search standard Git for Windows install locations.
+if not defined BASH (
+    for %%G in ("%ProgramFiles%\Git" "%ProgramFiles(x86)%\Git" "%LOCALAPPDATA%\Programs\Git") do (
+        if not defined BASH if exist "%%~G\bin\bash.exe" set "BASH=%%~G\bin\bash.exe"
+    )
+)
+
+rem 3. Fall back to bash.exe on PATH.
+if not defined BASH (
+    for %%B in (bash.exe) do set "BASH=%%~$PATH:B"
+)
+
+if not defined BASH (
+    echo Error: Git Bash not found. Install Git for Windows: https://git-scm.com/download/win 1>&2
+    echo        Or set DDPHOTOS_BASH to the full path of bash.exe. 1>&2
+    exit /b 1
+)
+
+rem Prepend the Git Unix tools (usr\bin and bin, relative to bash.exe) to PATH
+rem so dirname/awk/sed/etc. resolve.
+for %%B in ("%BASH%") do set "BINDIR=%%~dpB"
+set "PATH=%BINDIR%..\usr\bin;%BINDIR%;%PATH%"
+
+"%BASH%" "%~dp0ddphotos" %*
+exit /b %ERRORLEVEL%

--- a/docker/do-init.sh
+++ b/docker/do-init.sh
@@ -26,17 +26,20 @@ fi
 
 SCRIPT_ONLY=""
 SITE_ID="my-photos"
+WINDOWS=""
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --script-only) SCRIPT_ONLY=1; shift ;;
         --site-id) SITE_ID="$2"; shift 2 ;;
+        --windows) WINDOWS=1; shift ;;
         *)
             echo "Unknown option: $1" >&2
             echo "" >&2
-            echo "Usage: ddphotos init [--script-only] [--site-id ID]" >&2
+            echo "Usage: ddphotos init [--script-only] [--site-id ID] [--windows]" >&2
             echo "" >&2
             echo "  --script-only    Install just the 'ddphotos' wrapper script, skip config scaffold" >&2
             echo "  --site-id ID     Site ID written into albums.yaml (default: my-photos)" >&2
+            echo "  --windows        Also install the 'ddphotos.cmd' Windows launcher" >&2
             exit 1
             ;;
     esac
@@ -45,6 +48,12 @@ done
 # Always copy script
 cp /docker/ddphotos /ddphotos/ddphotos
 chmod +x /ddphotos/ddphotos
+
+# On Windows hosts, also install the .cmd launcher (the host can't be detected
+# from inside the container, so the caller signals it with --windows).
+if [ -n "$WINDOWS" ]; then
+    cp /docker/ddphotos.cmd /ddphotos/ddphotos.cmd
+fi
 
 # --script-only: install just the ddphotos wrapper script, skip config scaffold
 if [ -n "$SCRIPT_ONLY" ]; then

--- a/docker/do-run.sh
+++ b/docker/do-run.sh
@@ -16,6 +16,10 @@ fi
 
 export DDPHOTOS_SITE_ID="$SITE_ID"
 
+# Inside the container, Vite's "Network" URL is the container's internal IP, which
+# isn't reachable from the host — suppress it (see makeLogger in web/vite.config.ts).
+export DDPHOTOS_HIDE_NETWORK_URL=1
+
 # npm commands run from web dir
 cd /app/web
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,6 +46,14 @@ case "$cmd" in
             /bin/mv -f "${SCRIPT}.new" "$SCRIPT"
             echo "The 'ddphotos' script was upgraded ($VERSION)."
         fi
+        # On Windows installs, also refresh the ddphotos.cmd launcher if present
+        # (only updated when it already exists, so Mac/Linux installs are untouched).
+        CMD=/ddphotos-script-dir/ddphotos.cmd
+        if [ -f "$CMD" ] && ! diff -q /docker/ddphotos.cmd "$CMD" > /dev/null 2>&1; then
+            /bin/cp /docker/ddphotos.cmd "${CMD}.new"
+            /bin/mv -f "${CMD}.new" "$CMD"
+            echo "The 'ddphotos.cmd' launcher was upgraded ($VERSION)."
+        fi
         ;;
     help|*)
         [ "$cmd" != "help" ] && { echo "Unknown command: '$cmd'" >&2; echo >&2; }

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -272,6 +272,18 @@ There are two coordinated translations, both **no-ops on macOS/Linux**:
 
 **The two mappings must stay byte-for-byte in sync** — if you change one, change the other.
 
+### MSYS argument path conversion
+
+Git Bash also rewrites bare Unix-looking arguments before handing them to a native
+(non-MSYS) program like `docker.exe`. A standalone `-w /ddphotos` becomes
+`-w 'C:/Program Files/Git/ddphotos'` (the MSYS install root prepended), and the container
+fails to start with *"the working directory '...' is invalid"*. The `wrangler` and `surge`
+commands pass `-w /ddphotos`, so they run under the `DOCKER_NOPATHCONV` prefix
+(`env MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'`, empty off Windows) which disables that
+conversion. The `-v` mounts are unaffected because their host side is already a Windows
+path from `cygpath`. Commands like `photogen` avoid the issue entirely by `cd`-ing inside
+the container instead of passing `-w`.
+
 ## Static Site Examples
 
 Use `bin/deploy-sample-sites.sh --doit` to deploy `init` and `sample` sites to S3, Cloudflare and surge.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -251,8 +251,8 @@ share one convention for the container location of a Windows folder:
 C:\Users\name\Dropbox\Photos   ->   /mnt/c/Users/name/Dropbox/Photos
 ```
 
-(drive letter lowercased under `/mnt/<drive>/`, backslashes turned into forward slashes —
-the WSL convention).
+The drive letter is lowercased under `/mnt/<drive>/` and backslashes turned into forward slashes
+(the WSL convention).
 
 There are two coordinated translations, both **no-ops on macOS/Linux**:
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -229,6 +229,49 @@ docker system prune # get all the bytes possible
 
 The amount of space is set in _Docker Desktop → Settings → Resources → Advanced → Disk usage limit_.
 
+## Windows
+
+On Windows the `ddphotos` script runs under Git Bash (MSYS), and `ddphotos.cmd` is a thin
+wrapper that locates `bash.exe` and hands off to it. `photogen` itself almost always runs
+inside the Linux Docker container. The native Java wizard writes **Windows-style** paths
+into `config/albums.yaml` (`bases:`, album `source:`, hero `image:`), e.g.:
+
+```yaml
+bases:
+  dropbox: C:\Users\name\Dropbox\Photos
+```
+
+### Path translation convention
+
+Those Windows paths have to cross two boundaries — the Docker `-v` flag (which wants the
+host side in Windows form) and the Linux container (which needs a Unix path). Both sides
+share one convention for the container location of a Windows folder:
+
+```
+C:\Users\name\Dropbox\Photos   ->   /mnt/c/Users/name/Dropbox/Photos
+```
+
+(drive letter lowercased under `/mnt/<drive>/`, backslashes turned into forward slashes —
+the WSL convention).
+
+There are two coordinated translations, both **no-ops on macOS/Linux**:
+
+- **`docker/ddphotos` (host side).** `add_mount` normalizes the host (left) side of every
+  `-v` with `cygpath -w`, because Git Bash hands us Unix paths (`/c/Users/...`) but Docker
+  Desktop needs Windows paths (`C:\Users\...`). For mounts of photo folders, the container
+  (right) side is produced by `to_container_path`, which maps `C:\...` → `/mnt/<drive>/...`.
+  `is_abs_path` additionally recognizes drive-letter paths as absolute so Windows bases are
+  actually mounted. All of this is gated on `OSTYPE` being `msys`/`cygwin`.
+
+- **`pkg/photogen` (container side).** `winToUnixPath` in `pkg/photogen/winpath.go` applies
+  the same `C:\...` → `/mnt/<drive>/...` mapping when resolving paths, so `photogen` reads
+  from exactly where the bash side mounted the folder. It is gated on
+  `runtime.GOOS != "windows"` (native Windows runs need no translation) and is called from
+  `resolveFSPath` in `pkg/photogen/albums_config.go`, which feeds album image loading,
+  resizing, hero processing, and the custom CSS path.
+
+**The two mappings must stay byte-for-byte in sync** — if you change one, change the other.
+
 ## Static Site Examples
 
 Use `bin/deploy-sample-sites.sh --doit` to deploy `init` and `sample` sites to S3, Cloudflare and surge.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -15,7 +15,7 @@ installer for your machine.  Install it and then start _Docker.app_ (Mac) or _Do
 Windows users also needs to install [Git For Windows↗](https://git-scm.com/download/win).  This is
 needed so that the internal `ddphotos` bash and linux style commands work. 
 
-**NOTE**: It is perfectly **OK** to just accepted all the default options (there are a lot of screens!).
+**NOTE**: It is perfectly **OK** to just accept all the default options (there are a lot of screens!).
 
 ### 1-w2. Windows Note
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -10,14 +10,38 @@ If you don't have Docker installed, click on the **Download Docker Desktop** but
 [Docker Getting Started↗](https://www.docker.com/get-started/) page to download the appropriate
 installer for your machine.  Install it and then start _Docker.app_ (Mac) or _Docker Desktop_ (Windows/Linux).
 
+### 1-w1. Git for Windows
+
+Windows users also needs to install [Git For Windows↗](https://git-scm.com/download/win).  This is
+needed so that the internal `ddphotos` bash and linux style commands work. 
+
+**NOTE**: It is perfectly **OK** to just accepted all the default options (there are a lot of screens!).
+
+### 1-w2. Windows Note
+
+**IMPORTANT WINDOWS NOTE**
+
+We are just adding Windows support now and will improve out docs
+soon, but commands seen in here can be adapted to Windows following
+these rules:
+
+* Run commands in the `Terminal` app running `Windows PowerShell`
+* Instead of `./ddphotos` use `.\ddphotos.cmd`.
+* In place of `~` use `$HOME`
+
 ### 2. Initialize Scaffolding
 
 Initialize a dedicated working directory that contains both the `ddphotos` script and
 a starter config:
 
 ```bash
-mkdir ~/my-ddphotos
-docker run --rm -v ~/my-ddphotos:/ddphotos dougdonohoe/ddphotos init
+mkdir $HOME/my-ddphotos
+
+# Mac/Linux
+docker run --rm -v $HOME/my-ddphotos:/ddphotos dougdonohoe/ddphotos init
+
+# Windows - also installs `ddphotos.cmd` wrapper
+docker run --rm -v $HOME/my-ddphotos:/ddphotos dougdonohoe/ddphotos init --windows
 ```
 
 ### 3. Generate, run, build, and serve the starter site

--- a/pkg/photogen/albums_config.go
+++ b/pkg/photogen/albums_config.go
@@ -161,7 +161,10 @@ func (af *AlbumsFile) ToAlbumConfigs(configDir string) ([]*AlbumConfig, error) {
 	}
 
 	if af.Settings.CustomCSS != "" {
-		cssPath := filepath.Join(configDir, af.Settings.CustomCSS)
+		cssPath := winToUnixPath(af.Settings.CustomCSS)
+		if !filepath.IsAbs(cssPath) {
+			cssPath = filepath.Join(configDir, cssPath)
+		}
 		if _, err := os.Stat(cssPath); err != nil {
 			return nil, fmt.Errorf("css: file %q does not exist", cssPath)
 		}
@@ -176,9 +179,9 @@ func (af *AlbumsFile) ToAlbumConfigs(configDir string) ([]*AlbumConfig, error) {
 // paths are anchored to the working directory. If base is empty and relPath is relative,
 // it is anchored to configDir. errContext is prepended to any returned error.
 func (af *AlbumsFile) resolveFSPath(configDir, base, relPath, errContext string) (string, error) {
-	resolved := relPath
+	resolved := winToUnixPath(relPath)
 	if base != "" {
-		basePath := af.Bases[base]
+		basePath := winToUnixPath(af.Bases[base])
 		if !filepath.IsAbs(basePath) {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -186,7 +189,7 @@ func (af *AlbumsFile) resolveFSPath(configDir, base, relPath, errContext string)
 			}
 			basePath = filepath.Join(cwd, basePath)
 		}
-		resolved = filepath.Join(basePath, relPath)
+		resolved = filepath.Join(basePath, resolved)
 	} else if !filepath.IsAbs(resolved) {
 		resolved = filepath.Join(configDir, resolved)
 	}

--- a/pkg/photogen/winpath.go
+++ b/pkg/photogen/winpath.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// https://github.com/dougdonohoe/ddphotos
+
+package photogen
+
+import (
+	"runtime"
+	"strings"
+)
+
+// winToUnixPath converts a Windows-style path (as written by the native Java wizard
+// into albums.yaml) into the container path that the ddphotos mounts use. The mapping
+//
+//	C:\Users\name\Dropbox\Photos  ->  /mnt/c/Users/name/Dropbox/Photos
+//
+// (drive letter lowercased under /mnt/<drive>/, backslashes turned into forward slashes)
+// must stay in sync with the bash to_container_path helper in docker/ddphotos, which
+// mounts the host folder at exactly this location.
+//
+// It is a no-op on native Windows (runtime.GOOS == "windows"), where Windows paths are
+// already valid, and for paths that are not Windows-style (e.g. an ordinary Unix path
+// on macOS/Linux).
+func winToUnixPath(p string) string {
+	if runtime.GOOS == "windows" || p == "" {
+		return p
+	}
+	// Drive-absolute: C:\... or C:/...  ->  /mnt/c/...
+	if len(p) >= 3 && isDriveLetter(p[0]) && p[1] == ':' && (p[2] == '\\' || p[2] == '/') {
+		rest := strings.ReplaceAll(p[3:], "\\", "/")
+		return "/mnt/" + strings.ToLower(p[:1]) + "/" + rest
+	}
+	// Relative Windows path (backslashes only): sub\dir -> sub/dir
+	if strings.Contains(p, "\\") {
+		return strings.ReplaceAll(p, "\\", "/")
+	}
+	return p
+}
+
+// isDriveLetter reports whether c is an ASCII letter usable as a Windows drive letter.
+func isDriveLetter(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}

--- a/pkg/photogen/winpath_test.go
+++ b/pkg/photogen/winpath_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// https://github.com/dougdonohoe/ddphotos
+
+package photogen
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWinToUnixPath(t *testing.T) {
+	t.Parallel()
+
+	// These cases assume a non-Windows host (the container photogen runs in). On native
+	// Windows winToUnixPath is a no-op, so skip — the GOOS=="windows" short-circuit can't
+	// be exercised off-Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("winToUnixPath is a no-op on native Windows")
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"drive backslash", `C:\Users\xboxl\Dropbox\Photos`, "/mnt/c/Users/xboxl/Dropbox/Photos"},
+		{"drive forward slash", "D:/data/pics", "/mnt/d/data/pics"},
+		{"drive lowercased", `E:\Stuff`, "/mnt/e/Stuff"},
+		{"relative windows", `sub\dir\file.jpg`, "sub/dir/file.jpg"},
+		{"unix absolute unchanged", "/Users/example/Photos", "/Users/example/Photos"},
+		{"relative unix unchanged", "2025-10 Girona", "2025-10 Girona"},
+		{"empty unchanged", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, winToUnixPath(tc.in))
+		})
+	}
+}

--- a/web/testdata/albums.winpath.yaml
+++ b/web/testdata/albums.winpath.yaml
@@ -1,0 +1,21 @@
+# Test file used by docker-test.sh to validate Windows path (C:\...) handling.
+# The 'windrive' base is a Windows drive path; it must map to /mnt/c/Users/test/photos
+# on both sides: bash to_container_path (docker/ddphotos) and Go winToUnixPath
+# (pkg/photogen/winpath.go). Keep those two translations in sync.
+settings:
+  id: test-winpath
+  site_name: "Test Windows Path"
+  site_url: https://winpath.example.com
+  site_description: "Test windows path"
+  copyright_owner: "Sir Windows Path"
+  copyright_year: 1985
+
+bases:
+  windrive: C:\Users\test\photos
+
+albums:
+  - slug: the-way
+    name: The Way
+    base: windrive
+    source: theway
+    cover: 2024-The-Way-14.jpg

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import { resolve, join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, createLogger } from 'vite';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -84,7 +84,25 @@ const httpsPlugin = process.env.VITE_HTTPS
 	? [(await import('@vitejs/plugin-basic-ssl')).default()]
 	: [];
 
+// When DDPHOTOS_HIDE_NETWORK_URL is set (Docker runs via docker/do-run.sh), the
+// "Network" URL Vite prints is the container's internal IP, which isn't reachable
+// from the host. Suppress that one line while keeping host:true so the forwarded
+// port still works. Unset (e.g. `make web-npm-run-dev` on a dev box) keeps the
+// Network URL, which is useful for phone/LAN access.
+function makeLogger() {
+	if (!process.env.DDPHOTOS_HIDE_NETWORK_URL) return undefined;
+	const logger = createLogger();
+	const origInfo = logger.info.bind(logger);
+	logger.info = (msg, options) => {
+		// eslint-disable-next-line no-control-regex
+		if (/Network:/.test(msg.replace(/\x1b\[[0-9;]*m/g, ''))) return;
+		origInfo(msg, options);
+	};
+	return logger;
+}
+
 export default defineConfig({
+	customLogger: makeLogger(),
 	server: {
 		host: true // Listen on all interfaces (allows phone access via IP)
 	},


### PR DESCRIPTION
## Summary

Adds Windows support so `ddphotos` can be run on Windows via Git for Windows + Docker, alongside the existing macOS/Linux flow.

## Changes

### Windows launcher
- **`docker/ddphotos.cmd`** — Windows launcher that finds a Git for Windows `bash.exe` (checking `DDPHOTOS_BASH`, standard install locations, then `PATH`) and uses it to run the existing `ddphotos` bash script. Errors with install guidance if no bash is found.
- **`docker/ddphotos`** — slimmed and made Windows-aware: PATH self-heal for the Unix tools, plus host-to-container path translation.
- **`.gitattributes`** — enforces line endings so the bash script and `.cmd` launcher behave correctly when checked out on Windows.

### Windows path handling
- **`pkg/photogen/winpath.go`** (+ test) — `winToUnixPath` converts Windows paths written into `albums.yaml` (e.g. `C:\Users\name\Photos`) to the container mount path (`/mnt/c/Users/name/Photos`). No-op on native Windows and for ordinary Unix paths. Kept in sync with the bash `to_container_path` helper in `docker/ddphotos`.
- **`pkg/photogen/albums_config.go`** — applies the path translation when loading album config.

### Docker
- Named containers so the UI can shut them down cleanly.
- Strip the Vite "Network:" URL when running in Docker (container-internal IP isn't reachable from the host) via `DDPHOTOS_HIDE_NETWORK_URL` and a custom Vite logger in `web/vite.config.ts`; the URL is preserved for normal dev runs (LAN/phone access).
- Fixes for Windows localhost URLs and opening the wrangler URL.
- Updates to `docker/Dockerfile`, `do-init.sh`, `do-run.sh`, `entrypoint.sh`.

### Tests
- **`bin/docker-test.sh`** — exercises Windows-style paths.
- **`web/testdata/albums.winpath.yaml`** — Windows-path test fixture.

### Docs
- **`docs/DOCKER.md`** and **`docs/DEV.md`** — Windows setup and developer notes.
