### PR TITLE
Mount absolute albums.yaml paths that live inside the DD Photos dir

### DIFF
--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -182,6 +182,20 @@ sed "s|_REPO_ROOT_|$REPO_ROOT|g" "$REPO_ROOT/web/testdata/albums.abspath.yaml" >
 [ -f "$TEST_DIR/albums/$ABS_SITE_ID/hero.jpg" ] || fail "albums/$ABS_SITE_ID/hero.jpg not created"
 pass "photogen with absolute source paths OK (album dir and hero.jpg created)"
 
+# Same, but for absolute paths pointing INSIDE DDPHOTOS_DIR. These need their own mount
+# too: /ddphotos exposes the contents, but not under the host path the YAML names, so
+# skipping them makes photogen fail with "path does not exist".
+step "Photogen: absolute source paths inside DDPHOTOS_DIR"
+INSIDE_SITE_ID="test-abs-inside"
+INSIDE_CONFIG_DIR="$TEST_DIR/config-abs-inside"
+mkdir -p "$INSIDE_CONFIG_DIR" "$TEST_DIR/photos/theway"
+/bin/cp "$REPO_ROOT"/sample/source/theway/*.jpg "$TEST_DIR/photos/theway/"
+sed "s|_DDPHOTOS_DIR_|$TEST_DIR|g" "$REPO_ROOT/web/testdata/albums.abspath-inside.yaml" > "$INSIDE_CONFIG_DIR/albums.yaml"
+"${DDPHOTOS[@]}" --config-dir "$INSIDE_CONFIG_DIR" photogen
+[ -d "$TEST_DIR/albums/$INSIDE_SITE_ID/the-way" ] || fail "albums/$INSIDE_SITE_ID/the-way not created"
+[ -f "$TEST_DIR/albums/$INSIDE_SITE_ID/hero.jpg" ] || fail "albums/$INSIDE_SITE_ID/hero.jpg not created"
+pass "photogen with absolute source paths inside DDPHOTOS_DIR OK (album dir and hero.jpg created)"
+
 # ── 5b. Photogen: Windows-style C:\ path mapping ───────────────────────────────
 # A Windows drive path (C:\Users\...) in albums.yaml must map to the container
 # location /mnt/c/Users/... — the shared convention between bash to_container_path

--- a/docker/ddphotos
+++ b/docker/ddphotos
@@ -163,11 +163,14 @@ if [ -n "$OPT_SITE_ENV" ]; then
     add_mount "$OPT_SITE_ENV" "$DDPHOTOS_SITE_ENV" ro
 fi
 
-# Parse albums.yaml and add mounts for external photo dirs:
+# Parse albums.yaml and add mounts for photo dirs given as absolute paths:
 #   - bases: section values that are absolute paths
 #   - album source: values that are absolute paths (no base)
 #   - hero image: values that are absolute paths (no base)
-# Paths already inside DDPHOTOS_DIR are skipped (covered by the main /ddphotos mount).
+# Each is mounted at its own host path so the container resolves it to the same
+# string photogen reads from the YAML. This includes paths inside DDPHOTOS_DIR:
+# the main /ddphotos mount exposes their contents, but not under the host path the
+# YAML names, so without a mount here photogen fails with "path does not exist".
 build_config_bases_mounts() {
     local config="$CONFIG_HOST_DIR/albums.yaml"
     [ -f "$config" ] || return 0
@@ -199,8 +202,7 @@ build_config_bases_mounts() {
                 echo "       A base must be a folder that exists on this machine." >&2
                 exit 1
             fi
-            # Only mount absolute paths that fall outside DDPHOTOS_DIR (which is already mounted)
-            if is_abs_path "$path" && [[ "$path" != "$DDPHOTOS_DIR"* ]]; then
+            if is_abs_path "$path"; then
                 add_mount "$path" "$(to_container_path "$path")" ro
             fi
         else
@@ -215,7 +217,7 @@ build_config_bases_mounts() {
                 path="${path/#\~/$HOME}"
                 # Skip /ddphotos* and /docker* paths — container-internal placeholders
                 # used in the init template (e.g. /ddphotos-init) and older templates.
-                if is_abs_path "$path" && [[ "$path" != "$DDPHOTOS_DIR"* ]] && [[ "$path" != /ddphotos* ]] && [[ "$path" != /docker* ]]; then
+                if is_abs_path "$path" && [[ "$path" != /ddphotos* ]] && [[ "$path" != /docker* ]]; then
                     add_mount "$path" "$(to_container_path "$path")" ro
                 fi
             fi

--- a/web/testdata/albums.abspath-inside.yaml
+++ b/web/testdata/albums.abspath-inside.yaml
@@ -1,0 +1,21 @@
+# Test file used by docker-test.sh to validate absolute paths that point INSIDE
+# DDPHOTOS_DIR. The main /ddphotos mount exposes these files' contents, but not under
+# the host path written below, so build_config_bases_mounts() must still mount them at
+# their own host path. _DDPHOTOS_DIR_ is substituted with the host DDPHOTOS_DIR.
+settings:
+  id: test-abs-inside
+  site_name: "Test Absolute Path Inside"
+  site_url: https://absolute-path-inside.example.com
+  site_description: "Test absolute path inside DDPHOTOS_DIR"
+  copyright_owner: "Sir Absolute Path"
+  copyright_year: 1968
+
+  hero:
+    image: _DDPHOTOS_DIR_/photos/theway/2024-The-Way-13.jpg
+    crop: center
+
+albums:
+  - slug: the-way
+    name: The Way
+    source: _DDPHOTOS_DIR_/photos/theway
+    cover: 2024-The-Way-14.jpg


### PR DESCRIPTION
Absolute paths in `albums.yaml` that point *inside* the DD Photos directory failed under Docker
with `path ... does not exist`, even though the file was plainly there on the host.

## Symptom

```yaml
  hero:
    image: /Users/me/work/5fools/photos/world-map-v1.png
    crop: center
```

```
$ ddphotos --show-mounts photogen
DD Photos (using /usr/local/bin/docker) is mounting:
  /Users/me/.local/bin -> /ddphotos-script-dir
  /Users/me/work/5fools -> /ddphotos

Calling 'photogen -config-dir /ddphotos/config -site-id fwf-photos -resize -index -clean -doit' ...

Error loading config: hero: path "/Users/me/work/5fools/photos/world-map-v1.png" does not exist
```

## Cause

`build_config_bases_mounts()` mounts absolute paths found in `albums.yaml` at their own host path,
so the container resolves them to the same string `photogen` reads out of the YAML. It skipped any
path under `DDPHOTOS_DIR`, on the reasoning that the main `/ddphotos` mount already covered it.

That mount covers the *contents*, not the *path*. Nothing rewrites the YAML, so `photogen` resolves
the literal host path, which does not exist inside the container.

The resulting behavior was inverted: an absolute path **outside** the DD Photos directory worked,
and one **inside** it failed. The closer path was the broken one.

## Scope

Wider than the reported hero image. The same skip applied to all three places the wrapper scans:

- `bases:` values
- album `source:` values
- `hero.image`

Confirmed against a throwaway config using absolute paths for both `source:` and `hero.image`,
which failed on the album source before the fix and completes fully after it.

## Fix

Drop the `!= "$DDPHOTOS_DIR"*` condition from both branches. The `/ddphotos*` and `/docker*` guards
(container-internal placeholders from the init template) are unchanged, as is the Windows drive
translation via `to_container_path`.

`--show-mounts` now lists the additional read-only mounts alongside the main one:

```
  /path/to/dir -> /ddphotos
  /path/to/dir/photos/theway/2024-The-Way-13.jpg -> /path/to/dir/photos/theway/2024-The-Way-13.jpg (read-only)
  /path/to/dir/photos/theway -> /path/to/dir/photos/theway (read-only)
```

## Testing

`bin/docker-test.sh` already had a step covering absolute paths *outside* `DDPHOTOS_DIR`, which is
the case that worked, and that gap is why this went unnoticed. This adds the mirror-image step for
paths inside it, driven by a new `web/testdata/albums.abspath-inside.yaml` fixture whose
`_DDPHOTOS_DIR_` placeholder is substituted at run time.

- `bin/docker-test.sh --skip-playwright` passes, 43 checks
- `shellcheck` clean on `docker/ddphotos` and `bin/docker-test.sh`
- No Go changes

## Note for existing sites

The wrapper script is installed from the image, so this only takes effect after upgrading. Until
then the workaround is to express the path relative to a `base:` instead of absolutely.
