### PR TITLE
Ignore passwords.yaml entries that refer to non-existant album

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ sample-photogen-pw-uganda:
 	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -passwords sample/config/passwords-uganda.yaml -site-id sample-pw-uganda -doit
 
 .PHONY: sample-photogen-pw-keyonly
-## sample-photogen-pw-keyonly: run photogen using sample images, passwords file with no passwords
+## sample-photogen-pw-keyonly: run photogen using sample images, passwords file with no effective password
 sample-photogen-pw-keyonly:
 	go run cmd/photogen/photogen.go -config-dir sample/config -resize -index -clean -passwords sample/config/passwords-keyonly.yaml -site-id sample-pw-keyonly -doit
 

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -3,7 +3,7 @@
 #   1. No passwords (plain site)
 #   2. passwords-all.yaml (entire site encrypted + Uganda per-album)
 #   3. passwords-uganda.yaml (Uganda album only)
-#   4. passwords-keyonly.yaml (passwords file with no passwords — nothing encrypted)
+#   4. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)
 #   5. custom-css (sample/config/custom-example.css injected)
 #   6. album-nav (customization.yaml replacing the album page's "← Albums" link)
 #
@@ -24,7 +24,7 @@ usage() {
     echo "  1. No passwords (plain site)"
     echo "  2. passwords-all.yaml (entire site + Uganda album encrypted)"
     echo "  3. passwords-uganda.yaml (Uganda album only)"
-    echo "  4. passwords-keyonly.yaml (passwords file with no passwords — nothing encrypted)"
+    echo "  4. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)"
     echo "  5. custom-css (sample/config/custom-example.css injected)"
     echo "  6. album-nav (customization.yaml replacing the album page's \"← Albums\" link)"
     echo ""

--- a/cmd/photogen/photogen.go
+++ b/cmd/photogen/photogen.go
@@ -165,6 +165,17 @@ func main() {
 		if err != nil {
 			exit.Fatal("Error loading encrypt config", err)
 		}
+		// Drop entries for albums that are not in albums.yaml: they protect nothing, so
+		// they must not make the site look encrypted (which would show the logout button).
+		// Pruned here, against the full album list, because -album filtering happens below.
+		allSlugs := make([]string, 0, len(albums))
+		for _, a := range albums {
+			allSlugs = append(allSlugs, a.Slug)
+		}
+		if stale := ec.RestrictToAlbums(allSlugs); len(stale) > 0 {
+			warn.Warnf("WARN: passwords file %s has entries for albums not in albums.yaml (ignored): %s\n",
+				passwordsPath, strings.Join(stale, ", "))
+		}
 		cfg.Encrypt = ec
 	}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -199,14 +199,20 @@ albums:
 | `albums.<slug>.password` | Per-album password; encrypts only that album's `index.json`. Falls back to `site.password` if not set                                                             |
 | `albums.<slug>.hint`     | Optional hint shown in that album's password dialog                                                                                                               |
 
+An `albums.<slug>` entry whose slug is not in `albums.yaml` — typically an album that was
+deleted but whose password was left behind — is ignored, and `photogen` prints a warning
+naming the slug. It protects nothing, so it does not count towards whether the site is
+encrypted.
+
 Sample passwords files are in `sample/config/` — `passwords-all.yaml` (full site),
 `passwords-uganda.yaml` (single album), and `passwords-keyonly.yaml` (a test fixture with a
-`key` but no passwords, so nothing is encrypted). The first two contain demo-only passwords.
+`key` and a password for a nonexistent album, so nothing is encrypted). The first two
+contain demo-only passwords.
 
-A passwords file that declares no `site.password` and no `albums.<slug>.password` protects
-nothing: the `key` only applies to albums that have a password, so every album stays public
-and filenames stay unobfuscated. Such a site is reported as unencrypted in `config.json`,
-which means no logout button is shown.
+A passwords file that declares no effective password — no `site.password`, and no
+`albums.<slug>.password` for an album that exists — protects nothing: the `key` only applies
+to albums that have a password, so every album stays public and filenames stay unobfuscated.
+Such a site is reported as unencrypted in `config.json`, which means no logout button is shown.
 
 #### Frontend Behavior (Encrypted Sites)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -147,8 +147,8 @@ the appropriate site variant:
 
 Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants automatically.
 `bin/test-all.sh` runs six variants: no passwords, `passwords-all.yaml`, `passwords-uganda.yaml`,
-`passwords-keyonly.yaml` (a passwords file that declares no passwords, so nothing is encrypted),
-`custom-css` (with `sample/config/custom-example.css` injected), and `album-nav` (with
+`passwords-keyonly.yaml` (a passwords file that declares no effective password, so nothing is
+encrypted), `custom-css` (with `sample/config/custom-example.css` injected), and `album-nav` (with
 `sample/config/customization-album-nav.yaml`, which replaces each album page's "← Albums" link).
 
 ```bash

--- a/pkg/photogen/encrypt.go
+++ b/pkg/photogen/encrypt.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -156,6 +157,37 @@ func (ec *EncryptConfig) IsSiteEncrypted() bool {
 // False for a "key only" passwords file, which obfuscates filenames but protects nothing.
 func (ec *EncryptConfig) HasAnyPassword() bool {
 	return ec.IsSiteEncrypted() || len(ec.AlbumPasswords) > 0
+}
+
+// RestrictToAlbums drops per-album passwords and hints whose slug is not in knownSlugs
+// (typically an album deleted from albums.yaml but left in the passwords file). Such an
+// entry protects nothing, so it must not make the site look encrypted. Returns the removed
+// slugs, sorted, so the caller can warn about them.
+//
+// Must be called with every album in albums.yaml, not a filtered subset — pruning against a
+// subset would discard passwords for albums that do exist.
+func (ec *EncryptConfig) RestrictToAlbums(knownSlugs []string) []string {
+	known := make(map[string]bool, len(knownSlugs))
+	for _, slug := range knownSlugs {
+		known[slug] = true
+	}
+	// An entry may carry only a hint, so both maps are checked; a slug in both is
+	// reported once.
+	removed := map[string]bool{}
+	for _, m := range []map[string]string{ec.AlbumPasswords, ec.AlbumHints} {
+		for slug := range m {
+			if !known[slug] {
+				removed[slug] = true
+				delete(m, slug)
+			}
+		}
+	}
+	slugs := make([]string, 0, len(removed))
+	for slug := range removed {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
 }
 
 // PhotoWebPName returns the output WebP filename for a source photo.

--- a/pkg/photogen/encrypt_test.go
+++ b/pkg/photogen/encrypt_test.go
@@ -56,6 +56,73 @@ func TestLoadEncryptConfig_KeyOnly(t *testing.T) {
 	assert.False(t, ec.HasAnyPassword())
 }
 
+func TestRestrictToAlbums(t *testing.T) {
+	t.Parallel()
+
+	newConfig := func() *EncryptConfig {
+		return &EncryptConfig{
+			HMACKey: "secret",
+			AlbumPasswords: map[string]string{
+				"uganda":  "uganda-pass",
+				"deleted": "deleted-pass",
+			},
+			AlbumHints: map[string]string{
+				"uganda":    "Think of gorillas",
+				"deleted":   "Never shown",
+				"hint-only": "No password, no album",
+			},
+		}
+	}
+
+	t.Run("removes entries for albums that do not exist", func(t *testing.T) {
+		t.Parallel()
+		ec := newConfig()
+
+		removed := ec.RestrictToAlbums([]string{"uganda", "antarctica"})
+
+		assert.Equal(t, []string{"deleted", "hint-only"}, removed, "sorted, each slug once")
+		assert.Equal(t, map[string]string{"uganda": "uganda-pass"}, ec.AlbumPasswords)
+		assert.Equal(t, map[string]string{"uganda": "Think of gorillas"}, ec.AlbumHints)
+	})
+
+	t.Run("keeps everything when all slugs are known", func(t *testing.T) {
+		t.Parallel()
+		ec := newConfig()
+
+		removed := ec.RestrictToAlbums([]string{"uganda", "deleted", "hint-only"})
+
+		assert.Empty(t, removed)
+		assert.Len(t, ec.AlbumPasswords, 2)
+		assert.Len(t, ec.AlbumHints, 3)
+	})
+
+	t.Run("site with only stale album passwords is not encrypted", func(t *testing.T) {
+		t.Parallel()
+		ec := &EncryptConfig{
+			HMACKey:        "secret",
+			AlbumPasswords: map[string]string{"deleted": "deleted-pass"},
+			AlbumHints:     map[string]string{},
+		}
+		assert.True(t, ec.HasAnyPassword(), "before pruning the stale entry counts")
+
+		assert.Equal(t, []string{"deleted"}, ec.RestrictToAlbums([]string{"uganda"}))
+		assert.False(t, ec.HasAnyPassword(), "a password for a missing album protects nothing")
+	})
+
+	t.Run("site password survives pruning", func(t *testing.T) {
+		t.Parallel()
+		ec := &EncryptConfig{
+			SitePassword:   "site-pass",
+			AlbumPasswords: map[string]string{"deleted": "deleted-pass"},
+			AlbumHints:     map[string]string{},
+		}
+
+		assert.Equal(t, []string{"deleted"}, ec.RestrictToAlbums(nil))
+		assert.True(t, ec.HasAnyPassword())
+		assert.True(t, ec.IsSiteEncrypted())
+	})
+}
+
 func TestEncryptConfigValidate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/photogen/json_test.go
+++ b/pkg/photogen/json_test.go
@@ -299,6 +299,24 @@ func TestWriteConfigJSON(t *testing.T) {
 		assert.Contains(t, string(data), `"keyId"`, "key ID must still be emitted for key-only sites")
 	})
 
+	t.Run("passwords for albums that do not exist are not marked encrypted", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		encrypt := &EncryptConfig{
+			HMACKey:        "secret",
+			AlbumPasswords: map[string]string{"deleted": "deleted-pass"},
+			AlbumHints:     map[string]string{"deleted": "Never shown"},
+		}
+		encrypt.RestrictToAlbums([]string{"uganda"})
+		require.NoError(t, makeSiteCfg(dir, encrypt).WriteConfigJSON())
+
+		data, err := os.ReadFile(filepath.Join(dir, "testsite", "config.json"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"encrypted"`, "a stale album password protects nothing")
+		assert.NotContains(t, string(data), `"albumHints"`, "hints for missing albums are dropped too")
+		assert.Contains(t, string(data), `"albumsFile": "albums.json"`)
+	})
+
 	t.Run("unencrypted with HTML fields references html.json", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()

--- a/sample/config/passwords-keyonly.yaml
+++ b/sample/config/passwords-keyonly.yaml
@@ -1,6 +1,16 @@
-# A "key only" passwords file: a valid passwords file that protects nothing.
-# The key only affects albums that have a password (see Config.PhotoWebPName), so with
-# no site or album passwords every album stays public and filenames stay unobfuscated.
+# A passwords file that protects nothing, in the two ways that is possible:
+#
+#   1. "key only" — the key only affects albums that have a password (see
+#      Config.PhotoWebPName), so with no site or album passwords every album stays
+#      public and filenames stay unobfuscated.
+#   2. a password for an album that is not in albums.yaml (e.g. the album was deleted
+#      but its entry was left behind) — photogen warns and ignores it.
+#
 # Used by the test suite to verify such a site is treated as unencrypted — no logout
 # button, no password wording on /privacy.
 key: ddphotos-sample-key-keyonly
+
+albums:
+  deleted-album:
+    password: this-album-no-longer-exists
+    hint: Should never be shown

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -11,9 +11,24 @@ export interface Passwords {
 }
 
 /**
+ * Slugs of the albums the test site actually publishes, from sample/config/albums.yaml.
+ * The tests always run against the sample config (see bin/run-tests.sh).
+ */
+function sampleAlbumSlugs(): Set<string> {
+	const path = new URL('../../sample/config/albums.yaml', import.meta.url);
+	const parsed = yaml.load(fs.readFileSync(path, 'utf-8')) as {
+		albums?: { slug?: string }[];
+	};
+	return new Set((parsed?.albums ?? []).map((a) => a.slug).filter((s): s is string => !!s));
+}
+
+/**
  * Parse a ddphotos passwords file (sample/config/passwords-*.yaml).
  * Returns { all, albums } from PLAYWRIGHT_PASSWORDS_FILE env var.
  * Returns nulls/empty if the env var is not set (no-password variant).
+ *
+ * Entries for slugs that are not in albums.yaml are dropped: photogen ignores them
+ * (they protect nothing), so tests must see the same effective set it does.
  */
 export function loadPasswords(): Passwords {
 	const file = process.env.PLAYWRIGHT_PASSWORDS_FILE;
@@ -27,11 +42,13 @@ export function loadPasswords(): Passwords {
 	const all: string | null = site?.password ?? null;
 	const allHint: string | null = site?.hint ?? null;
 
+	const knownSlugs = sampleAlbumSlugs();
 	const albums: Record<string, string> = {};
 	const albumHints: Record<string, string> = {};
 	const albumsMap = parsed['albums'] as Record<string, Record<string, string>> | undefined;
 	if (albumsMap) {
 		for (const [slug, entry] of Object.entries(albumsMap)) {
+			if (!knownSlugs.has(slug)) continue;
 			if (entry?.password) albums[slug] = entry.password;
 			if (entry?.hint) albumHints[slug] = entry.hint;
 		}

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { type APIRequestContext, type Page, type Locator } from '@playwright/test';
 import type { NavLink } from '../src/lib/types';
@@ -11,12 +12,18 @@ export interface Passwords {
 }
 
 /**
- * Slugs of the albums the test site actually publishes, from sample/config/albums.yaml.
- * The tests always run against the sample config (see bin/run-tests.sh).
+ * Slugs published by the site under test, read from the albums.yaml sitting next to the
+ * given passwords file. That mirrors how ddphotos resolves the pair (settings.passwords is
+ * relative to the config dir), so this works for the sample config and for the throwaway
+ * config dirs bin/docker-test.sh generates alike.
+ *
+ * Returns null if no albums.yaml is there, meaning "cannot tell" — callers then keep every
+ * entry rather than dropping passwords the site may really need.
  */
-function sampleAlbumSlugs(): Set<string> {
-	const path = new URL('../../sample/config/albums.yaml', import.meta.url);
-	const parsed = yaml.load(fs.readFileSync(path, 'utf-8')) as {
+function albumSlugsBesidePasswords(passwordsFile: string): Set<string> | null {
+	const albumsFile = path.join(path.dirname(passwordsFile), 'albums.yaml');
+	if (!fs.existsSync(albumsFile)) return null;
+	const parsed = yaml.load(fs.readFileSync(albumsFile, 'utf-8')) as {
 		albums?: { slug?: string }[];
 	};
 	return new Set((parsed?.albums ?? []).map((a) => a.slug).filter((s): s is string => !!s));
@@ -42,13 +49,13 @@ export function loadPasswords(): Passwords {
 	const all: string | null = site?.password ?? null;
 	const allHint: string | null = site?.hint ?? null;
 
-	const knownSlugs = sampleAlbumSlugs();
+	const knownSlugs = albumSlugsBesidePasswords(file);
 	const albums: Record<string, string> = {};
 	const albumHints: Record<string, string> = {};
 	const albumsMap = parsed['albums'] as Record<string, Record<string, string>> | undefined;
 	if (albumsMap) {
 		for (const [slug, entry] of Object.entries(albumsMap)) {
-			if (!knownSlugs.has(slug)) continue;
+			if (knownSlugs && !knownSlugs.has(slug)) continue;
 			if (entry?.password) albums[slug] = entry.password;
 			if (entry?.hint) albumHints[slug] = entry.hint;
 		}

--- a/web/tests/password.spec.ts
+++ b/web/tests/password.spec.ts
@@ -130,7 +130,8 @@ test('logout button is visible when encryption is configured', async ({ page }) 
 
 // Runs in both the no-passwords variant and the key-only variant (passwords-keyonly.yaml),
 // since loadPasswords() reports no passwords for both. The key-only case is the regression
-// guard: a passwords file used to imply encryption even when it declared no passwords.
+// guard: a passwords file used to imply encryption even when it declared no passwords, and
+// again when its only password was for an album that no longer exists in albums.yaml.
 test('logout button is hidden when no passwords are configured', async ({ page }) => {
 	test.skip(!!pw.all || Object.keys(pw.albums).length > 0, 'passwords are configured');
 	const config = await page.request.get('/albums/config.json').then((r) => r.json());


### PR DESCRIPTION
Follow-up to #79, which fixed the logout button for "key only" passwords files but still keyed the
decision off the raw contents of the passwords file (`len(ec.AlbumPasswords) > 0`).

Deleting an album from `albums.yaml` while leaving its entry in `passwords.yaml` therefore still
marked the site as encrypted, so the logout button stayed visible on a site where nothing was
actually protected.

## Fix

`EncryptConfig.RestrictToAlbums(knownSlugs)` drops per-album passwords and hints whose slug is not
in `albums.yaml`, returning the removed slugs. `cmd/photogen` calls it right after loading the
passwords file and warns:

```
WARN: passwords file config/passwords.yaml has entries for albums not in albums.yaml (ignored): secret
```

Two ordering details matter at the call site:

* It runs against the **full** album list, before `-album` filtering. Pruning against a filtered
  subset would discard passwords for albums that do exist.
* It runs before `cfg.Validate()`, so a stale entry can no longer fail validation.

Pruning once at load time, rather than special-casing the `encrypted` flag, keeps every consumer
consistent: `config.json`'s `encrypted` (which gates the logout button in `+layout.svelte`) and its
`albumHints`, `EncryptConfig.Validate()`, and the `encrypt:` line in the photogen run summary.

## Tests

`sample/config/passwords-keyonly.yaml` now also declares a password for a nonexistent album, so the
existing `logout button is hidden when no passwords are configured` test covers the real case
without adding a test variant.

That required `loadPasswords()` in `web/tests/helpers.ts` to filter entries against
`sample/config/albums.yaml`. Without it, `firstAlbumSlug` would have become `deleted-album` and the
per-album tests would have tried to unlock an album that does not exist.

Also adds `TestRestrictToAlbums` and a `WriteConfigJSON` subtest on the Go side.

## Verification

* `make build test vet`
* `make sample-photogen-pw-keyonly`: warns, and `config.json` has no `encrypted` key
* `make sample-photogen-pw-uganda`: still reports `encrypt: 1 album(s)` and `"encrypted": true`, with
  no spurious warning, so real album passwords are untouched
* `bin/run-tests.sh --mode apache --passwords sample/config/passwords-keyonly.yaml`
* `make web-sanity-test`
