### PR TITLE
Fix logic which determines logout button visibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,11 @@ sample-photogen-pw-all:
 sample-photogen-pw-uganda:
 	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -passwords sample/config/passwords-uganda.yaml -site-id sample-pw-uganda -doit
 
+.PHONY: sample-photogen-pw-keyonly
+## sample-photogen-pw-keyonly: run photogen using sample images, passwords file with no passwords
+sample-photogen-pw-keyonly:
+	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -passwords sample/config/passwords-keyonly.yaml -site-id sample-pw-keyonly -doit
+
 .PHONY: sample-photogen-css
 ## sample-photogen-css: run photogen using sample images with custom CSS injected
 sample-photogen-css:

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -3,7 +3,8 @@
 #   1. No passwords (plain site)
 #   2. passwords-all.yaml (entire site encrypted + Uganda per-album)
 #   3. passwords-uganda.yaml (Uganda album only)
-#   4. custom-css (sample/config/custom.css injected)
+#   4. passwords-keyonly.yaml (passwords file with no passwords — nothing encrypted)
+#   5. custom-css (sample/config/custom.css injected)
 #
 # Usage:
 #   bin/test-all.sh [--mode dev|apache|nginx|all] [--ci]
@@ -22,7 +23,8 @@ usage() {
     echo "  1. No passwords (plain site)"
     echo "  2. passwords-all.yaml (entire site + Uganda album encrypted)"
     echo "  3. passwords-uganda.yaml (Uganda album only)"
-    echo "  4. custom-css (sample/config/custom.css injected)"
+    echo "  4. passwords-keyonly.yaml (passwords file with no passwords — nothing encrypted)"
+    echo "  5. custom-css (sample/config/custom.css injected)"
     echo ""
     echo "Options:"
     echo "  --mode <mode>  Server to test against: dev, apache, nginx, or all (default: all)."
@@ -60,9 +62,10 @@ run_variant() {
 }
 
 run_variant "no passwords"
-run_variant "passwords-all.yaml"    --passwords sample/config/passwords-all.yaml
-run_variant "passwords-uganda.yaml" --passwords sample/config/passwords-uganda.yaml
-run_variant "custom-css"            --css sample/config/custom.css
+run_variant "passwords-all.yaml"     --passwords sample/config/passwords-all.yaml
+run_variant "passwords-uganda.yaml"  --passwords sample/config/passwords-uganda.yaml
+run_variant "passwords-keyonly.yaml" --passwords sample/config/passwords-keyonly.yaml
+run_variant "custom-css"             --css sample/config/custom.css
 
 echo ""
 echo "All variants passed."

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -196,8 +196,14 @@ albums:
 | `albums.<slug>.password` | Per-album password; encrypts only that album's `index.json`. Falls back to `site.password` if not set                                                             |
 | `albums.<slug>.hint`     | Optional hint shown in that album's password dialog                                                                                                               |
 
-Sample passwords files are in `sample/config/` — `passwords-all.yaml` (full site) and
-`passwords-uganda.yaml` (single album). Both contain demo-only passwords and a prominent WARNING header.
+Sample passwords files are in `sample/config/` — `passwords-all.yaml` (full site),
+`passwords-uganda.yaml` (single album), and `passwords-keyonly.yaml` (a test fixture with a
+`key` but no passwords, so nothing is encrypted). The first two contain demo-only passwords.
+
+A passwords file that declares no `site.password` and no `albums.<slug>.password` protects
+nothing: the `key` only applies to albums that have a password, so every album stays public
+and filenames stay unobfuscated. Such a site is reported as unencrypted in `config.json`,
+which means no logout button is shown.
 
 #### Frontend Behavior (Encrypted Sites)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -146,20 +146,21 @@ the appropriate site variant:
 | `PLAYWRIGHT_CUSTOM_CSS`        | `bin/run-tests.sh`   | Set to `true`; enables CSS tests               |
 
 Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants automatically.
-`bin/test-all.sh` runs four variants: no passwords, `passwords-all.yaml`, `passwords-uganda.yaml`,
+`bin/test-all.sh` runs five variants: no passwords, `passwords-all.yaml`, `passwords-uganda.yaml`,
+`passwords-keyonly.yaml` (a passwords file that declares no passwords, so nothing is encrypted),
 and `custom-css` (with `sample/config/custom.css` injected).
 
 ```bash
-# Run all 4 variants against dev + Apache + nginx (default; recommended locally)
+# Run all 5 variants against dev + Apache + nginx (default; recommended locally)
 bin/test-all.sh
 
-# Run all 4 variants against Apache only (mirrors CI)
+# Run all 5 variants against Apache only (mirrors CI)
 bin/test-all.sh --mode apache
 
-# Run all 4 variants against nginx only
+# Run all 5 variants against nginx only
 bin/test-all.sh --mode nginx
 
-# Run all 4 variants against dev server, Apache, and nginx
+# Run all 5 variants against dev server, Apache, and nginx
 bin/test-all.sh --mode all
 
 # Run a single variant against Apache (no password)
@@ -181,7 +182,7 @@ bin/run-tests.sh --mode dev --test tests/privacy.spec.ts
 ### Sanity Check
 
 A good sanity check verifies against Apache (which requires a build), and tests
-both password and no-password sites.  It's quicker than running all 4 variants against
+both password and no-password sites.  It's quicker than running all 5 variants against
 dev, Apache and nginx:
 
 ```bash

--- a/pkg/photogen/config.go
+++ b/pkg/photogen/config.go
@@ -156,6 +156,11 @@ func (c *Config) HasPerAlbumPassword(slug string) bool {
 	return c.Encrypt != nil && c.Encrypt.HasPerAlbumPassword(slug)
 }
 
+// HasAnyPassword reports whether any password is configured, site-wide or per-album.
+func (c *Config) HasAnyPassword() bool {
+	return c.Encrypt != nil && c.Encrypt.HasAnyPassword()
+}
+
 // JsonNames returns the output filename and its counterpart for a JSON artifact.
 // When the site is encrypted, the primary file gets the ".enc.json" suffix.
 func (c *Config) JsonNames(base string) (output, counterpart string) {

--- a/pkg/photogen/encrypt.go
+++ b/pkg/photogen/encrypt.go
@@ -109,7 +109,7 @@ func checkPasswordLen(name, p string) error {
 //   - passwords must be at least minPasswordLen characters
 //   - empty per-album password values are rejected (they silently override site with no encryption)
 func (ec *EncryptConfig) Validate() error {
-	if ec.HMACKey == "" && (ec.IsSiteEncrypted() || len(ec.AlbumPasswords) > 0) {
+	if ec.HMACKey == "" && ec.HasAnyPassword() {
 		return fmt.Errorf("passwords file: key is required when any album is encrypted")
 	}
 	if ec.SitePassword != "" {
@@ -150,6 +150,12 @@ func (ec *EncryptConfig) HasPerAlbumPassword(slug string) bool {
 // IsSiteEncrypted reports whether albums.json is encrypted (i.e., site.password is set).
 func (ec *EncryptConfig) IsSiteEncrypted() bool {
 	return ec.SitePassword != ""
+}
+
+// HasAnyPassword reports whether any password is configured, site-wide or per-album.
+// False for a "key only" passwords file, which obfuscates filenames but protects nothing.
+func (ec *EncryptConfig) HasAnyPassword() bool {
+	return ec.IsSiteEncrypted() || len(ec.AlbumPasswords) > 0
 }
 
 // PhotoWebPName returns the output WebP filename for a source photo.

--- a/pkg/photogen/encrypt_test.go
+++ b/pkg/photogen/encrypt_test.go
@@ -53,6 +53,7 @@ func TestLoadEncryptConfig_KeyOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "secret", ec.HMACKey)
 	assert.False(t, ec.IsSiteEncrypted())
+	assert.False(t, ec.HasAnyPassword())
 }
 
 func TestEncryptConfigValidate(t *testing.T) {

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -273,7 +273,7 @@ type SiteConfig struct {
 	KeyID           string            `json:"keyId,omitempty"` // short fingerprint of the HMAC key; changes when the key changes
 	SiteHint        string            `json:"siteHint,omitempty"`
 	AlbumHints      map[string]string `json:"albumHints,omitempty"`
-	Encrypted       bool              `json:"encrypted,omitempty"`    // true if any encryption is configured
+	Encrypted       bool              `json:"encrypted,omitempty"`    // true if any password is configured (site or per-album); false for a key-only passwords file
 	HeroImage       string            `json:"heroImage,omitempty"`    // "hero.jpg" if a hero image is configured
 	CustomCSS       string            `json:"customCss,omitempty"`    // "custom.css" if a CSS override is configured
 	DefaultTheme    string            `json:"defaultTheme,omitempty"` // "light" or "dark"; omitted when dark (the built-in default)
@@ -315,7 +315,9 @@ func (c *Config) WriteConfigJSON() error {
 		AllowCrawling:   c.AllowCrawling,
 	}
 	if c.Encrypt != nil {
-		cfg.Encrypted = true
+		// Note this is not `true` just because a passwords file exists: a key-only file
+		// obfuscates filenames but leaves every album readable, so nothing is protected.
+		cfg.Encrypted = c.Encrypt.HasAnyPassword()
 		cfg.SiteHint = c.Encrypt.SiteHint
 		if len(c.Encrypt.AlbumHints) > 0 {
 			cfg.AlbumHints = c.Encrypt.AlbumHints

--- a/pkg/photogen/json_test.go
+++ b/pkg/photogen/json_test.go
@@ -285,6 +285,19 @@ func TestWriteConfigJSON(t *testing.T) {
 		assert.NotContains(t, string(data), `"htmlFile"`)
 	})
 
+	t.Run("key-only passwords file is not marked encrypted", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		encrypt := &EncryptConfig{HMACKey: "secret", AlbumPasswords: map[string]string{}}
+		require.NoError(t, makeSiteCfg(dir, encrypt).WriteConfigJSON())
+
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"encrypted"`, "a key-only file protects nothing")
+		assert.Contains(t, string(data), `"albumsFile": "albums.json"`)
+		assert.Contains(t, string(data), `"keyId"`, "key ID must still be emitted for key-only sites")
+	})
+
 	t.Run("unencrypted with HTML fields references html.json", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()

--- a/sample/config/passwords-keyonly.yaml
+++ b/sample/config/passwords-keyonly.yaml
@@ -1,0 +1,6 @@
+# A "key only" passwords file: a valid passwords file that protects nothing.
+# The key only affects albums that have a password (see Config.PhotoWebPName), so with
+# no site or album passwords every album stays public and filenames stay unobfuscated.
+# Used by the test suite to verify such a site is treated as unencrypted — no logout
+# button, no password wording on /privacy.
+key: ddphotos-sample-key-keyonly

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -51,7 +51,7 @@ export interface SiteConfig {
 	keyId?: string;
 	siteHint?: string;
 	albumHints?: Record<string, string>;
-	encrypted?: boolean;
+	encrypted?: boolean; // true if any password is configured (site or per-album); false for a key-only passwords file
 	heroImage?: string;
 	customCss?: string;
 	defaultTheme?: string;

--- a/web/tests/password.spec.ts
+++ b/web/tests/password.spec.ts
@@ -128,6 +128,18 @@ test('logout button is visible when encryption is configured', async ({ page }) 
 	await expect(page.locator('button[aria-label="Log out"]')).toBeVisible();
 });
 
+// Runs in both the no-passwords variant and the key-only variant (passwords-keyonly.yaml),
+// since loadPasswords() reports no passwords for both. The key-only case is the regression
+// guard: a passwords file used to imply encryption even when it declared no passwords.
+test('logout button is hidden when no passwords are configured', async ({ page }) => {
+	test.skip(!!pw.all || Object.keys(pw.albums).length > 0, 'passwords are configured');
+	const config = await page.request.get('/albums/config.json').then((r) => r.json());
+	expect(config.encrypted ?? false).toBe(false);
+	await page.goto('/');
+	await waitForHydration(page);
+	await expect(page.locator('button[aria-label="Log out"]')).toBeHidden();
+});
+
 test('logout button clears site password and shows prompt again', async ({ page }) => {
 	test.skip(!pw.all, 'no site-wide password configured');
 	await page.goto('/');


### PR DESCRIPTION
The logout button is meant to appear only when the site or at least one album is actually
password protected. It was appearing whenever a passwords file existed, even one that
declares no passwords at all (a "key only" file). Clicking it did nothing, since there
were no stored keys to clear.

## Root cause

The Svelte condition was already correct — the data feeding it was wrong.

`WriteConfigJSON` in `pkg/photogen/json.go` set `cfg.Encrypted = true` whenever
`c.Encrypt != nil`, which is true whenever a passwords file parsed successfully,
regardless of its contents. `LoadEncryptConfig` always returns a non-nil config on a
successful parse, and `Validate` explicitly permits a key-only file. So `encrypted` meant
"a passwords file exists" while its own comment claimed it meant "any encryption is
configured".

## Changes

Fixed in photogen rather than in the frontend, so there is a single source of truth.

- `pkg/photogen/encrypt.go` — new `HasAnyPassword()` predicate alongside the existing
  `IsSiteEncrypted` / `IsAlbumEncrypted` / `HasPerAlbumPassword`. `Validate()` already
  used that exact expression inline and now calls the helper.
- `pkg/photogen/config.go` — nil-safe `Config.HasAnyPassword()` wrapper.
- `pkg/photogen/json.go` — `cfg.Encrypted = c.Encrypt.HasAnyPassword()`. `KeyID` is still
  emitted for key-only sites so the frontend can detect key rotation and clear stale
  cover URLs.
- Comments corrected on the Go struct field and its TypeScript counterpart in
  `web/src/lib/types.ts`, per the type sync requirement.

No frontend code changes were needed. This also fixes the second consumer of the same
flag: `/privacy` was claiming "this site uses password-protected albums" on a site with
no passwords.

## Tests

- **Go** — new `TestWriteConfigJSON` subtest for the key-only case, asserting `encrypted`
  is absent while `keyId` is still present. Verified it fails against the old line and
  passes with the fix.
- **E2E** — added `sample/config/passwords-keyonly.yaml` as a fifth variant in
  `bin/test-all.sh` (auto-named `sample-pw-keyonly` by `bin/run-tests.sh`), a
  `sample-photogen-pw-keyonly` Makefile target, and a negative test in
  `web/tests/password.spec.ts`. `loadPasswords()` reports no passwords for both the
  no-passwords and key-only variants, so one test covers both.

Verified end to end: the new e2e test passes on the key-only variant and fails with
`Received: true` when `"encrypted": true` is reinstated in the generated `config.json`.

`make build test vet`, `make web-sanity-test`, and `make web-lint` all pass.

## Notes

A key-only passwords file does even less than the docs implied. The HMAC key is only
applied to albums that have a password (`Config.PhotoWebPName`), so with no passwords
anywhere, filenames stay unobfuscated — confirmed in the generated output
(`steeple_jason_26.webp`). `docs/CONFIGURATION.md` is updated accordingly; it previously
read as if `key` obfuscated filenames generally.

Existing deployed sites keep the stale `encrypted: true` until photogen re-runs, since
`config.json` is generated output. An `-index` pass (no re-resize) is enough.
