### PR TITLE
Add nginx deploy support, tests, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Run nginx Playwright e2e tests (all password variants)
         run: bin/test-all.sh --mode nginx --ci
 
+      - name: Run nginx rsync deploy test
+        run: make sample-rsync-test-nginx
+
       - name: Run S3 deploy test
         run: make sample-s3-test
 

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,11 @@ web-docker-build-nginx:
 web-docker-build-apache-ssh:
 	docker build --pull -t photos-apache-ssh -f web/apache-ssh.dockerfile web/
 
+.PHONY: web-docker-build-nginx-ssh
+## web-docker-build-nginx-ssh: build the nginx+SSH Docker image used for rsync testing
+web-docker-build-nginx-ssh:
+	docker build --pull -t photos-nginx-ssh -f web/nginx-ssh.dockerfile web/
+
 .PHONY: _check-docker-schema-apache
 _check-docker-schema-apache:
 	bin/docker-check.sh --server apache
@@ -300,9 +305,14 @@ sample-test-nginx: _check-docker-schema-nginx
 	EXIT=$$?; docker stop sample-test-nginx 2>/dev/null || true; exit $$EXIT
 
 .PHONY: sample-rsync-test
-## sample-rsync-test: test deploy-photos.sh rsync path by rsyncing into a fresh Docker container (starts/stops automatically)
+## sample-rsync-test: test deploy-photos.sh rsync path into a fresh Apache Docker container (starts/stops automatically)
 sample-rsync-test:
 	bin/rsync-test.sh
+
+.PHONY: sample-rsync-test-nginx
+## sample-rsync-test-nginx: test deploy-photos.sh rsync path into a fresh nginx Docker container (starts/stops automatically)
+sample-rsync-test-nginx:
+	bin/rsync-test.sh --server nginx
 
 .PHONY: sample-s3-test
 ## sample-s3-test: test deploy-photos.sh S3 path against MinIO; verifies file placement and Cache-Control headers

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -13,6 +13,7 @@ SKIP_PLAYWRIGHT=false
 SKIP_SERVER_TEST=false
 DRY_RUN=false
 S3_MODE=false
+SERVER="apache"
 CONFIG_DIR="config"
 SITE_ENV_ARG=""
 SITE_ID_ARG=""
@@ -27,6 +28,8 @@ while [[ $# -gt 0 ]]; do
         --no-server-test)    SKIP_SERVER_TEST=true; shift ;;
         --dry-run)           DRY_RUN=true; shift ;;
         --s3)                S3_MODE=true; shift ;;
+        --server)            SERVER="$2"; shift 2 ;;
+        --server=*)          SERVER="${1#*=}"; shift ;;
         --config-dir)        CONFIG_DIR="$2"; shift 2 ;;
         --config-dir=*)      CONFIG_DIR="${1#*=}"; shift ;;
         --site-env)          SITE_ENV_ARG="$2"; shift 2 ;;
@@ -42,6 +45,7 @@ while [[ $# -gt 0 ]]; do
             echo "" >&2
             echo "  --dry-run              Show what would be deployed without transferring files" >&2
             echo "  --s3                   Deploy to S3 (default: rsync; auto-set if S3_BUCKET in site.env)" >&2
+            echo "  --server NAME          Server used for pre-deploy tests: apache or nginx (default: apache)" >&2
             echo "  --config-dir DIR       Config directory (default: config/)" >&2
             echo "  --site-env FILE        Path to site.env (default: config-dir/site.env)" >&2
             echo "  --site-id ID           Site ID (overrides albums.yaml)" >&2
@@ -56,6 +60,13 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# --server selects the image used for the pre-deploy local tests only. It has no effect on
+# what gets deployed: both servers are fed the identical two-source tree (see docs/DEPLOY.md).
+if [[ "$SERVER" != "apache" && "$SERVER" != "nginx" ]]; then
+    echo "Error: --server must be 'apache' or 'nginx' (got '$SERVER')" >&2
+    exit 1
+fi
 
 # cd to root of repo (REPO_ROOT may be pre-set by caller, e.g. docker/do-deploy.sh)
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
@@ -199,18 +210,18 @@ _pre_deploy() {
         echo "Skipping local server tests (--no-server-test)"
     else
         # Verify Docker image is current before running
-        "$SDIR/docker-check.sh"
+        "$SDIR/docker-check.sh" --server "$SERVER"
 
         DOCKER_RUNNING=$(docker ps -q --filter publish=8080)
         if [ -n "$DOCKER_RUNNING" ]; then
             echo "Docker already running on port 8080, using existing container..."
         else
-            echo "Starting local Docker container for testing..."
+            echo "Starting local Docker container ($SERVER) for testing..."
             docker run -d --rm -p 8080:80 \
                 -e DDPHOTOS_SITE_ID="$SITE_ID" \
                 -v "$REPO_ROOT/build":/build:ro \
                 -v "$DDPHOTOS_ALBUMS_DIR/$SITE_ID":/albums:ro \
-                photos-apache > /dev/null
+                "photos-$SERVER" > /dev/null
             DOCKER_STARTED=true
             sleep 1
         fi

--- a/bin/rsync-test.sh
+++ b/bin/rsync-test.sh
@@ -2,21 +2,44 @@
 #
 # Test the rsync deploy path of deploy-photos.sh against a local Docker container.
 #
-# Spins up an Apache+SSH container, builds a temporary config with siteUrl pointing
-# at localhost, then runs deploy-photos.sh (photogen → build → rsync → post-deploy
+# Spins up an Apache+SSH (or nginx+SSH) container, builds a temporary config with siteUrl
+# pointing at localhost, then runs deploy-photos.sh (photogen → build → rsync → post-deploy
 # server routing tests + Playwright) against it.
 #
-# Usage: bin/rsync-test.sh
+# Usage: bin/rsync-test.sh [--server apache|nginx]
+#
+#   --server  Which server to deploy into (default: apache)
 
 set -eo pipefail
+
+SERVER="apache"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server)   SERVER="$2"; shift 2 ;;
+        --server=*) SERVER="${1#*=}"; shift ;;
+        *) echo "Usage: $0 [--server apache|nginx]" >&2; exit 1 ;;
+    esac
+done
+
+if [[ "$SERVER" != "apache" && "$SERVER" != "nginx" ]]; then
+    echo "Error: --server must be 'apache' or 'nginx' (got '$SERVER')" >&2
+    exit 1
+fi
 
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 cd "$SDIR/.."
 
 HTTP_PORT=8083
 SSH_PORT=2222
-IMAGE=photos-apache-ssh
-CONTAINER=rsync-test
+IMAGE="photos-$SERVER-ssh"
+CONTAINER="rsync-test-$SERVER"
+
+# Document root differs per server; RSYNC_DEST must match what the server actually serves.
+if [ "$SERVER" = "apache" ]; then
+    DOC_ROOT=/usr/local/apache2/htdocs/
+else
+    DOC_ROOT=/usr/share/nginx/html/
+fi
 TEST_KEY="$(pwd)/web/testdata/rsync-test-key"
 # SSH refuses keys that are world-readable; git checkouts default to 0644.
 chmod 600 "$TEST_KEY"
@@ -31,7 +54,7 @@ trap cleanup EXIT
 # Build Docker image if missing
 docker image inspect "$IMAGE" >/dev/null 2>&1 || {
     echo "=== Building $IMAGE ==="
-    docker build --pull -t "$IMAGE" -f web/apache-ssh.dockerfile web/
+    docker build --pull -t "$IMAGE" -f "web/$SERVER-ssh.dockerfile" web/
 }
 
 # Build temp config dir.
@@ -42,16 +65,16 @@ awk '/site_url:/{print "  site_url: http://localhost:'"$HTTP_PORT"'"; next} {pri
 /bin/cp sample/config/descriptions.txt "$TEMP_CONFIG/descriptions.txt"
 cat > "$TEMP_CONFIG/site.env" <<EOF
 RSYNC_HOST=root@localhost
-RSYNC_DEST=/usr/local/apache2/htdocs/
+RSYNC_DEST=$DOC_ROOT
 EOF
 
 # Start container (empty htdocs — rsync fills it)
 echo "=== Starting $IMAGE on HTTP :$HTTP_PORT, SSH :$SSH_PORT ==="
 docker run -d --rm --name "$CONTAINER" -p "$HTTP_PORT:80" -p "$SSH_PORT:22" "$IMAGE"
-echo "Waiting for Apache..."
+echo "Waiting for $SERVER..."
 until curl -s -o /dev/null "http://localhost:$HTTP_PORT"; do sleep 1; done
 
 # Run full deploy: photogen → build → rsync → post-deploy server tests + Playwright.
 # RSYNC_RSH tells rsync which SSH command to use (custom port + test key).
 export RSYNC_RSH="ssh -i $TEST_KEY -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-bin/deploy-photos.sh --no-pre-deploy-tests --config-dir "$TEMP_CONFIG"
+bin/deploy-photos.sh --no-pre-deploy-tests --server "$SERVER" --config-dir "$TEMP_CONFIG"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -3,7 +3,7 @@
 DD Photos supports the following deployment approaches:
 
  * **Static** - via `export` script (for any compatible static-hosting service, e.g., [Cloudflare Pages↗](https://pages.cloudflare.com), [Surge↗](https://surge.sh))
- * **Apache via rsync** - via `deploy` script (for any SSH-accessible server)
+ * **Apache or nginx via rsync** - via `deploy` script (for any SSH-accessible server)
  * **S3 + CloudFront** - via `deploy` script (fully serverless).
 
 All are described below.
@@ -127,15 +127,49 @@ The site will be at https://my-unique-site.surge.sh.
 
 See [Surge](DEPLOYMENT-SERVERS.md#surge) for page routing behavior and known limitations.
 
-## Apache + rsync
+## Apache or nginx + rsync
 
-In this scenario, the site is rsynced to any SSH-accessible server running Apache.
+In this scenario, the site is rsynced to any SSH-accessible server running Apache or nginx.
 That's the only hard requirement.
 
 ```mermaid
 flowchart LR
-    User -->|HTTPS| Apache["Server / Apache"]
+    User -->|HTTPS| Server["Server / Apache or nginx"]
 ```
+
+The rsync itself is server-agnostic — it copies the same two-source tree either way (see
+[Syncing Logic](#syncing-logic) above). The servers differ only in how the routing rules
+get onto the machine:
+
+| | Apache | nginx |
+|---|---|---|
+| **Routing rules** | `web/static/.htaccess`, shipped in the build output and rsynced with it | `web/nginx.conf`, installed on the server by hand |
+| **Server config** | `AllowOverride All` and `ErrorDocument 404 /404.html` in the `VirtualHost` | The `server` block from `web/nginx.conf` |
+| **Deploy-time action** | None — the rules travel with every deploy | Copy `web/nginx.conf` once, and again whenever it changes |
+
+Because `.htaccess` rides along in the build output, an nginx origin receives it too and
+silently ignores it. That file is harmless but inert: **on nginx, routing comes entirely from
+`web/nginx.conf`, which the deploy script never touches.** If you change routing rules, update
+both files and re-copy `nginx.conf` to the server.
+
+See [Web Server Configuration](DEPLOYMENT-SERVERS.md) for the Apache `VirtualHost` and
+`.htaccess` details and the equivalent `nginx.conf` rules. Both are verified against the same
+routing and Playwright suites in CI.
+
+### Pre-deploy tests on nginx
+
+In rsync mode the deploy script starts a local Docker container and runs the routing and
+Playwright suites against it before transferring anything. That container defaults to Apache,
+so an nginx origin is verified against the wrong server unless you pass `--server nginx`:
+
+```bash
+bin/deploy-photos.sh --server nginx
+```
+
+This only selects the image used for the local pre-deploy check (`photos-nginx` instead of
+`photos-apache`) — it does not change what is deployed. Build the image first with
+`make web-docker-build-nginx`; the script fails with instructions if it is stale or missing.
+The post-deploy tests against production are server-agnostic and need no flag.
 
 Optionally, you can place CloudFront (and a WAFv2 web ACL) in front of the origin:
 
@@ -228,6 +262,9 @@ Docker mode is intentionally simple and prescriptive. It:
 5. Runs `bin/test-photos-server.sh` to verify the deployment against production
 
 Pre-deploy tests and Playwright are skipped — run `ddphotos photogen` and `ddphotos build` before deploying.
+There is therefore no `--server` flag in Docker mode: it selects the pre-deploy test container,
+which Docker mode never starts. (The `ddphotos` image itself serves with Apache — `ddphotos serve`
+runs `apache2` — but that affects only local serving, not the deploy.)
 
 ## Deploying — Developer Mode
 
@@ -235,8 +272,9 @@ Pre-deploy tests and Playwright are skipped — run `ddphotos photogen` and `ddp
 
 1. Runs `photogen` to resize images and generate JSON
 2. Builds the static site via `npm run build` into `build/<site-id>/`
-3. *(rsync mode only)* Starts Docker/Apache, runs `bin/test-photos-server.sh --local` to verify
-   routing locally, runs Playwright tests against Docker/Apache, then stops the container
+3. *(rsync mode only)* Starts Docker/Apache (or Docker/nginx with `--server nginx`), runs
+   `bin/test-photos-server.sh --local` to verify routing locally, runs Playwright tests against
+   that container, then stops it
 4. Deploys the site:
    - **S3**: two-pass `aws s3 sync` — pass 1 syncs the build output (excluding `albums/*` but
      re-including `albums/*.html`); pass 2 syncs album images and JSON (`--size-only`, excluding
@@ -255,6 +293,7 @@ The script uses `set -eo pipefail` — any failure aborts before deployment.
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `--s3`                  | Deploy to S3 instead of rsync (requires `S3_BUCKET` in `site.env`; skips pre-deploy Docker/Apache and Playwright tests) |
 | `--dry-run`             | Pass `--dry-run`/`--dryrun` to rsync or `aws s3 sync`; skips CloudFront invalidation and post-deploy tests              |
+| `--server NAME`         | Server image for the pre-deploy local tests: `apache` (default) or `nginx`; no effect on what is deployed              |
 | `--no-photogen`         | Skip photo generation step                                                                                              |
 | `--no-build`            | Skip the static site build step                                                                                         |
 | `--no-rsync`            | Skip deploy, CloudFront invalidation, and post-deploy tests (build + local test only)                                   |
@@ -275,6 +314,7 @@ bin/deploy-photos.sh --s3 --aws-profile my-profile # use a named AWS profile for
 
 # rsync mode
 bin/deploy-photos.sh                               # full deploy
+bin/deploy-photos.sh --server nginx                # full deploy, pre-deploy tests run against nginx
 bin/deploy-photos.sh --dry-run                     # preview what rsync would transfer, no changes made
 bin/deploy-photos.sh --no-photogen                 # skip photo generation
 bin/deploy-photos.sh --no-rsync                    # build + local test only (safe on a dev machine)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -141,16 +141,22 @@ The rsync itself is server-agnostic — it copies the same two-source tree eithe
 [Syncing Logic](#syncing-logic) above). The servers differ only in how the routing rules
 get onto the machine:
 
-| | Apache | nginx |
-|---|---|---|
-| **Routing rules** | `web/static/.htaccess`, shipped in the build output and rsynced with it | `web/nginx.conf`, installed on the server by hand |
-| **Server config** | `AllowOverride All` and `ErrorDocument 404 /404.html` in the `VirtualHost` | The `server` block from `web/nginx.conf` |
-| **Deploy-time action** | None — the rules travel with every deploy | Copy `web/nginx.conf` once, and again whenever it changes |
+|                        | Apache                                                                     | nginx                                                     |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------|
+| **Routing rules**      | `web/static/.htaccess`, shipped in the build output and rsynced with it    | `web/nginx.conf`, installed on the server by hand         |
+| **Server config**      | `AllowOverride All` and `ErrorDocument 404 /404.html` in the `VirtualHost` | The `server` block from `web/nginx.conf`                  |
+| **Deploy-time action** | None — the rules travel with every deploy                                  | Copy `web/nginx.conf` once, and again whenever it changes |
 
 Because `.htaccess` rides along in the build output, an nginx origin receives it too and
 silently ignores it. That file is harmless but inert: **on nginx, routing comes entirely from
 `web/nginx.conf`, which the deploy script never touches.** If you change routing rules, update
 both files and re-copy `nginx.conf` to the server.
+
+Copy it to `/etc/nginx/sites-available/` (Debian/Ubuntu) or `/etc/nginx/conf.d/` (RHEL family),
+and edit its `root` to match `RSYNC_DEST` — the file ships with the Docker images' root
+(`/usr/share/nginx/html`), which is unlikely to be yours. See
+[Installing nginx.conf on a server](DEPLOYMENT-SERVERS.md#installing-nginxconf-on-a-server)
+for the full procedure.
 
 See [Web Server Configuration](DEPLOYMENT-SERVERS.md) for the Apache `VirtualHost` and
 `.htaccess` details and the equivalent `nginx.conf` rules. Both are verified against the same
@@ -293,7 +299,7 @@ The script uses `set -eo pipefail` — any failure aborts before deployment.
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `--s3`                  | Deploy to S3 instead of rsync (requires `S3_BUCKET` in `site.env`; skips pre-deploy Docker/Apache and Playwright tests) |
 | `--dry-run`             | Pass `--dry-run`/`--dryrun` to rsync or `aws s3 sync`; skips CloudFront invalidation and post-deploy tests              |
-| `--server NAME`         | Server image for the pre-deploy local tests: `apache` (default) or `nginx`; no effect on what is deployed              |
+| `--server NAME`         | Server image for the pre-deploy local tests: `apache` (default) or `nginx`; no effect on what is deployed               |
 | `--no-photogen`         | Skip photo generation step                                                                                              |
 | `--no-build`            | Skip the static site build step                                                                                         |
 | `--no-rsync`            | Skip deploy, CloudFront invalidation, and post-deploy tests (build + local test only)                                   |

--- a/docs/DEPLOYMENT-SERVERS.md
+++ b/docs/DEPLOYMENT-SERVERS.md
@@ -66,9 +66,10 @@ The `.htaccess` file (`web/static/.htaccess`) configures URL routing:
 ## nginx
 
 Unlike Apache, nginx needs no per-directory config file — all routing rules live in
-`web/nginx.conf`, which is baked into the Docker image. `web/nginx-entrypoint.sh`
-symlinks the active build into the document root at container startup (same role as
-`web/apache-entrypoint.sh`).
+`web/nginx.conf`. The Docker images bake it in; on a real server it is installed once by hand
+(see [Installing nginx.conf on a server](#installing-nginxconf-on-a-server) below), because
+nothing in the deploy path transfers it. `web/nginx-entrypoint.sh` symlinks the active build
+into the document root at container startup (same role as `web/apache-entrypoint.sh`).
 
 ### nginx.conf
 
@@ -80,6 +81,38 @@ symlinks the active build into the document root at container startup (same role
 - **HTML rewrite** — Serves `.html` files without the extension
   (e.g., `/albums/patagonia` serves `patagonia.html`)
 - **Unknown paths** — Return 404 (served as `404.html` via `error_page 404`)
+
+### Installing nginx.conf on a server
+
+`web/nginx.conf` is a bare `server { ... }` block, so it goes wherever your nginx package's
+`http` block already includes config from. The stock `/etc/nginx/nginx.conf` includes both of
+these, so either location works:
+
+| Distribution                     | Destination                                                                       |
+|----------------------------------|-----------------------------------------------------------------------------------|
+| Debian / Ubuntu                  | `/etc/nginx/sites-available/ddphotos`, symlinked into `/etc/nginx/sites-enabled/` |
+| RHEL / Alma / Rocky, nginx image | `/etc/nginx/conf.d/ddphotos.conf`                                                 |
+
+**Edit `root` before reloading.** The file ships with `root /usr/share/nginx/html;` — the
+document root of the Docker images it was written for. On a real server it must match the
+`RSYNC_DEST` you set in `config/site.env`, or nginx will serve a directory the deploy never
+writes to. You will also want a `server_name`, and TLS if you are not terminating it upstream.
+
+```bash
+scp web/nginx.conf myserver:/etc/nginx/sites-available/ddphotos
+ssh myserver
+sudo sed -i 's|root /usr/share/nginx/html;|root /var/www/photos;|' /etc/nginx/sites-available/ddphotos
+sudo ln -sf /etc/nginx/sites-available/ddphotos /etc/nginx/sites-enabled/ddphotos
+sudo rm -f /etc/nginx/sites-enabled/default   # the stock site also claims :80
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+`nginx -t` validates the config before you reload; a reload with a broken config is refused and
+leaves the running server untouched.
+
+This is a one-time step, plus a repeat whenever `web/nginx.conf` changes — the deploy script
+never touches it. See [Apache or nginx + rsync](DEPLOY.md#apache-or-nginx--rsync) for how this
+differs from Apache, where `.htaccess` is rsynced with every deploy.
 
 ## CloudFront Function
 

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -27,6 +27,7 @@ as defined in `config/defaults.env`.
 | `web-docker-build-apache`     | Build the `photos-apache` Docker image                                                        |
 | `web-docker-build-nginx`      | Build the `photos-nginx` Docker image                                                         |
 | `web-docker-build-apache-ssh` | Build the `photos-apache-ssh` Docker image (Apache + SSH, used for rsync testing)             |
+| `web-docker-build-nginx-ssh`  | Build the `photos-nginx-ssh` Docker image (nginx + SSH, used for rsync testing)               |
 | `web-docker-run-apache`       | Run Apache on port 8080 (mounts `build/` and `albums/$DDPHOTOS_SITE_ID/`)                     |
 | `web-docker-run-nginx`        | Run nginx on port 8080 (mounts `build/` and `albums/$DDPHOTOS_SITE_ID/`)                      |
 | `web-docker-stop`             | Stop the container running on port 8080                                                       |
@@ -52,7 +53,8 @@ as defined in `config/defaults.env`.
 | `sample-npm-run-dev-css`      | Run the Vite dev server using sample config with custom CSS                                   |
 | `sample-test-apache`          | Run routing tests against Docker/Apache on port 8082                                          |
 | `sample-test-nginx`           | Run routing tests against Docker/nginx on port 8082                                           |
-| `sample-rsync-test`           | Test the rsync deploy path: photogen, build, rsync into a fresh Docker container, verify      |
+| `sample-rsync-test`           | Test the rsync deploy path: photogen, build, rsync into a fresh Apache container, verify      |
+| `sample-rsync-test-nginx`     | Same, but rsyncs into a fresh nginx container (`bin/rsync-test.sh --server nginx`)            |
 | `sample-s3-test`              | Test the S3 deploy path against MinIO: verifies file placement and Cache-Control headers      |
 | `web-screenshots`             | Capture screenshots (requires a running server on port 8080)                                  |
 | `gen-deploy-tree`             | Regenerate `docs/deploy-tree.svg` (run after changing the deploy directory structure)         |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -202,12 +202,19 @@ The two deploy paths can be validated locally without touching a real server:
 
 ```bash
 # rsync path — rsyncs into a local Docker container; runs server routing tests and Playwright
-make sample-rsync-test
+make sample-rsync-test        # into Apache (photos-apache-ssh)
+make sample-rsync-test-nginx  # into nginx  (photos-nginx-ssh)
 
 # S3 path — syncs against MinIO; verifies file placement and Cache-Control headers
 # (post-deploy server and Playwright tests are skipped: MinIO serves S3 API only, not HTTP)
 make sample-s3-test
 ```
+
+The two rsync targets exercise a real difference, not just a swapped base image: Apache gets its
+routing from the `.htaccess` that rsync transfers, while nginx gets it from the `nginx.conf` baked
+into `photos-nginx-ssh`. Both start with an empty document root that rsync fills from scratch, so
+they also verify the deploy against real files rather than the symlink tree that
+`web/setup-htdocs.sh` builds for the other Docker test images.
 
 ## Testing Docker
 

--- a/web/nginx-ssh-entrypoint.sh
+++ b/web/nginx-ssh-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+/usr/sbin/sshd
+exec nginx -g 'daemon off;'

--- a/web/nginx-ssh.dockerfile
+++ b/web/nginx-ssh.dockerfile
@@ -1,0 +1,34 @@
+FROM nginx:alpine
+
+# Routing rules: the same nginx.conf used by nginx.dockerfile and documented in
+# docs/DEPLOYMENT-SERVERS.md. Unlike Apache (whose .htaccess is rsynced with the build),
+# nginx routing lives on the server, so it is baked in here rather than deployed.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Start from an empty document root — rsync fills it. The stock nginx image ships an
+# index.html here, which would mask a deploy that failed to transfer the real one.
+RUN rm -f /usr/share/nginx/html/index.html /usr/share/nginx/html/50x.html
+
+# Install OpenSSH and rsync (rsync is required on both sender and receiver)
+# Generate host keys and create sshd privilege-separation dir
+RUN apk add --no-cache openssh rsync \
+    && ssh-keygen -A \
+    && mkdir -p /run/sshd
+
+# Allow root login with key auth; disable password auth.
+# Alpine ships root locked ("!" in /etc/shadow), which sshd rejects even for pubkey auth
+# (platform_locked_account). "*" is not treated as locked, so key auth is allowed.
+RUN printf '\nPermitRootLogin prohibit-password\nPasswordAuthentication no\n' >> /etc/ssh/sshd_config \
+    && sed -i 's/^root:!/root:*/' /etc/shadow
+
+# Bake in the test public key (private key lives in web/testdata/rsync-test-key)
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh
+COPY testdata/rsync-test-key.pub /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys
+
+COPY nginx-ssh-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+CMD ["/entrypoint.sh"]
+
+# Runtime ports: 80 (nginx), 22 (SSH for rsync)
+# Test key: web/testdata/rsync-test-key — local Docker testing only, not a production credential


### PR DESCRIPTION
nginx was already a fully supported serving target (`web/nginx.conf`, `photos-nginx` image, routing and Playwright suites in CI), but nothing on the deploy side knew about it: `bin/deploy-photos.sh` hard-coded `photos-apache` for its pre-deploy check, `bin/rsync-test.sh` could only deploy into Apache, and the docs described the rsync path as Apache-only.

This wires nginx through the deploy path and documents it.

## Changes

**`bin/deploy-photos.sh`** — new `--server apache|nginx` flag (default `apache`, accepts `--server=x` too). It selects the image for the pre-deploy local check: `docker-check.sh --server "$SERVER"` and `photos-$SERVER` instead of the hard-coded `photos-apache`. It deliberately does not touch the rsync/S3 passes, since what gets transferred is identical either way.

**`bin/rsync-test.sh`** — same flag, but here it selects a real deploy target: image, dockerfile, container name, and `DOC_ROOT` (which becomes `RSYNC_DEST`, since Apache and nginx serve from different paths).

**`web/nginx-ssh.dockerfile` + `web/nginx-ssh-entrypoint.sh`** (new) — the nginx counterpart to `apache-ssh.dockerfile`, so the rsync test has an nginx origin to deploy into. `nginx:alpine` plus openssh and rsync, with the real `web/nginx.conf` baked in and the stock `index.html`/`50x.html` removed so an empty document root cannot mask a failed transfer.

One non-obvious bit: Alpine ships root locked (`!` in `/etc/shadow`), and sshd rejects that even for pubkey auth (`platform_locked_account`). The dockerfile rewrites it to `*`. Without that line, rsync fails at the SSH handshake with no obvious cause.

**`Makefile`** — `web-docker-build-nginx-ssh` and `sample-rsync-test-nginx`.

**`.github/workflows/ci.yml`** — `make sample-rsync-test-nginx` added to the `test-nginx-s3` job, so the two jobs now mirror each other: build image, routing tests, Playwright across all password variants, rsync deploy test.

**Docs** — `DEPLOY.md` covers the rsync path for both servers, including the one real difference: Apache gets routing from the `.htaccess` that rsync transfers, while nginx gets it from an `nginx.conf` the deploy never touches. `DEPLOYMENT-SERVERS.md` gains an "Installing nginx.conf on a server" section with the destination path per distribution, since "install it by hand" previously did not say where. `MAKEFILE.md` and `TESTING.md` document the new targets.

## Worth knowing

`web/nginx.conf` hard-codes `root /usr/share/nginx/html;`, which is correct for the Docker images but not for a real server, where it has to match `RSYNC_DEST`. Copying the file unedited yields a valid config that serves the wrong directory. The docs call this out, but templating the root (envsubst at deploy time, or an include for a site-local root) would remove the manual step entirely. Left for a follow-up.

Docker mode gets no `--server` flag: `docker/do-deploy.sh` always passes `--no-pre-deploy-tests`, so there is no container to select.

## Testing

Run locally, all passing:

- `make sample-rsync-test-nginx` — photogen, build, rsync into a fresh nginx origin, 22 routing tests, 38 Playwright
- `make sample-rsync-test` — unchanged Apache path, same counts (regression check)
- `bin/deploy-photos.sh --server nginx` and the default Apache path, pre-deploy only, 22 routing tests each
- `make web-lint` clean; `bash -n` clean on both scripts; invalid `--server` values rejected with exit 1

Not verified: the `scp`/`systemctl` sequence in the new install docs is the standard nginx procedure but is not exercised by any test.
