### PR TITLE
Ubuntu docs and tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Run recipes under bash. Make defaults to /bin/sh, which is dash on Debian/Ubuntu but
+# bash on macOS. nvm.sh locates itself via BASH_SOURCE; under dash that is unset, so it
+# guesses NVM_DIR=/bin and every nvm target fails with a cryptic error. Pinning bash keeps
+# Linux and macOS on the same shell.
+SHELL := /bin/bash
+
 # Migration check: album data moved from web/albums/ to albums/ in the decouple refactor.
 ifneq ($(wildcard web/albums),)
 $(warning MIGRATION REQUIRED: web/albums/ exists but album data now lives in albums/ )
@@ -30,40 +36,48 @@ override DDPHOTOS_ALBUMS_DIR := $(abspath $(patsubst ~/%,$(HOME)/%,$(DDPHOTOS_AL
 # - NVM_INIT always sources nvm.sh (nvm is a shell function, not a binary, so Make's subshell
 #   never has it). NVM_SH is derived from NVM_DIR if set (e.g. Homebrew install), else ~/.nvm.
 #   Override NVM_SH if your nvm lives elsewhere and NVM_DIR is not set.
-# - If 'node' is already on PATH (system install, volta, fnm, etc.),
-#   NODE_INIT is empty and node is used directly. Otherwise, nvm is sourced from NVM_SH
-#   and switched to the version in web/.nvmrc (sourcing alone activates nvm's default
-#   alias, which is not necessarily the version this repo wants).
+# - If a 'node' on PATH already matches the major version in web/.nvmrc (system install,
+#   volta, fnm, etc.), NODE_INIT is empty and that node is used directly. Otherwise, nvm is
+#   sourced from NVM_SH and switched to the version in web/.nvmrc (sourcing alone activates
+#   nvm's default alias, which is not necessarily the version this repo wants). Matching on
+#   the version, not mere presence, keeps a distro node at the wrong major (Ubuntu's apt
+#   'nodejs' is commonly pulled in as a dependency) from shadowing the repo's Node.
 NVM_SH ?= $(or $(NVM_DIR),$(HOME)/.nvm)/nvm.sh
 NVM_INIT := . "$(NVM_SH)" &&
-NODE := $(shell command -v node 2>/dev/null)
-ifndef NODE
-NODE_INIT := . "$(NVM_SH)" && nvm use --silent $(shell cat web/.nvmrc) &&
+NODE_WANTED := $(shell cat web/.nvmrc)
+NODE_FOUND := $(shell node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+ifneq ($(NODE_FOUND),$(NODE_WANTED))
+NODE_INIT := . "$(NVM_SH)" && nvm use --silent $(NODE_WANTED) &&
 endif
 
 # 1st item is default, so 'make' with no arguments shows help
 .PHONY: help
 ## help: show this help message
 help:
-	@echo "Usage: \n"
+	@printf "Usage:\n\n"
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+# All Go source lives in cmd/ and pkg/. Scoping to those, rather than ./..., keeps Go out
+# of web/node_modules — npm packages may vendor Go source (flatted ships a Go port), and
+# since it has no go.mod of its own, ./... treats it as part of this module and builds it.
+GO_PKGS := ./cmd/... ./pkg/...
 
 .PHONY: build
 ## build: run `go build`
 build:
-	go build -ldflags "-X main.repoRoot=$(PWD)" ./...
+	go build -ldflags "-X main.repoRoot=$(PWD)" $(GO_PKGS)
 
 .PHONY: test
 ## test: run `go test` (with the race detector)
 # -race catches data races in the concurrent resize and metadata workers. It needs cgo,
 # which is already required by govips, and roughly doubles the runtime.
 test:
-	go test -v -race -cover ./...
+	go test -v -race -cover $(GO_PKGS)
 
 .PHONY: vet
 ## vet: run `go vet`
 vet:
-	go vet ./...
+	go vet $(GO_PKGS)
 
 .PHONY: mod-tidy
 ## mod-tidy: run `go mod tidy` (clean up imports)

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -36,6 +36,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# --- temp dir location ---
+# Several tests below mktemp a directory and bind-mount it into a container. Docker Desktop
+# only mounts host paths shared with its VM: on Linux $HOME is shared but /tmp is not, so a
+# default mktemp path fails with "mounts denied: ... is not shared from the host". Placing
+# them under $HOME works on macOS, Linux and native Docker Engine alike.
+#
+# Pass an explicit template rather than exporting TMPDIR: TMPDIR would be inherited by every
+# child process, relocating node's and Playwright's caches here as a side effect. A template
+# containing a path is portable; GNU's -p flag is not (macOS ships BSD mktemp). cleanup()
+# rmdir's TMP_ROOT, which succeeds only once the individual dirs below have been removed.
+TMP_ROOT="$HOME/.cache/ddphotos/tmp"
+mkdir -p "$TMP_ROOT"
+mktempd() { mktemp -d "$TMP_ROOT/XXXXXXXX"; }
+
 # --- helpers ---
 step()  { echo; echo "=== $* ==="; }
 pass()  { echo "  PASS: $*"; }
@@ -55,6 +69,8 @@ cleanup() {
     if [ -n "$SC_TEST_DIR" ];   then /bin/rm -rf "$SC_TEST_DIR";   fi
     if [ -n "$WIN_CONFIG_DIR" ]; then /bin/rm -rf "$WIN_CONFIG_DIR"; fi
     if [ -n "$WIN_OUT_DIR" ];    then /bin/rm -rf "$WIN_OUT_DIR";    fi
+    # Only removes TMP_ROOT if empty, so anything unexpected is left for inspection
+    rmdir "$TMP_ROOT" 2>/dev/null || true
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -100,7 +116,7 @@ fi
 
 # ── 2. Init ────────────────────────────────────────────────────────────────────
 step "Init"
-TEST_DIR=$(mktemp -d)
+TEST_DIR=$(mktempd)
 chmod 755 "$TEST_DIR"
 docker run --rm -v "$TEST_DIR":/ddphotos "$IMAGE" init --site-id "$SITE_ID"
 [ -x "$TEST_DIR/ddphotos" ]              || fail "ddphotos script not installed"
@@ -175,7 +191,7 @@ pass "albums/$SITE_ID created ($ALBUM_COUNT albums)"
 # Exercises build_config_bases_mounts() handling of source: and image: with absolute paths.
 step "Photogen: absolute source paths"
 ABS_SITE_ID="test-abs-path"
-ABS_CONFIG_DIR=$(mktemp -d)
+ABS_CONFIG_DIR=$(mktempd)
 sed "s|_REPO_ROOT_|$REPO_ROOT|g" "$REPO_ROOT/web/testdata/albums.abspath.yaml" > "$ABS_CONFIG_DIR/albums.yaml"
 "${DDPHOTOS[@]}" --config-dir "$ABS_CONFIG_DIR" photogen
 [ -d "$TEST_DIR/albums/$ABS_SITE_ID/the-way" ] || fail "albums/$ABS_SITE_ID/the-way not created"
@@ -204,7 +220,7 @@ pass "photogen with absolute source paths inside DDPHOTOS_DIR OK (album dir and 
 # Windows-only), so the two translation halves are validated separately.
 
 step "Photogen: Windows path mapping (bash host side)"
-WIN_CONFIG_DIR=$(mktemp -d)
+WIN_CONFIG_DIR=$(mktempd)
 /bin/cp "$REPO_ROOT/web/testdata/albums.winpath.yaml" "$WIN_CONFIG_DIR/albums.yaml"
 # --show-mounts prints the mount table before the (expected-to-fail) docker run,
 # so we capture that output and ignore the failure.
@@ -218,7 +234,7 @@ step "Photogen: Windows path mapping (container side, real photos)"
 # mounted at the translated container location, and the config dir whose base is
 # C:\Users\test\photos. photogen's winToUnixPath must translate that base to
 # /mnt/c/Users/test/photos and read the real photos mounted there.
-WIN_OUT_DIR=$(mktemp -d)
+WIN_OUT_DIR=$(mktempd)
 chmod 755 "$WIN_OUT_DIR"
 docker run --rm \
     -v "$WIN_OUT_DIR":/ddphotos \
@@ -243,7 +259,7 @@ pass "decode: $ENC_FILE decrypted OK"
 # The enc.json is placed in a secret/ subdirectory so the album slug is preserved in the
 # container path (/ddphotos-args/arg-N/secret/index.enc.json), which decode needs to find
 # the right per-album password.
-TEMP_DECODE_DIR=$(mktemp -d)
+TEMP_DECODE_DIR=$(mktempd)
 mkdir -p "$TEMP_DECODE_DIR/secret"
 /bin/cp "$TEST_DIR/config/passwords.yaml"  "$TEMP_DECODE_DIR/passwords.yaml"
 /bin/cp "$TEST_DIR/$ENC_FILE"              "$TEMP_DECODE_DIR/secret/index.enc.json"
@@ -282,7 +298,7 @@ step "Decode + Search-Cover with external --config-dir"
 
 # Simulate photogen having been run with an external --config-dir by rewriting
 # the embedded pwFile path from /ddphotos/config/... to /ddphotos-config/...
-EXT_CONFIG_DIR=$(mktemp -d)
+EXT_CONFIG_DIR=$(mktempd)
 /bin/cp "$TEST_DIR/config/passwords.yaml" "$EXT_CONFIG_DIR/"
 /bin/cp "$TEST_DIR/config/albums.yaml"    "$EXT_CONFIG_DIR/"
 
@@ -298,7 +314,7 @@ pass "decode --config-dir: external config dir mounted correctly"
 
 # search-cover needs the modified enc.json at the album path. Use a fresh
 # user-owned SC_TEST_DIR with --dir so we can write to it freely.
-SC_TEST_DIR=$(mktemp -d)
+SC_TEST_DIR=$(mktempd)
 chmod 755 "$SC_TEST_DIR"
 mkdir -p "$SC_TEST_DIR/albums/$SITE_ID/secret"
 /bin/cp "$EXT_ENC_FILE" "$SC_TEST_DIR/albums/$SITE_ID/secret/index.enc.json"
@@ -435,7 +451,7 @@ pass "version: Site ID '$SITE_ID' auto-detected from albums.yaml"
 
 # ── 15. Init --script-only ─────────────────────────────────────────────────────
 step "Init --script-only"
-TEST_DIR2=$(mktemp -d)
+TEST_DIR2=$(mktempd)
 chmod 755 "$TEST_DIR2"
 docker run --rm -v "$TEST_DIR2":/ddphotos "$IMAGE" init --script-only
 [ -x "$TEST_DIR2/ddphotos" ]   || fail "ddphotos script not installed"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -24,14 +24,34 @@ account and an SSH key.
 ## Prerequisites
 
 DD Photos uses Go, Node.js, `libvips`, so they must be installed and configured first.
+Instructions are given for macOS (via [Homebrew↗](https://docs.brew.sh/Installation)) and
+Debian/Ubuntu (`apt`). Other distributions should work with equivalent package manager
+commands (`dnf`, `pacman`). Windows users should use WSL2.
 
-**NOTE**: The following setup instructions are Mac-centric (via [Homebrew↗](https://docs.brew.sh/Installation)). Linux should work with 
-equivalent package manager commands (`apt`, `yum`). Windows users should use WSL2.
+### macOS
 
 ```bash
 # Install Go, vips library and pkg-config dependency (for photogen)
 brew install go vips pkg-config
+```
 
+### Debian/Ubuntu
+
+```bash
+# Install Go, vips library and pkg-config dependency (for photogen)
+sudo apt-get install golang-go libvips-dev pkg-config build-essential
+
+# HEIC/HEIF decoding (iPhone photos)
+sudo apt-get install libheif-plugin-libde265
+```
+
+Note the package is `libvips-dev`, not `vips` — the headers are needed to compile
+`photogen`. `build-essential` supplies the C compiler that cgo requires, and is often
+already installed.
+
+### Both platforms
+
+```bash
 # In root of this repo, fetch Go libraries
 go mod download
 ```
@@ -54,8 +74,16 @@ CI all read them. `web/package.json` sets a matching `engines.node`, and with
 `engine-strict=true` in `web/.npmrc` an `npm install` on the wrong Node version
 fails fast rather than silently installing.
 
+If your system already provides a `node` — Ubuntu's `nodejs` package is often pulled in as a
+dependency of something else — the Makefile uses it only when its major version matches
+`web/.nvmrc`, and otherwise falls back to nvm. A distro Node at the wrong version will not
+shadow the repo's.
+
 You may also want to install [Docker↗](https://www.docker.com/get-started/) if
 you don't have it, as it is required for testing site behavior using Apache or nginx.
+On Linux, install Docker Engine and add yourself to the `docker` group
+([post-install steps↗](https://docs.docker.com/engine/install/linux-postinstall/)) so the
+`make` targets can run it without `sudo`.
 
 ## Developer Tools on PATH
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
 			"devDependencies": {
 				"@eslint/compat": "^2.0.2",
 				"@eslint/js": "^9.39.2",
-				"@playwright/test": "^1.50.0",
+				"@playwright/test": "^1.62.1",
 				"@sveltejs/adapter-auto": "^7.0.0",
 				"@sveltejs/kit": "^2.70.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -352,19 +352,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+			"integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.62.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -2293,35 +2293,35 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.62.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
 	"devDependencies": {
 		"@eslint/compat": "^2.0.2",
 		"@eslint/js": "^9.39.2",
-		"@playwright/test": "^1.50.0",
+		"@playwright/test": "^1.62.1",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.70.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",


### PR DESCRIPTION
Makes the developer setup work on Linux. `docs/INSTALL.md` was Mac-centric, and walking
through it on Ubuntu 26.04 turned up four real breakages plus one latent bug that was never
platform-specific.

## Docs

`docs/INSTALL.md` Prerequisites split into **macOS** / **Debian/Ubuntu** / **Both**, replacing
the "Linux should work with equivalent package manager commands" note.

```bash
sudo apt-get install golang-go libvips-dev pkg-config build-essential
sudo apt-get install libheif-plugin-libde265
```

The libheif plugin is the non-obvious one. Homebrew's `vips` bundles a full codec set, but
Debian and Ubuntu split libheif's codecs into plugin packages and list the HEVC decoder as
only *suggested*. `libvips` still advertises HEIF support, so nothing fails until you decode
a real `.heic` file — `TestResizeImage_HEIC` and `TestResizeHeroJPEG_HEIC` catch it. Since
`photogen` exists largely to process iPhone photos, this matters.

The Docker image is unaffected: its Debian bookworm base has libheif 1.15, which links the
HEVC decoder directly instead of using plugins. Worth remembering if the base ever moves to
trixie or later.

## Makefile

**`SHELL := /bin/bash`** — Make defaults to `/bin/sh`, which is dash on Debian/Ubuntu but bash
on macOS. `nvm.sh` locates itself via `BASH_SOURCE`; under dash it guessed `NVM_DIR=/bin` and
tried to compile Node from source into `/bin/.cache`. Every nvm target died with a cryptic
`Error 3`. Fixed in the Makefile rather than documented as a shell-profile workaround.

**`@echo "Usage: \n"` → `@printf`** in `help` — required by the shell change, since bash's
builtin `echo` doesn't expand `\n` the way dash's does.

**Version-aware Node probe** — the old check tested whether *any* `node` was on `PATH`. Ubuntu
ships `nodejs` at `/usr/bin/node` (v22 here), commonly pulled in as a transitive dependency,
so the wrong Node won and `engine-strict` hard-failed on `Required: 24.x`. Now compares the
major version against `web/.nvmrc` and falls back to nvm on a mismatch. On macOS a `node` on
`PATH` is one you installed deliberately; on Ubuntu it often isn't.

**`GO_PKGS := ./cmd/... ./pkg/...`** for `build`/`test`/`vet` — not Linux-specific. Go's
`./...` doesn't skip `node_modules`, and `flatted` vendors a Go port with no `go.mod` of its
own, so it was being absorbed into this module and built. `mod-tidy` is left alone: `go mod
tidy` takes no package pattern, but flatted's imports are stdlib-only so there's nothing it
could pull into `go.mod`.

## bin/docker-test.sh

`make docker-test` failed at Init with:

```
docker: Error response from daemon: mounts denied:
The path /tmp/tmp.5d5mZldD3g is not shared from the host
```

The script `mktemp`s directories and bind-mounts them into containers. Docker Desktop only
mounts host paths shared with its VM — on Linux `$HOME` is shared but `/tmp` is not. macOS
works because the OS sets `TMPDIR` to a path Docker Desktop already shares.

Added a `mktempd()` helper that creates dirs under `$HOME/.cache/ddphotos/tmp`, and a `rmdir`
of that root in `cleanup()` — plain `rmdir`, so it only succeeds once the individual dirs are
gone and leaves anything unexpected behind for inspection.

Two details worth noting: it passes an explicit template rather than exporting `TMPDIR`, since
exporting would be inherited by every child process and relocate node's and Playwright's
caches as a side effect. And it uses a template path rather than GNU's `-p` flag, which BSD
`mktemp` on macOS doesn't support.

## Playwright

Bumped `@playwright/test` `^1.50.0` → `^1.62.1`. 1.59.1 refused to install:

```
Error: ERROR: Playwright does not support chromium on ubuntu26.04-x64
```

## Verified on Ubuntu 26.04

`make build` / `vet` / `test`, `sample-photogen`, `sample-npm-run-dev`, `sample-build`,
`web-sanity-test` (52 passed), `sample-test-apache` (22/22), `sample-test-nginx` (22/22),
`web-playwright-test-dev`, and `make docker-test`.

## Review note

Three changes affect macOS and CI, not just Linux: the Playwright bump, `SHELL := /bin/bash`,
and `GO_PKGS`. These were only exercised on Ubuntu, so CI on this branch is the real check.
