### PR TITLE
Photogen performance improvement via metadata cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,11 @@ build:
 	go build -ldflags "-X main.repoRoot=$(PWD)" ./...
 
 .PHONY: test
-## test: run `go test`
+## test: run `go test` (with the race detector)
+# -race catches data races in the concurrent resize and metadata workers. It needs cgo,
+# which is already required by govips, and roughly doubles the runtime.
 test:
-	go test -v -cover ./...
+	go test -v -race -cover ./...
 
 .PHONY: vet
 ## vet: run `go vet`

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -70,6 +70,15 @@ var (
 	heroOnly   = flag.Bool("hero-only", false, "regenerate hero image only, skipping all album and index processing")
 )
 
+// saveMetaCache persists the photo metadata cache, reporting failures as warnings
+// rather than errors: a cache that could not be written only costs time on the next
+// run, it does not invalidate anything that was generated.
+func saveMetaCache(cfg *photogen.Config) {
+	if err := cfg.MetaCache.Save(); err != nil {
+		fmt.Printf("WARN: could not save metadata cache: %s\n", err)
+	}
+}
+
 func main() {
 	flag.Parse()
 	exit.HandleSignal()
@@ -132,6 +141,12 @@ func main() {
 		SiteOverviewHTML: settings.SiteOverviewHTML,
 	}
 
+	// Photo metadata (dimensions, orientation, EXIF date) is cached between runs so
+	// unchanged photos are not re-decoded. -force means "redo everything", so it
+	// re-reads every photo and rewrites those entries.
+	cfg.MetaCache = photogen.LoadMetaCache(photogen.MetaCachePath(cfg.OutputRoot))
+	cfg.MetaCache.SetRefresh(*force)
+
 	// -passwords overrides settings.passwords; fall back to YAML setting if flag not provided
 	passwordsPath := *passwords
 	if passwordsPath == "" && settings.Passwords != "" {
@@ -181,8 +196,10 @@ func main() {
 		}
 		cfg.Force = true
 		if err := cfg.WriteHeroJPEG(); err != nil {
+			saveMetaCache(cfg)
 			exit.Fatal("Error writing hero JPEG", err)
 		}
+		saveMetaCache(cfg)
 		exit.ExitWithStatus(nil)
 	}
 
@@ -229,6 +246,7 @@ func main() {
 	for i, albumConfig := range albums {
 		if exit.ExitRequested() {
 			fmt.Println("Exit requested, stopping.")
+			saveMetaCache(cfg)
 			exit.ExitWithStatus(nil)
 		}
 		album := photogen.NewAlbumProcessor(cfg, albumConfig)
@@ -246,6 +264,9 @@ func main() {
 			exit.SetExitRequestedWithError(err)
 		}
 	}
+
+	// Saved after the hero so its stamp is recorded too.
+	saveMetaCache(cfg)
 
 	// Write albums.json, config.json, sitemap.xml, custom CSS, and build metadata if index generation is enabled
 	if cfg.Index {

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -11,7 +11,7 @@ as defined in `config/defaults.env`.
 |-------------------------------|-----------------------------------------------------------------------------------------------|
 | `help`                        | Show all available make targets (default when running `make`)                                 |
 | `build`                       | Compile all Go binaries                                                                       |
-| `test`                        | Run Go unit tests                                                                             |
+| `test`                        | Run Go unit tests (with the race detector)                                                    |
 | `mod-tidy`                    | Run `go mod tidy` to clean up imports                                                         |
 | `clean-cache`                 | Run `go clean -cache` (useful after a vips library upgrade)                                   |
 | `vet`                         | Run `go vet` static analysis                                                                  |

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -35,7 +35,7 @@ bin/photogen -resize -index -clean -doit  # developer mode
 | `-index`      | `false`       | Generate JSON index files and sitemap.xml                                                                                            |
 | `-out`        | *(from env)*  | Albums directory override (overrides `DDPHOTOS_ALBUMS_DIR`)                                                                          |
 | `-limit N`    | `0` (all)     | Limit photos per album (useful during development)                                                                                   |
-| `-force`      | `false`       | Regenerate files even if they already exist                                                                                          |
+| `-force`      | `false`       | Regenerate files even if they already exist; also re-reads photo metadata instead of using the [cache](#metadata-cache)              |
 | `-workers N`  | `0` (auto)    | Concurrent resize workers (auto = NumCPU/2, min 2)                                                                                   |
 | `-album`      | `""` (all)    | Comma-separated album slugs to process                                                                                               |
 | `-site-url`   | *(from YAML)* | Sitemap base URL override (overrides `settings.site_url`)                                                                            |
@@ -44,6 +44,37 @@ bin/photogen -resize -index -clean -doit  # developer mode
 | `-css`        | *(from YAML)* | Path to custom CSS file; overrides `settings.css` (see [Custom CSS](CONFIGURATION.md#custom-css))                                    |
 | `-clean`      | `false`       | Remove stale files from processed album directories after a run (requires `-resize`)                                                 |
 | `-hero-only`  | `false`       | Regenerate the hero image only; skips all album processing and index/JSON generation (see [Hero Image](CONFIGURATION.md#hero-image)) |
+
+## Metadata Cache
+
+Re-running `photogen` after adding a few photos should only cost what those new photos
+need. To make that true, photogen keeps a cache at `<albums-dir>/.build/metadata-cache.json`.
+
+It records two things, both keyed by the source file's modification time and size:
+
+- **Photo metadata** (dimensions, orientation, EXIF date). Without the cache every photo
+  is decoded on every run just to recover four values, even when nothing needs resizing.
+- **Stamps for fixed-name outputs** (`cover.jpg`, `hero.jpg`). These cannot use the normal
+  "output already exists, skip it" rule, because the same filename is produced from a
+  source that may have been swapped, so they used to be re-encoded on every run. The stamp
+  records which source and settings produced the file, making the skip safe.
+
+Anything that changes is picked up automatically: editing or replacing a source photo,
+pointing an album at a different `cover`, changing the hero `image` or `crop`, or deleting
+a generated file all trigger a regeneration. The cache only ever suppresses work that would
+have produced an identical file.
+
+Notes:
+
+- The cache is shared by every site ID under the same albums directory, since photo
+  metadata does not depend on which site is being generated.
+- It lives outside `<albums-dir>/<id>/`, so it is never deployed, never served, and never
+  touched by `-clean`.
+- It is written in dry-run mode too. It is a local performance artifact rather than site
+  output, so writing it does not conflict with `-doit`, and it means repeated dry-runs are
+  fast as well.
+- `-force` re-reads everything and rewrites the cache. To discard it entirely, delete
+  `<albums-dir>/.build/metadata-cache.json`; it is rebuilt on the next run.
 
 ## Photo Descriptions (`photogen.txt`)
 

--- a/pkg/photogen/album.go
+++ b/pkg/photogen/album.go
@@ -6,7 +6,12 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
+
+// defaultMetadataWorkers is the concurrency used when there is no Config to ask
+// (unit tests construct AlbumProcessors directly).
+const defaultMetadataWorkers = 4
 
 var allowedPhotoExtensions = map[string]struct{}{
 	".jpg":  {},
@@ -201,6 +206,68 @@ func (ap *AlbumProcessor) LoadPhotos() error {
 	return nil
 }
 
+// readMetadata reads metadata for one photo, going through the Config's metadata cache
+// when there is one. A nil Config (unit tests) or nil cache reads directly.
+func (ap *AlbumProcessor) readMetadata(path string) (*PhotoMetadata, error) {
+	if ap.Config == nil {
+		return ReadPhotoMetadata(path)
+	}
+	return ap.Config.MetaCache.Metadata(path)
+}
+
+// fillMetadata populates PhotoMetadata for each photo concurrently. Decoding images is
+// by far the most expensive part of a run that has nothing to resize, so it is spread
+// across the same number of workers used for resizing.
+//
+// Each goroutine writes only to its own *Photo, so the slice needs no locking; the
+// metadata cache guards its own map. Errors are collected by index and the
+// lowest-index one is returned, so a failure is reported deterministically rather than
+// depending on which worker lost the race.
+func (ap *AlbumProcessor) fillMetadata(photos []*Photo) error {
+	if len(photos) == 0 {
+		return nil
+	}
+
+	numWorkers := defaultMetadataWorkers
+	if ap.Config != nil {
+		numWorkers = ap.Config.Workers()
+	}
+	if numWorkers > len(photos) {
+		numWorkers = len(photos)
+	}
+
+	errs := make([]error, len(photos))
+	indexes := make(chan int, len(photos))
+	for i := range photos {
+		indexes <- i
+	}
+	close(indexes)
+
+	var wg sync.WaitGroup
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range indexes {
+				meta, err := ap.readMetadata(photos[i].AbsolutePath)
+				if err != nil {
+					errs[i] = fmt.Errorf("read metadata for %s: %w", photos[i].AbsolutePath, err)
+					continue
+				}
+				photos[i].PhotoMetadata = meta
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // collectPhotosRecursive collects photos from dir, optionally recursing into subdirectories.
 // relDir is the path of dir relative to the album root (empty string for the root itself).
 // Photos in subdirectories get a prefixed ID and FileName derived from the relative path
@@ -247,18 +314,17 @@ func (ap *AlbumProcessor) collectPhotosRecursive(dir, relDir string, recurse boo
 		}
 
 		fullPath := filepath.Join(dir, name)
-		photo := &Photo{
+		localPhotos = append(localPhotos, &Photo{
 			ID:           photoID,
 			FileName:     outputName,
 			AbsolutePath: fullPath,
 			SourcePath:   filepath.ToSlash(filepath.Join(relDir, name)),
-		}
-		meta, err := ReadPhotoMetadata(fullPath)
-		if err != nil {
-			return nil, fmt.Errorf("read metadata for %s: %w", fullPath, err)
-		}
-		photo.PhotoMetadata = meta
-		localPhotos = append(localPhotos, photo)
+		})
+	}
+
+	// Metadata is filled in before any sorting below, since sort order depends on dates.
+	if err := ap.fillMetadata(localPhotos); err != nil {
+		return nil, err
 	}
 
 	// Subdirectories default to alphabetical order.
@@ -506,11 +572,22 @@ func (ap *AlbumProcessor) WriteCoverJPEG() error {
 	}
 	outputPath := ap.OutputPath("cover.jpg")
 	ap.Config.TrackFile(outputPath)
-	// Always force-regenerate cover.jpg: the output filename is fixed, so a source
-	// change won't trigger normal skip logic. Covers are few and cheap to redo.
+
+	// cover.jpg has a fixed output name, so "the file exists" is not enough to skip it:
+	// the album's cover can be pointed at a different photo. The cache stamps the output
+	// with the source that produced it, which makes the skip safe. Without a cache this
+	// falls through to the unconditional regeneration it replaces.
+	if !ap.Config.Force && ap.Config.MetaCache.DerivedUpToDate(outputPath, cover.AbsolutePath, "") {
+		fmt.Printf("  exists: %s (cover jpeg)\n", outputPath)
+		return nil
+	}
+
 	result, err := ResizeCoverJPEG(cover.AbsolutePath, outputPath, true, ap.Config.DryRun)
 	if err != nil {
 		return fmt.Errorf("write cover jpeg: %w", err)
+	}
+	if result.Written {
+		ap.Config.MetaCache.RecordDerived(outputPath, cover.AbsolutePath, "")
 	}
 	fmt.Printf("  %s\n", result.Message)
 	return nil

--- a/pkg/photogen/config.go
+++ b/pkg/photogen/config.go
@@ -66,6 +66,9 @@ type Config struct {
 	SiteSubtitleHTML string
 	// SiteOverviewHTML is HTML shown above the album cards on the home page.
 	SiteOverviewHTML string
+	// MetaCache caches photo metadata between runs so unchanged photos are not
+	// re-decoded. nil disables caching.
+	MetaCache *MetaCache
 	// expectedFiles tracks files generated in this run (for --clean).
 	expectedFiles map[string]bool
 }
@@ -228,6 +231,14 @@ func (c *Config) Summary() string {
 		cssDesc = c.CustomCSS
 	}
 
+	cacheDesc := "disabled"
+	if c.MetaCache != nil {
+		cacheDesc = fmt.Sprintf("%s (%d entries)", c.MetaCache.path, c.MetaCache.Len())
+		if c.Force {
+			cacheDesc += " [rebuilding: -force]"
+		}
+	}
+
 	lines := []string{
 		fmt.Sprintf("  output:   %s", c.SiteOutputPath()),
 		fmt.Sprintf("  resize:   %s", on(c.Resize)),
@@ -235,6 +246,7 @@ func (c *Config) Summary() string {
 		fmt.Sprintf("  force:    %s", on(c.Force)),
 		fmt.Sprintf("  clean:    %s", on(c.Clean)),
 		fmt.Sprintf("  workers:  %d", c.Workers()),
+		fmt.Sprintf("  cache:    %s", cacheDesc),
 		fmt.Sprintf("  site_url: %s", c.SiteURL),
 		fmt.Sprintf("  encrypt:  %s", encryptDesc),
 		fmt.Sprintf("  hero:     %s", heroDesc),

--- a/pkg/photogen/exif_test.go
+++ b/pkg/photogen/exif_test.go
@@ -147,6 +147,25 @@ func TestReadPhotoMetadata_RealImages(t *testing.T) {
 			assert.False(t, meta.DateTaken.IsZero(), "expected date to be set")
 			assert.Equal(t, tc.wantDate, meta.DateTaken.Format("2006-01-02"))
 			t.Logf("%s: date taken = %s", tc.filename, meta.DateTaken.Format("2006-01-02 15:04:05"))
+
+			// Values served from the cache, including across a save/load round trip, must
+			// match the direct read exactly. Dimensions in particular are post-AutoRotate
+			// canonical values, so a cache that lost the rotation would show up here.
+			cachePath := filepath.Join(t.TempDir(), MetaCacheFileName)
+			mc := NewMetaCache(cachePath)
+
+			fresh, err := mc.Metadata(path)
+			require.NoError(t, err)
+			assert.Equal(t, meta, fresh, "cache miss must match a direct read")
+
+			cached, err := mc.Metadata(path)
+			require.NoError(t, err)
+			assert.Equal(t, meta, cached, "cache hit must match a direct read")
+
+			require.NoError(t, mc.Save())
+			reloaded, err := LoadMetaCache(cachePath).Metadata(path)
+			require.NoError(t, err)
+			assert.Equal(t, meta, reloaded, "reloaded cache must match a direct read")
 		})
 	}
 }

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -420,14 +420,25 @@ func (c *Config) WriteHeroJPEG() error {
 		return nil
 	}
 	outputPath := c.SiteOutputPath("hero.jpg")
-	// Always force-regenerate hero.jpg: the output filename is fixed, so a source
-	// change won't trigger normal skip logic.
+	c.TrackFile(outputPath)
+
+	// hero.jpg has a fixed output name, so "the file exists" is not enough to skip it:
+	// the configured hero image and its crop can both change. The cache stamps the
+	// output with the source and crop that produced it, which makes the skip safe.
+	// Without a cache this falls through to the unconditional regeneration it replaces.
+	if !c.Force && c.MetaCache.DerivedUpToDate(outputPath, c.Hero.ImagePath, c.Hero.Crop) {
+		fmt.Printf("  exists: %s (hero jpeg)\n", outputPath)
+		return nil
+	}
+
 	result, err := ResizeHeroJPEG(c.Hero.ImagePath, outputPath, c.Hero.Crop, true, c.DryRun)
 	if err != nil {
 		return err
 	}
+	if result.Written {
+		c.MetaCache.RecordDerived(outputPath, c.Hero.ImagePath, c.Hero.Crop)
+	}
 	fmt.Println(result.Message)
-	c.TrackFile(outputPath)
 	return nil
 }
 

--- a/pkg/photogen/metacache.go
+++ b/pkg/photogen/metacache.go
@@ -1,0 +1,299 @@
+package photogen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// metaCacheVersion is the on-disk schema version. Bump it whenever the shape of
+// metaCacheEntry or PhotoMetadata changes; a mismatch discards the whole file.
+const metaCacheVersion = 1
+
+// MetaCacheFileName is the cache file written under {OutputRoot}/.build/.
+const MetaCacheFileName = "metadata-cache.json"
+
+// MetaCache caches PhotoMetadata keyed by absolute source path so that re-runs skip
+// the libvips decode in ReadPhotoMetadata for source files that have not changed.
+//
+// Reading metadata is the dominant cost of a run with nothing to resize: resizing
+// already short-circuits on an os.Stat of the output file, but every photo was
+// previously decoded on every run just to recover width, height, orientation and date.
+//
+// Metadata depends only on the source file, so a single cache is shared by every
+// site ID under the same albums directory.
+//
+// A nil *MetaCache is valid and means "no caching": Metadata falls through to
+// ReadPhotoMetadata and Save does nothing.
+type MetaCache struct {
+	mu      sync.Mutex
+	path    string
+	dirty   bool
+	refresh bool
+	entries map[string]metaCacheEntry
+	derived map[string]derivedCacheEntry
+}
+
+// metaCacheFile is the on-disk representation of a MetaCache.
+type metaCacheFile struct {
+	Version int                          `json:"version"`
+	Entries map[string]metaCacheEntry    `json:"entries"`
+	Derived map[string]derivedCacheEntry `json:"derived"`
+}
+
+// derivedCacheEntry records which source file (and which settings) produced a derived
+// output whose filename is fixed, such as cover.jpg and hero.jpg. Those cannot use the
+// usual "output exists, skip it" rule, because the same output name is produced from a
+// source that may have been swapped for a different photo. Stamping the output with its
+// source lets a re-run tell "already up to date" apart from "needs regenerating".
+type derivedCacheEntry struct {
+	Source      string `json:"source"`
+	ModTimeNano int64  `json:"modTimeNano"`
+	Size        int64  `json:"size"`
+	Variant     string `json:"variant,omitempty"` // settings that affect the output, e.g. hero crop
+}
+
+// metaCacheEntry is one cached photo, stamped with the source file's modification
+// time and size. Both must match for the entry to be considered valid.
+type metaCacheEntry struct {
+	ModTimeNano int64          `json:"modTimeNano"`
+	Size        int64          `json:"size"`
+	Meta        *PhotoMetadata `json:"meta"`
+}
+
+// MetaCachePath returns the cache file location for an albums output root. It lives
+// beside the .build/<site-id>.json files, outside the per-site directory, so it is
+// never synced to a server and never seen by -clean.
+func MetaCachePath(outputRoot string) string {
+	return filepath.Join(outputRoot, ".build", MetaCacheFileName)
+}
+
+// NewMetaCache returns an empty cache bound to path.
+func NewMetaCache(path string) *MetaCache {
+	return &MetaCache{
+		path:    path,
+		entries: map[string]metaCacheEntry{},
+		derived: map[string]derivedCacheEntry{},
+	}
+}
+
+// SetRefresh makes Metadata ignore existing entries and re-decode every photo, while
+// still recording what it reads. This is what -force uses: entries for the photos in
+// this run are rebuilt, and entries for albums that were not processed (say, because
+// -album narrowed the run) are preserved rather than discarded.
+func (mc *MetaCache) SetRefresh(refresh bool) {
+	if mc == nil {
+		return
+	}
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.refresh = refresh
+}
+
+// LoadMetaCache reads the cache at path. It never fails: a missing, unreadable,
+// malformed, or wrong-version file simply yields an empty cache that repopulates
+// itself over the course of the run.
+func LoadMetaCache(path string) *MetaCache {
+	mc := NewMetaCache(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return mc // no cache yet: normal on a first run
+	}
+
+	var f metaCacheFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		fmt.Printf("  WARN: ignoring unreadable metadata cache %s: %v\n", path, err)
+		return mc
+	}
+	if f.Version != metaCacheVersion {
+		fmt.Printf("  Metadata cache %s is version %d (want %d), starting fresh\n", path, f.Version, metaCacheVersion)
+		return mc
+	}
+	if f.Entries != nil {
+		mc.entries = f.Entries
+	}
+	if f.Derived != nil {
+		mc.derived = f.Derived
+	}
+	return mc
+}
+
+// DerivedUpToDate reports whether the fixed-name output at outputPath was already
+// generated from exactly this source file and these settings, and still exists on disk.
+// A false result means "regenerate it", which is also what a nil cache always says, so
+// caching off simply restores the unconditional regeneration this replaces.
+func (mc *MetaCache) DerivedUpToDate(outputPath, sourcePath, variant string) bool {
+	if mc == nil {
+		return false
+	}
+
+	if _, err := os.Stat(outputPath); err != nil {
+		return false // output missing (or unreadable): regenerate
+	}
+	stat, err := os.Stat(sourcePath)
+	if err != nil {
+		return false // let the resize report the real problem with the source
+	}
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	if mc.refresh {
+		return false
+	}
+	entry, ok := mc.derived[outputPath]
+	return ok &&
+		entry.Source == sourcePath &&
+		entry.ModTimeNano == stat.ModTime().UnixNano() &&
+		entry.Size == stat.Size() &&
+		entry.Variant == variant
+}
+
+// RecordDerived stamps a freshly written fixed-name output with the source and settings
+// that produced it. Safe on a nil receiver.
+func (mc *MetaCache) RecordDerived(outputPath, sourcePath, variant string) {
+	if mc == nil {
+		return
+	}
+	stat, err := os.Stat(sourcePath)
+	if err != nil {
+		return // nothing worth recording if we cannot stamp it
+	}
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.derived[outputPath] = derivedCacheEntry{
+		Source:      sourcePath,
+		ModTimeNano: stat.ModTime().UnixNano(),
+		Size:        stat.Size(),
+		Variant:     variant,
+	}
+	mc.dirty = true
+}
+
+// Metadata returns the metadata for the photo at path, reading it from the cache when
+// the source file's modification time and size are unchanged and decoding it via
+// ReadPhotoMetadata otherwise. Safe for concurrent use, and safe on a nil receiver.
+func (mc *MetaCache) Metadata(path string) (*PhotoMetadata, error) {
+	if mc == nil {
+		return ReadPhotoMetadata(path)
+	}
+
+	// A failed stat is not fatal here: fall through and let ReadPhotoMetadata report
+	// the real problem with the file.
+	var modNano, size int64
+	stat, statErr := os.Stat(path)
+	if statErr == nil {
+		modNano = stat.ModTime().UnixNano()
+		size = stat.Size()
+
+		mc.mu.Lock()
+		entry, ok := mc.entries[path]
+		if mc.refresh {
+			ok = false
+		}
+		mc.mu.Unlock()
+		if ok && entry.Meta != nil && entry.ModTimeNano == modNano && entry.Size == size {
+			// Copy so callers can never mutate cache state through the returned pointer.
+			meta := *entry.Meta
+			return &meta, nil
+		}
+	}
+
+	meta, err := ReadPhotoMetadata(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if statErr == nil {
+		cached := *meta
+		mc.mu.Lock()
+		mc.entries[path] = metaCacheEntry{ModTimeNano: modNano, Size: size, Meta: &cached}
+		mc.dirty = true
+		mc.mu.Unlock()
+	}
+
+	return meta, nil
+}
+
+// Save writes the cache to disk, dropping entries whose source file no longer exists
+// so the file does not grow without bound as photos are renamed or deleted. It is a
+// no-op when nothing changed, and safe on a nil receiver.
+//
+// The cache is written even in dry-run mode: it is a local performance artifact under
+// .build/, never part of the generated site and never deployed, so writing it does not
+// break the -doit contract and lets repeated dry-runs benefit too.
+func (mc *MetaCache) Save() error {
+	if mc == nil {
+		return nil
+	}
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	if !mc.dirty {
+		return nil
+	}
+
+	for path := range mc.entries {
+		if _, err := os.Stat(path); err != nil {
+			delete(mc.entries, path)
+		}
+	}
+	for path := range mc.derived {
+		if _, err := os.Stat(path); err != nil {
+			delete(mc.derived, path)
+		}
+	}
+
+	contents := metaCacheFile{Version: metaCacheVersion, Entries: mc.entries, Derived: mc.derived}
+	b, err := json.MarshalIndent(contents, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode metadata cache: %w", err)
+	}
+	b = append(b, '\n')
+
+	dir := filepath.Dir(mc.path)
+	if err := os.MkdirAll(dir, dirPerms); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+
+	// Write to a temp file and rename so an interrupted run cannot leave a truncated
+	// cache behind, which would then be discarded as malformed on the next run.
+	tmp, err := os.CreateTemp(dir, MetaCacheFileName+".tmp*")
+	if err != nil {
+		return fmt.Errorf("create temp metadata cache: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp metadata cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp metadata cache: %w", err)
+	}
+	if err := os.Chmod(tmpName, filePerms); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod temp metadata cache: %w", err)
+	}
+	if err := os.Rename(tmpName, mc.path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("write %s: %w", mc.path, err)
+	}
+
+	mc.dirty = false
+	return nil
+}
+
+// Len returns the number of cached entries. Safe on a nil receiver.
+func (mc *MetaCache) Len() int {
+	if mc == nil {
+		return 0
+	}
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	return len(mc.entries)
+}

--- a/pkg/photogen/metacache_test.go
+++ b/pkg/photogen/metacache_test.go
@@ -1,0 +1,452 @@
+package photogen
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realFixture returns the path to a testdata image with known metadata.
+const realFixture = "landscape-1.jpg"
+
+// copyFixture copies a testdata image into dir so tests can freely modify it.
+func copyFixture(t *testing.T, dir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+func TestMetaCache_Metadata(t *testing.T) {
+	t.Run("a hit returns the same values as a direct read", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		want, err := ReadPhotoMetadata(src)
+		require.NoError(t, err)
+
+		mc := NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+
+		first, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, want, first, "miss must match a direct read")
+
+		second, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, want, second, "hit must match a direct read")
+		assert.Equal(t, 1, mc.Len())
+	})
+
+	t.Run("the returned pointer does not alias cache state", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		mc := NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+
+		first, err := mc.Metadata(src)
+		require.NoError(t, err)
+		first.Width = -1
+
+		second, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.NotEqual(t, -1, second.Width, "mutating a result must not corrupt the cache")
+	})
+
+	t.Run("a changed modification time invalidates the entry", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		mc := NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+
+		_, err := mc.Metadata(src)
+		require.NoError(t, err)
+
+		// Replace the file contents with a different image but keep the same path.
+		other, err := os.ReadFile(filepath.Join("testdata", "portrait-1.jpg"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(src, other, 0644))
+		require.NoError(t, os.Chtimes(src, time.Now(), time.Now().Add(time.Second)))
+
+		meta, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, "portrait", meta.Orientation, "stale entry must not be served")
+	})
+
+	t.Run("a changed size invalidates the entry even at the same mtime", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		mc := NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+
+		_, err := mc.Metadata(src)
+		require.NoError(t, err)
+		stat, err := os.Stat(src)
+		require.NoError(t, err)
+
+		other, err := os.ReadFile(filepath.Join("testdata", "portrait-1.jpg"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(src, other, 0644))
+		// Pin the modification time back so only the size differs.
+		require.NoError(t, os.Chtimes(src, stat.ModTime(), stat.ModTime()))
+
+		meta, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, "portrait", meta.Orientation, "size change must invalidate")
+	})
+
+	t.Run("refresh mode ignores existing entries but still records them", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		mc := NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+
+		_, err := mc.Metadata(src)
+		require.NoError(t, err)
+
+		// Corrupt the cached value; refresh must re-read rather than serve it.
+		mc.entries[src] = metaCacheEntry{
+			ModTimeNano: mc.entries[src].ModTimeNano,
+			Size:        mc.entries[src].Size,
+			Meta:        &PhotoMetadata{Width: 1, Height: 1, Orientation: "square"},
+		}
+		mc.SetRefresh(true)
+
+		meta, err := mc.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, 5028, meta.Width, "refresh must re-decode")
+		assert.Equal(t, "landscape", mc.entries[src].Meta.Orientation, "refresh must rewrite the entry")
+	})
+
+	t.Run("a nil cache reads directly", func(t *testing.T) {
+		var mc *MetaCache
+		meta, err := mc.Metadata(filepath.Join("testdata", realFixture))
+		require.NoError(t, err)
+		assert.Equal(t, 5028, meta.Width)
+		assert.Equal(t, 0, mc.Len())
+		assert.NoError(t, mc.Save())
+	})
+
+	t.Run("an unreadable file reports the underlying error", func(t *testing.T) {
+		mc := NewMetaCache(filepath.Join(t.TempDir(), MetaCacheFileName))
+		_, err := mc.Metadata("/nonexistent/path/photo.jpg")
+		assert.Error(t, err)
+		assert.Equal(t, 0, mc.Len(), "a failed read must not be cached")
+	})
+}
+
+func TestMetaCache_LoadAndSave(t *testing.T) {
+	t.Run("saved entries survive a round trip", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		path := filepath.Join(dir, ".build", MetaCacheFileName)
+
+		mc := NewMetaCache(path)
+		want, err := mc.Metadata(src)
+		require.NoError(t, err)
+		require.NoError(t, mc.Save())
+
+		reloaded := LoadMetaCache(path)
+		assert.Equal(t, 1, reloaded.Len())
+		got, err := reloaded.Metadata(src)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("a missing file loads as an empty cache", func(t *testing.T) {
+		mc := LoadMetaCache(filepath.Join(t.TempDir(), "does-not-exist.json"))
+		assert.Equal(t, 0, mc.Len())
+	})
+
+	t.Run("a malformed file loads as an empty cache", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), MetaCacheFileName)
+		require.NoError(t, os.WriteFile(path, []byte("{not json"), 0644))
+		mc := LoadMetaCache(path)
+		assert.Equal(t, 0, mc.Len())
+	})
+
+	t.Run("a wrong version loads as an empty cache", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), MetaCacheFileName)
+		body, err := json.Marshal(metaCacheFile{
+			Version: metaCacheVersion + 1,
+			Entries: map[string]metaCacheEntry{"/some/photo.jpg": {Meta: &PhotoMetadata{Width: 9}}},
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, body, 0644))
+
+		mc := LoadMetaCache(path)
+		assert.Equal(t, 0, mc.Len())
+	})
+
+	t.Run("save is a no-op when nothing changed", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), MetaCacheFileName)
+		mc := NewMetaCache(path)
+		require.NoError(t, mc.Save())
+		_, err := os.Stat(path)
+		assert.True(t, os.IsNotExist(err), "clean cache must not write a file")
+	})
+
+	t.Run("save drops entries whose source file is gone", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		path := filepath.Join(dir, MetaCacheFileName)
+
+		mc := NewMetaCache(path)
+		_, err := mc.Metadata(src)
+		require.NoError(t, err)
+		require.NoError(t, mc.Save())
+		require.Equal(t, 1, LoadMetaCache(path).Len())
+
+		require.NoError(t, os.Remove(src))
+		// Touch something so the cache is dirty and actually rewrites.
+		mc.RecordDerived(path, path, "")
+		require.NoError(t, mc.Save())
+
+		assert.Equal(t, 0, LoadMetaCache(path).Len(), "pruned entry must not persist")
+	})
+
+	t.Run("save leaves no temp files behind", func(t *testing.T) {
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		path := filepath.Join(dir, MetaCacheFileName)
+
+		mc := NewMetaCache(path)
+		_, err := mc.Metadata(src)
+		require.NoError(t, err)
+		require.NoError(t, mc.Save())
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			assert.NotContains(t, e.Name(), ".tmp", "temp file left behind: %s", e.Name())
+		}
+	})
+}
+
+// TestFixedNameOutputs_Regeneration covers cover.jpg and hero.jpg, which have fixed
+// output names and so used to be regenerated unconditionally on every run. They are now
+// skipped when the cache says the source is unchanged, and this is what keeps that skip
+// from going stale.
+func TestFixedNameOutputs_Regeneration(t *testing.T) {
+	// modTime returns the modification time of path, used to detect a rewrite.
+	modTime := func(t *testing.T, path string) time.Time {
+		t.Helper()
+		stat, err := os.Stat(path)
+		require.NoError(t, err)
+		return stat.ModTime()
+	}
+
+	// age backdates a file so a rewrite is detectable regardless of clock resolution.
+	age := func(t *testing.T, path string) {
+		t.Helper()
+		old := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(path, old, old))
+	}
+
+	t.Run("cover.jpg", func(t *testing.T) {
+		newAP := func(t *testing.T) (*AlbumProcessor, string) {
+			t.Helper()
+			dir := t.TempDir()
+			src := copyFixture(t, dir, realFixture)
+			ap := newTestProcessor(t, []*Photo{{FileName: realFixture, AbsolutePath: src}})
+			ap.Config.MetaCache = NewMetaCache(filepath.Join(dir, MetaCacheFileName))
+			return ap, src
+		}
+
+		t.Run("is skipped when the source is unchanged", func(t *testing.T) {
+			ap, _ := newAP(t)
+			require.NoError(t, ap.WriteCoverJPEG())
+			out := ap.OutputPath("cover.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.Equal(t, before, modTime(t, out), "unchanged source must not be re-encoded")
+		})
+
+		t.Run("is regenerated when the cover points at a different photo", func(t *testing.T) {
+			ap, src := newAP(t)
+			require.NoError(t, ap.WriteCoverJPEG())
+			out := ap.OutputPath("cover.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			other := copyFixture(t, filepath.Dir(src), "portrait-1.jpg")
+			ap.Photos = []*Photo{{FileName: "portrait-1.jpg", AbsolutePath: other}}
+
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.NotEqual(t, before, modTime(t, out), "a new cover source must be re-encoded")
+		})
+
+		t.Run("is regenerated when the output is deleted", func(t *testing.T) {
+			ap, _ := newAP(t)
+			require.NoError(t, ap.WriteCoverJPEG())
+			out := ap.OutputPath("cover.jpg")
+			require.NoError(t, os.Remove(out))
+
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.FileExists(t, out)
+		})
+
+		t.Run("is regenerated under -force", func(t *testing.T) {
+			ap, _ := newAP(t)
+			require.NoError(t, ap.WriteCoverJPEG())
+			out := ap.OutputPath("cover.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			ap.Config.Force = true
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.NotEqual(t, before, modTime(t, out))
+		})
+
+		t.Run("without a cache it always regenerates", func(t *testing.T) {
+			ap, _ := newAP(t)
+			ap.Config.MetaCache = nil
+			require.NoError(t, ap.WriteCoverJPEG())
+			out := ap.OutputPath("cover.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.NotEqual(t, before, modTime(t, out), "no cache must preserve the old behaviour")
+		})
+
+		t.Run("dry-run records nothing", func(t *testing.T) {
+			ap, _ := newAP(t)
+			ap.Config.DryRun = true
+			require.NoError(t, ap.WriteCoverJPEG())
+			assert.NoFileExists(t, ap.OutputPath("cover.jpg"))
+			assert.False(t, ap.Config.MetaCache.DerivedUpToDate(
+				ap.OutputPath("cover.jpg"), ap.Photos[0].AbsolutePath, ""),
+				"a dry run must not stamp an output it never wrote")
+		})
+	})
+
+	t.Run("hero.jpg", func(t *testing.T) {
+		newCfg := func(t *testing.T, crop string) (*Config, string) {
+			t.Helper()
+			dir := t.TempDir()
+			src := copyFixture(t, dir, realFixture)
+			cfg := &Config{
+				OutputRoot: dir,
+				SiteID:     "test",
+				Warn:       &WarnCollector{},
+				Hero:       &HeroConfig{ImagePath: src, Crop: crop},
+				MetaCache:  NewMetaCache(filepath.Join(dir, MetaCacheFileName)),
+			}
+			return cfg, src
+		}
+
+		t.Run("is skipped when the source and crop are unchanged", func(t *testing.T) {
+			cfg, _ := newCfg(t, "center")
+			require.NoError(t, cfg.WriteHeroJPEG())
+			out := cfg.SiteOutputPath("hero.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			require.NoError(t, cfg.WriteHeroJPEG())
+			assert.Equal(t, before, modTime(t, out))
+		})
+
+		t.Run("is regenerated when the crop changes", func(t *testing.T) {
+			cfg, _ := newCfg(t, "center")
+			require.NoError(t, cfg.WriteHeroJPEG())
+			out := cfg.SiteOutputPath("hero.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			cfg.Hero.Crop = "top"
+			require.NoError(t, cfg.WriteHeroJPEG())
+			assert.NotEqual(t, before, modTime(t, out), "a crop change must be re-encoded")
+		})
+
+		t.Run("is regenerated when the hero image changes", func(t *testing.T) {
+			cfg, src := newCfg(t, "center")
+			require.NoError(t, cfg.WriteHeroJPEG())
+			out := cfg.SiteOutputPath("hero.jpg")
+			age(t, out)
+			before := modTime(t, out)
+
+			cfg.Hero.ImagePath = copyFixture(t, filepath.Dir(src), "portrait-1.jpg")
+			require.NoError(t, cfg.WriteHeroJPEG())
+			assert.NotEqual(t, before, modTime(t, out))
+		})
+	})
+}
+
+func TestMetaCache_Derived(t *testing.T) {
+	// setup returns a cache plus an existing source and output file.
+	setup := func(t *testing.T) (*MetaCache, string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		src := copyFixture(t, dir, realFixture)
+		out := filepath.Join(dir, "cover.jpg")
+		require.NoError(t, os.WriteFile(out, []byte("generated"), 0644))
+		return NewMetaCache(filepath.Join(dir, MetaCacheFileName)), src, out
+	}
+
+	t.Run("an unrecorded output is not up to date", func(t *testing.T) {
+		mc, src, out := setup(t)
+		assert.False(t, mc.DerivedUpToDate(out, src, ""))
+	})
+
+	t.Run("a recorded output is up to date", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "")
+		assert.True(t, mc.DerivedUpToDate(out, src, ""))
+	})
+
+	t.Run("a different source invalidates", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "")
+		other := copyFixture(t, filepath.Dir(src), "portrait-1.jpg")
+		assert.False(t, mc.DerivedUpToDate(out, other, ""),
+			"pointing the cover at a different photo must regenerate")
+	})
+
+	t.Run("a different variant invalidates", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "center")
+		assert.False(t, mc.DerivedUpToDate(out, src, "top"),
+			"changing the hero crop must regenerate")
+	})
+
+	t.Run("a modified source invalidates", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "")
+		require.NoError(t, os.Chtimes(src, time.Now(), time.Now().Add(time.Hour)))
+		assert.False(t, mc.DerivedUpToDate(out, src, ""))
+	})
+
+	t.Run("a deleted output invalidates", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "")
+		require.NoError(t, os.Remove(out))
+		assert.False(t, mc.DerivedUpToDate(out, src, ""))
+	})
+
+	t.Run("refresh mode invalidates", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "")
+		mc.SetRefresh(true)
+		assert.False(t, mc.DerivedUpToDate(out, src, ""))
+	})
+
+	t.Run("a nil cache always regenerates", func(t *testing.T) {
+		var mc *MetaCache
+		mc.RecordDerived("out.jpg", "src.jpg", "")
+		assert.False(t, mc.DerivedUpToDate("out.jpg", "src.jpg", ""))
+	})
+
+	t.Run("derived stamps survive a round trip", func(t *testing.T) {
+		mc, src, out := setup(t)
+		mc.RecordDerived(out, src, "top")
+		require.NoError(t, mc.Save())
+
+		reloaded := LoadMetaCache(mc.path)
+		assert.True(t, reloaded.DerivedUpToDate(out, src, "top"))
+		assert.False(t, reloaded.DerivedUpToDate(out, src, "center"))
+	})
+}

--- a/pkg/photogen/resize_worker.go
+++ b/pkg/photogen/resize_worker.go
@@ -2,6 +2,7 @@ package photogen
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/dougdonohoe/ddphotos/pkg/exit"
@@ -20,12 +21,23 @@ type resizeWork struct {
 // concurrent goroutines. The number of workers is determined by Config.Workers().
 // Output: outputRoot/albums/[album-slug]/[size]/[filename].webp
 func (ap *AlbumProcessor) ResizePhotos() error {
-	// Build list of work
+	// Build list of work, skipping variants that already exist. ResizeImage would skip
+	// them anyway, but filtering here avoids dispatching a goroutine and printing a line
+	// for every up-to-date file, which is the bulk of the work on a re-run.
 	sizes := AllSizes()
 	items := make([]resizeWork, 0, len(ap.Photos)*len(sizes))
+	upToDate := 0
 	for i, photo := range ap.Photos {
 		for _, size := range sizes {
 			outPath := ap.OutputPath(string(size), ap.Config.PhotoWebPName(ap.AlbumConfig.Slug, photo.FileName))
+			// Tracked whether or not it needs writing, so -clean keeps existing files.
+			ap.Config.TrackFile(outPath)
+			if !ap.Config.Force {
+				if _, err := os.Stat(outPath); err == nil {
+					upToDate++
+					continue
+				}
+			}
 			items = append(items, resizeWork{
 				photo:      photo,
 				size:       size,
@@ -33,14 +45,17 @@ func (ap *AlbumProcessor) ResizePhotos() error {
 				photoIndex: i + 1,
 				totalCount: len(ap.Photos),
 			})
-			ap.Config.TrackFile(outPath)
 		}
 	}
 
 	// Do work using numWorkers goroutines
 	numWorkers := ap.Config.Workers()
-	fmt.Printf("  Resizing %d photos (%d items, %d workers)...\n",
-		len(ap.Photos), len(items), numWorkers)
+	fmt.Printf("  Resizing %d photos (%d items, %d workers, %d up to date)...\n",
+		len(ap.Photos), len(items), numWorkers, upToDate)
+
+	if len(items) == 0 {
+		return nil
+	}
 
 	// Pre-fill a buffered channel with all work items and close it so
 	// goroutines drain it naturally with no further coordination needed.

--- a/pkg/photogen/resize_worker_test.go
+++ b/pkg/photogen/resize_worker_test.go
@@ -51,6 +51,23 @@ func TestResizePhotos_SkipExisting(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestResizePhotos_SkipExistingWithoutReadingSource proves the skip happens before any
+// work is dispatched: the source file is removed after the first run, so a second run
+// that still tried to open it would fail.
+func TestResizePhotos_SkipExistingWithoutReadingSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "landscape-1.jpg")
+	data, err := os.ReadFile(filepath.Join("testdata", "landscape-1.jpg"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(src, data, 0644))
+
+	ap := newTestProcessor(t, []*Photo{{FileName: "landscape-1.jpg", AbsolutePath: src}})
+	require.NoError(t, ap.ResizePhotos())
+
+	require.NoError(t, os.Remove(src))
+	assert.NoError(t, ap.ResizePhotos(), "existing outputs must be skipped without opening the source")
+}
+
 func TestResizePhotos_DryRun(t *testing.T) {
 	ap := newTestProcessor(t, []*Photo{
 		{FileName: "landscape-1.jpg", AbsolutePath: filepath.Join("testdata", "landscape-1.jpg")},


### PR DESCRIPTION
Speeds up `photogen` re-runs by roughly **26x** at realistic scale: a 30-album / 2,250-photo site goes from **~5.5s to ~0.20s** on a warm re-run. (The 3-album sample site goes from ~0.84s to ~0.13s.)

## Problem

`photogen` already skipped re-encoding images whose output existed, but that skip only covered the *encoding* half of the pipeline. Two costs were paid on every run regardless:

1. **Every photo was decoded on every run.** `collectPhotosRecursive` called `ReadPhotoMetadata` per photo, single-threaded, doing a full `vips.LoadImageFromFile` + `AutoRotate()` just to recover four values (width, height, orientation, EXIF date). This ran regardless of `-force`, regardless of whether output existed, in dry-run, and even with only `-index`.

2. **`cover.jpg` and `hero.jpg` were regenerated unconditionally.** Both passed `force=true` because their output filenames are fixed, so "the file exists" could not distinguish *already correct* from *the cover now points at a different photo*. That meant a full decode + re-encode of a large image per album, plus one for the hero, every single run — scaling linearly with album count.

The two scale differently, which matters for judging the fix. Measured on a 30-album / 2,250-photo site, the old ~5.5s warm run breaks down as:

| Cost | Time | Share | Scales with |
|---|---|---|---|
| Photo metadata decode | ~3.3s | ~60% | photos (2,250) |
| `cover.jpg` + `hero.jpg` | ~1.5s | ~27% | albums (31) |
| Stats, JSON, output | ~0.7s | ~13% | mixed |

A cover costs ~48ms against ~1.45ms per photo of metadata, so cover/hero dominates a small site (on the 3-album sample the split is roughly inverted) while metadata dominates a real one. Both are fixed here: metadata alone would have left ~2.2s, cover/hero alone ~4.0s.

## Approach

New `MetaCache` (`pkg/photogen/metacache.go`), persisted to `<albums-dir>/.build/metadata-cache.json`. It holds two maps, both validated against the source file's mtime + size:

- **Photo metadata**, replacing the per-photo libvips decode.
- **Stamps for fixed-name outputs**, recording which source file and settings produced each one. This is what makes skipping `cover.jpg` / `hero.jpg` safe — the hero's stamp includes `crop`, so a crop change regenerates.

Design notes:

- Shared across site IDs, since photo metadata does not depend on which site is generated. The seven `sample-photogen-*` targets now warm each other.
- Lives outside `<albums-dir>/<id>/`, following the existing `WriteBuildMeta` precedent — never deployed, never served, never touched by `-clean`.
- Written in dry-run too. It is a local performance artifact rather than site output, so this does not conflict with `-doit`, and it makes repeated dry-runs fast as well.
- A nil `*MetaCache` means "no caching" and restores the previous unconditional behavior, so existing call sites and tests needed no rewiring.
- Written via temp file + rename, and chmod'd to `0666` so a Docker container running as root leaves a cache the host user can still rewrite.

Two further changes:

- **Metadata reads are now parallel** across `Config.Workers()`. Errors are collected by index and the lowest-index one returned, so a failure is reported deterministically rather than depending on which worker lost the race.
- **The resize existence check moved out of the goroutine** into the item-building loop. Skipped variants now cost one `os.Stat` instead of a channel round-trip plus a printed line, and the per-variant `exists:` spam collapses into one per-album summary. `TrackFile` deliberately stays outside the skip so `-clean` still keeps existing files.

## Invalidation

Everything that should regenerate does: editing or replacing a source photo, pointing an album at a different `cover`, changing the hero `image` or `crop`, deleting a generated file, or passing `-force`. Each of these was verified by hand against the sample site in addition to unit tests. `-force` re-reads everything and rewrites the cache rather than discarding it, so entries for albums excluded by `-album` survive.

## Testing

- New `pkg/photogen/metacache_test.go`: hit/miss, mtime and size invalidation, result-pointer aliasing, refresh mode, nil receiver, corrupt/missing/version-mismatch load, pruning, no temp files left behind, and full coverage of the `cover.jpg` / `hero.jpg` regeneration rules including dry-run recording nothing.
- `TestReadPhotoMetadata_RealImages` extended to assert cached and round-tripped values match a direct read for every fixture. Dimensions are post-`AutoRotate` canonical values, so a cache that lost rotation would fail here.
- `TestResizePhotos_SkipExistingWithoutReadingSource` deletes the source after the first run; a second run that still opened it would fail.
- Existing `TestCollectPhotosRecursive` and the resize worker tests pass unmodified, confirming ordering and dry-run semantics are unchanged.

**`make test` now runs with `-race`** (so CI does too via `make build test vet`). It catches races in the resize and new metadata workers, needs cgo which govips already requires, and takes the suite from ~12s to ~20s.

## Verification

- Generated output is **byte-identical to baseline** across cold, warm, and `-force` runs.
- Benchmarked at scale on a synthetic 30-album / 2,250-photo site built from hardlinked real photos, matching the shape of a production site.
- `make build test vet`, `make web-sanity-test` (49 passed), `make docker-test` all green.
- Docker checked specifically for the root-writes-to-host-mount case: cache written `0666`, and a second container run loads it and skips correctly.

## Not addressed

`-limit` still reads metadata for every photo before truncating, because the global date sort needs all dates to pick the first N. Changing that would change which photos are selected. The cache makes warm runs cheap regardless.
