### PR TITLE
Caption layout fixes

### DIFF
--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -364,6 +364,8 @@
 					el.style.bottom = `${Math.floor((vp.y - Math.ceil(item.h * scale)) / 2)}px`;
 					el.style.left = `${sideInset}px`;
 					el.style.right = `${sideInset}px`;
+					// Drop any leftover vertical-drag offset (see zoomPanUpdate below).
+					el.style.transform = '';
 				});
 			};
 
@@ -402,6 +404,20 @@
 						captionFadeTimer = null;
 						setCaptionOpacity('1');
 					}, 0);
+				}
+				// Glue the caption to the photo during a vertical drag-to-close gesture.
+				// PhotoSwipe moves only the slide's own container for that gesture, and the
+				// caption lives in the item holder outside it — a horizontal swipe moves the
+				// whole main-scroll container and takes the caption along for free, but a
+				// vertical one leaves it behind. bounds.center.y is the at-rest pan position
+				// (the same zero point PhotoSwipe measures the drag against). Applied even
+				// while zoomed — the caption is invisible then, and the offset converges back
+				// to zero on its own as the zoom-out animation recentres the pan.
+				const dragHolder = holders.find((h: ItemHolder) => h.slide === slide);
+				const dragEl = dragHolder?.el.querySelector('.pswp-caption') as HTMLElement | null;
+				if (dragEl) {
+					const dy = slide ? slide.pan.y - slide.bounds.center.y : 0;
+					dragEl.style.transform = dy ? `translate3d(0, ${dy}px, 0)` : '';
 				}
 			});
 			// Reset caption opacity when navigating between slides

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -352,8 +352,18 @@
 					}
 					el.textContent = item.caption;
 					el.style.display = '';
-					const scale = Math.min(window.innerWidth / item.w, window.innerHeight / item.h);
-					el.style.bottom = `${Math.floor((window.innerHeight - item.h * scale) / 2)}px`;
+					// Inset the caption to the displayed photo box rather than the viewport, so it
+					// spans exactly the image's edges. Mirrors PhotoSwipe's own geometry: it sizes
+					// the viewport from document.documentElement.clientWidth (exposed as
+					// pswp.viewportSize — unlike window.innerWidth it excludes the scrollbar, which
+					// otherwise leaves a gap at each edge), caps the fit zoom at 1 so images smaller
+					// than the viewport aren't upscaled, and ceils the displayed size.
+					const vp = pswp.viewportSize;
+					const scale = Math.min(1, vp.x / item.w, vp.y / item.h);
+					const sideInset = Math.floor((vp.x - Math.ceil(item.w * scale)) / 2);
+					el.style.bottom = `${Math.floor((vp.y - Math.ceil(item.h * scale)) / 2)}px`;
+					el.style.left = `${sideInset}px`;
+					el.style.right = `${sideInset}px`;
 				});
 			};
 
@@ -852,12 +862,13 @@
 		pointer-events: none;
 	}
 
-	/* Lightbox caption — bottom set dynamically in JS to align with photo bottom edge */
+	/* Lightbox caption — bottom/left/right set dynamically in JS to match the photo's
+	   displayed box. The 0 values here are the pre-measurement fallback. */
 	:global(.pswp-caption) {
 		position: absolute;
 		left: 0;
 		right: 0;
-		padding: 1.5rem 3rem 0.75rem;
+		padding: 1.5rem 1rem 0.75rem;
 		background: linear-gradient(transparent, rgba(0, 0, 0, 0.75));
 		color: white;
 		font-size: 0.9rem;
@@ -866,5 +877,12 @@
 		pointer-events: none;
 		z-index: 10;
 		transition: opacity 0.3s ease;
+	}
+
+	/* Larger lightbox caption on desktop, where there's room for it */
+	@media (min-width: 769px) {
+		:global(.pswp-caption) {
+			font-size: 1.2rem;
+		}
 	}
 </style>

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -786,6 +786,10 @@
 		font-size: 0.78rem;
 		line-height: 1.2;
 		text-align: center;
+		/* Even out line lengths when a caption wraps, rather than leaving a lone
+		   trailing word. Ignored by browsers without support, and browsers stop
+		   balancing past a handful of lines — both fall back to normal wrapping. */
+		text-wrap: balance;
 		opacity: 0;
 		transform: translateY(4px);
 		transition:
@@ -874,6 +878,8 @@
 		font-size: 0.9rem;
 		line-height: 1.2;
 		text-align: center;
+		/* See .photo-caption — evens out wrapped lines instead of orphaning a word. */
+		text-wrap: balance;
 		pointer-events: none;
 		z-index: 10;
 		transition: opacity 0.3s ease;

--- a/web/tests/captions.spec.ts
+++ b/web/tests/captions.spec.ts
@@ -62,6 +62,30 @@ test('caption shows when loading a photo permalink directly (animate=false path)
 	await expectCaptionVisible(page);
 });
 
+test('lightbox caption uses balanced line wrapping', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
+	await page.goto(`/albums/${ALBUM}`);
+	await unlockAlbumIfNeeded(page, ALBUM, pw);
+	await waitForHydration(page);
+	await page
+		.locator('.photo')
+		.nth(PHOTO_N - 1)
+		.click();
+	await expect(page.locator('.pswp')).toBeVisible();
+	await expectCaptionVisible(page);
+
+	// Guards against text-wrap: balance being dropped from the caption rule — without it
+	// a wrapped caption strands its last word on a line by itself. Asserts the property
+	// is applied rather than measuring line boxes: sample captions are short enough that
+	// they don't wrap at the test viewport, so a geometric check would assert nothing.
+	const textWrap = await page
+		.locator('.pswp-caption')
+		.filter({ hasText: /\S/ })
+		.first()
+		.evaluate((el) => getComputedStyle(el).textWrap || getComputedStyle(el).textWrapStyle);
+	expect(textWrap).toBe('balance');
+});
+
 test('caption updates when navigating to prev/next photo', async ({ page }) => {
 	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto(`/albums/${ALBUM}`);

--- a/web/tests/captions.spec.ts
+++ b/web/tests/captions.spec.ts
@@ -86,6 +86,55 @@ test('lightbox caption uses balanced line wrapping', async ({ page }) => {
 	expect(textWrap).toBe('balance');
 });
 
+test('caption moves with the photo during a vertical drag', async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
+	await page.goto(`/albums/${ALBUM}`);
+	await unlockAlbumIfNeeded(page, ALBUM, pw);
+	await waitForHydration(page);
+	await page
+		.locator('.photo')
+		.nth(PHOTO_N - 1)
+		.click();
+	await expect(page.locator('.pswp')).toBeVisible();
+	await expectCaptionVisible(page);
+
+	// Read the caption and image tops from the *current* slide. All three item holders
+	// (prev/current/next) carry a caption, so aria-hidden="false" — which PhotoSwipe sets
+	// on the active holder — is what distinguishes the one being dragged.
+	const readTops = () =>
+		page.evaluate(() => {
+			const item = document.querySelector('.pswp__item[aria-hidden="false"]');
+			const cap = item?.querySelector('.pswp-caption');
+			const img = item?.querySelector('img');
+			if (!cap || !img) return null;
+			return { cap: cap.getBoundingClientRect().top, img: img.getBoundingClientRect().top };
+		});
+
+	const before = await readTops();
+	expect(before).not.toBeNull();
+
+	// Drag downward without releasing: on release the pan springs back to centre, and a
+	// release past the close threshold would dismiss the lightbox entirely.
+	const vp = page.viewportSize()!;
+	await page.mouse.move(vp.width / 2, vp.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(vp.width / 2, vp.height / 2 + 80, { steps: 10 });
+
+	const during = await readTops();
+	expect(during).not.toBeNull();
+
+	const imgDelta = during!.img - before!.img;
+	const capDelta = during!.cap - before!.cap;
+
+	// The photo actually moved (guards against the drag being swallowed)...
+	expect(imgDelta).toBeGreaterThan(10);
+	// ...and the caption tracked it. Both derive from the same slide.pan.y, so PhotoSwipe's
+	// drag friction applies equally and the deltas should match within a rounding pixel.
+	expect(Math.abs(capDelta - imgDelta)).toBeLessThanOrEqual(2);
+
+	await page.mouse.up();
+});
+
 test('caption updates when navigating to prev/next photo', async ({ page }) => {
 	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto(`/albums/${ALBUM}`);


### PR DESCRIPTION
## Summary

Four refinements to photo captions, in the album grid and the PhotoSwipe lightbox. All production
changes are confined to `web/src/routes/albums/[slug]/[[index]]/+page.svelte`, with new Playwright
coverage in `web/tests/captions.spec.ts`. No JSON schema or type changes.

### 1. Larger lightbox caption on desktop

Lightbox captions were small on a big display. Bumped to `1.2rem` behind `@media (min-width: 769px)`,
matching the existing desktop breakpoint in `BackToTop.svelte`. Mobile keeps `0.9rem`, where the
caption sits over a much smaller photo.

### 2. Caption sized to the photo, not the viewport

The caption box was `left: 0; right: 0`, so it spanned the full window while only its `bottom` was
measured against the photo. On a letterboxed photo the gradient ran out over the black bars. It is
now inset on both axes to the photo's displayed box.

Two subtleties, both verified against the PhotoSwipe source rather than guessed:

* PhotoSwipe measures its viewport with `document.documentElement.clientWidth`, which excludes the
  scrollbar, while `window.innerWidth` includes it. Using the latter left a visible gap of half a
  scrollbar width at each edge. The code now reads `pswp.viewportSize`, which is the value
  PhotoSwipe itself uses.
* Its fit zoom is capped at 1 (`Math.min(1, ...)`), so an image smaller than the viewport is never
  upscaled. The old uncapped math would have overshot on, say, a 2048px photo on a 5K display.

Side padding dropped from `3rem` to `1rem`, since the box is now only as wide as the photo and the
old gutter squeezed text on portrait shots.

### 3. Balanced line wrapping

A wrapped caption could strand a single word on the last line. `text-wrap: balance` on both caption
rules evens out the lines instead. Pure CSS, no JavaScript. Browsers without support, and browsers
past their line-count limit for balancing, fall back to normal wrapping.

### 4. Caption follows a vertical drag

Captions already travelled with the photo on a horizontal swipe, because PhotoSwipe moves the whole
main-scroll container and the caption lives inside the slide's item holder. The drag-to-close
gesture is different: it moves only the slide's own container, so the caption stayed put while the
photo slid away from it.

The existing `zoomPanUpdate` listener now offsets the caption by `slide.pan.y - slide.bounds.center.y`,
which is the same zero point PhotoSwipe measures the drag against. No new event subscription was
needed, and because the release spring re-dispatches that event every frame, the caption rides the
bounce back for free. `updateAll` clears the offset on slide change and resize.

## Testing

`make web-sanity-test` passes (51 passed, 7 skipped, both the no-passwords and all-passwords Apache
variants). `npm run check` and `npm run lint` are clean.

Two tests added to `web/tests/captions.spec.ts`:

* **Vertical drag**: opens the lightbox, drags down 80px without releasing, and asserts the caption's
  `top` moved by the same delta as the image's within 2px. It reads both rects from
  `.pswp__item[aria-hidden="false"]`, since all three item holders carry a caption and the `.first()`
  pattern used elsewhere in the file can land on a neighbouring slide. An `imgDelta > 10` assertion
  guards against the drag being swallowed, which would otherwise make the equality check pass
  trivially.
* **Balanced wrapping**: asserts the computed `text-wrap` is `balance`. This one is a weak guard that
  only catches accidental removal of the property. A geometric check is not viable against the
  committed sample data, whose longest caption is 77 characters and does not wrap at the test
  viewport.