### PR TITLE
Add clearer error message for EDEADLK on image load

### DIFF
--- a/pkg/photogen/exif.go
+++ b/pkg/photogen/exif.go
@@ -1,14 +1,38 @@
 package photogen
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/davidbyttow/govips/v2/vips"
 
 	"github.com/dougdonohoe/ddphotos/pkg/exit"
 )
+
+// annotateImageLoadErr adds a human-friendly hint when an image fails to load with
+// EDEADLK ("resource deadlock avoided"). On macOS this typically surfaces when the
+// source file is an online-only cloud-storage placeholder (e.g. Dropbox or iCloud
+// under ~/Library/CloudStorage) whose contents cannot be downloaded on demand when
+// read from inside Docker's file-sharing layer. Non-EDEADLK errors are returned as-is.
+func annotateImageLoadErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	// libvips surfaces the underlying read failure as a plain string (see govips
+	// handleVipsError), so the typed errno is usually unavailable — match the
+	// message too, while still catching a real syscall.Errno from the os path.
+	if !errors.Is(err, syscall.EDEADLK) && !strings.Contains(err.Error(), "resource deadlock avoided") {
+		return err
+	}
+	return fmt.Errorf("%w\n"+
+		"    hint: \"resource deadlock avoided\" usually means the source file is an online-only\n"+
+		"    cloud-storage placeholder (e.g. Dropbox or iCloud under ~/Library/CloudStorage) that\n"+
+		"    could not be downloaded when read from inside Docker. Make the files available offline\n"+
+		"    (download them locally) or move the source photos to a regular local folder, then re-run", err)
+}
 
 func init() {
 	vips.LoggingSettings(nil, vips.LogLevelWarning)
@@ -28,7 +52,7 @@ type PhotoMetadata struct {
 func ReadPhotoMetadata(path string) (*PhotoMetadata, error) {
 	img, err := vips.LoadImageFromFile(path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("load image: %w", err)
+		return nil, fmt.Errorf("load image: %w", annotateImageLoadErr(err))
 	}
 	defer img.Close()
 

--- a/pkg/photogen/exif_test.go
+++ b/pkg/photogen/exif_test.go
@@ -1,14 +1,46 @@
 package photogen
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAnnotateImageLoadErr(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		assert.NoError(t, annotateImageLoadErr(nil))
+	})
+
+	t.Run("unrelated error is unchanged", func(t *testing.T) {
+		orig := errors.New("no such file or directory")
+		got := annotateImageLoadErr(orig)
+		assert.Equal(t, orig, got)
+		assert.NotContains(t, got.Error(), "cloud-storage")
+	})
+
+	t.Run("vips string error gets a hint", func(t *testing.T) {
+		// govips returns a plain string error (no typed errno).
+		orig := fmt.Errorf("read /photos/x.jpg: resource deadlock avoided")
+		got := annotateImageLoadErr(orig)
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "resource deadlock avoided")
+		assert.Contains(t, got.Error(), "cloud-storage")
+		assert.Contains(t, got.Error(), "available offline")
+	})
+
+	t.Run("typed EDEADLK errno gets a hint", func(t *testing.T) {
+		orig := fmt.Errorf("read x.jpg: %w", syscall.EDEADLK)
+		got := annotateImageLoadErr(orig)
+		assert.Contains(t, got.Error(), "cloud-storage")
+	})
+}
 
 // createTestImage creates a solid-color JPEG at the specified dimensions.
 // Returns the path to the created image.

--- a/pkg/photogen/resize.go
+++ b/pkg/photogen/resize.go
@@ -54,7 +54,7 @@ func openImage(inputPath, outputPath, dryRunLabel string, force, dryRun bool) (*
 	params.FailOnError.Set(false)
 	img, err := vips.LoadImageFromFile(inputPath, params)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load image %s: %w", inputPath, err)
+		return nil, nil, fmt.Errorf("load image %s: %w", inputPath, annotateImageLoadErr(err))
 	}
 
 	if err := img.AutoRotate(); err != nil {


### PR DESCRIPTION
## Summary

When a source image fails to load with `EDEADLK` (`resource deadlock avoided`), the tool now appends a hint explaining the likely cause and how to fix it, instead of surfacing the bare OS error.

On macOS this error typically occurs when the source file is an online-only cloud-storage placeholder (e.g. Dropbox or iCloud under `~/Library/CloudStorage`) whose contents cannot be hydrated on demand when read from inside Docker's file-sharing layer.

Example output:

```
Error loading photos: read metadata for .../19410330-0001.jpg: load image: read .../19410330-0001.jpg: resource deadlock avoided
    hint: "resource deadlock avoided" usually means the source file is an online-only
    cloud-storage placeholder (e.g. Dropbox or iCloud under ~/Library/CloudStorage) that
    could not be downloaded when read from inside Docker. Make the files available offline
    (download them locally) or move the source photos to a regular local folder, then re-run
```

## Changes

- New `annotateImageLoadErr` helper in `pkg/photogen/exif.go`.
- Detection matches both the libvips message string (govips returns a plain string error with no typed errno) and `syscall.EDEADLK`.
- Wired into both image-load sites: `ReadPhotoMetadata` (`exif.go`) and `openImage` (`resize.go`).
- Added `TestAnnotateImageLoadErr` covering nil pass-through, unrelated errors, the vips string case, and the typed-errno case.

## Testing

- `go vet ./pkg/photogen/` passes
- `go test ./pkg/photogen/` passes