### PR TITLE
Fix Node version selection in bin scripts, verify setup on WSL2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Install npm dependencies
         run: cd web && npm ci
 
+      # test-cover rather than test: setup-go installs a full Go distribution, so the
+      # `covdata` tool is present and coverage works. `make test` drops -cover so it also
+      # works with a toolchain fetched via GOTOOLCHAIN auto-download (see the Makefile).
       - name: Go build, test, vet
-        run: make build test vet
+        run: make build test-cover vet
 
       - name: Web lint (prettier + eslint)
         run: make web-lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,15 @@ define the JSON schema consumed by the frontend. Their TypeScript counterparts l
 ## Node/npm version sync requirement
 
 `web/.nvmrc` (Node major) and `web/.npm-version` (exact npm version) are the single sources of
-truth. Everything else reads them: the Makefile, `bin/docker-push.sh`, `bin/run-tests.sh`, and the
+truth. Everything else reads them: the Makefile, `bin/docker-push.sh`, `bin/node-init.sh`, and the
 three `setup-node` steps in `.github/workflows/ci.yml`. **Do not hardcode either version anywhere
 else.**
+
+`bin/node-init.sh` is the shell-side counterpart to the Makefile's `NODE_INIT`: the bash scripts
+that run npm/npx (`bin/run-tests.sh`, `bin/docker-test.sh`, `bin/deploy-photos.sh`) source it
+rather than each doing their own nvm setup. Both it and `NODE_INIT` use the node on PATH only
+when its **major version matches** `web/.nvmrc` — testing for mere presence lets a distro node at
+the wrong major (Ubuntu's apt `nodejs`) shadow the repo's. **Keep the two in sync.**
 
 `docker/Dockerfile` takes both as **required** build args (`NODE_VERSION`, `NPM_VERSION`) with no
 defaults, so it cannot carry a stale copy of either version. It is built only via `make

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,19 @@ build:
 ## test: run `go test` (with the race detector)
 # -race catches data races in the concurrent resize and metadata workers. It needs cgo,
 # which is already required by govips, and roughly doubles the runtime.
+#
+# -cover is deliberately NOT here: it needs the `covdata` tool, which a toolchain fetched
+# via GOTOOLCHAIN auto-download does not supply, so `go test -cover` fails with
+# `go: no such tool "covdata"` on any package that has no test files (cmd/decode,
+# cmd/photogen). That bites whenever the installed Go is older than the `go` directive in
+# go.mod — e.g. Ubuntu 24.04, whose apt golang-go is 1.22 and downloads 1.25 on demand.
+# Use `make test-cover` for coverage; it needs a real Go install (see docs/INSTALL.md).
 test:
+	go test -v -race $(GO_PKGS)
+
+.PHONY: test-cover
+## test-cover: run `go test` with coverage (needs a full Go install, not a downloaded toolchain)
+test-cover:
 	go test -v -race -cover $(GO_PKGS)
 
 .PHONY: vet

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -177,12 +177,10 @@ DEFAULT_URL="https://your-ddphotos.example.com"
 if [ "$SKIP_BUILD" = true ]; then
     echo "Skipping build (--no-build)"
 else
+    # Node.js init (see bin/node-init.sh)
+    # shellcheck source=/dev/null
+    source "$SDIR/node-init.sh"
     cd web
-    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-    if ! command -v node &>/dev/null; then
-        # shellcheck source=/dev/null
-        source "$NVM_SH"
-    fi
     DDPHOTOS_ALBUMS_DIR="$DDPHOTOS_ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build
 fi
 

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -75,13 +75,9 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT TERM
 
-# Source nvm if node not on PATH
-if ! command -v node &>/dev/null; then
-    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-    [ -f "$NVM_SH" ] || { echo "Error: node not found; install Node.js or nvm" >&2; exit 1; }
-    # shellcheck source=/dev/null
-    source "$NVM_SH"
-fi
+# Node.js init (see bin/node-init.sh)
+# shellcheck source=/dev/null
+source "$REPO_ROOT/bin/node-init.sh"
 
 run_playwright() {
     $SKIP_PLAYWRIGHT && { echo "  (Playwright skipped)"; return 0; }

--- a/bin/node-init.sh
+++ b/bin/node-init.sh
@@ -6,7 +6,7 @@
 # sources nvm and switches to that version. Matching on the version, rather than mere
 # presence, keeps a distro node at the wrong major (Ubuntu's apt 'nodejs' is commonly
 # pulled in as a dependency of something else) from shadowing the repo's Node. Sourcing
-# nvm alone is not enough either — that activates nvm's default alias, which is not
+# nvm alone is not enough either, since that activates nvm's default alias, which is not
 # necessarily the version this repo wants.
 #
 # This mirrors NODE_INIT in the Makefile; keep the two in sync.
@@ -18,7 +18,9 @@ _ni_wanted=$(cat "$_ni_root/web/.nvmrc")
 _ni_found=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/' || true)
 
 if [ "$_ni_found" != "$_ni_wanted" ]; then
-    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    # Same precedence as the Makefile's 'NVM_SH ?= $(or $(NVM_DIR),$(HOME)/.nvm)/nvm.sh':
+    # an explicit NVM_SH wins, then NVM_DIR, then ~/.nvm.
+    NVM_SH="${NVM_SH:-${NVM_DIR:-$HOME/.nvm}/nvm.sh}"
     if [ ! -f "$NVM_SH" ]; then
         echo "Error: node $_ni_wanted required (found '${_ni_found:-none}') and nvm not found at $NVM_SH" >&2
         echo "Install Node.js or nvm before continuing." >&2

--- a/bin/node-init.sh
+++ b/bin/node-init.sh
@@ -13,7 +13,9 @@
 
 _ni_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _ni_wanted=$(cat "$_ni_root/web/.nvmrc")
-_ni_found=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+# The '|| true' matters: the callers run under 'set -eo pipefail', where a missing node
+# makes the pipeline exit 127 and takes the whole script down before the check below.
+_ni_found=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/' || true)
 
 if [ "$_ni_found" != "$_ni_wanted" ]; then
     NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"

--- a/bin/node-init.sh
+++ b/bin/node-init.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Shared Node.js initialization. Sourced (not executed) by the bin/*.sh scripts that run
+# npm/npx, so that PATH changes apply to the calling shell.
+#
+# Uses the node already on PATH only if its major version matches web/.nvmrc; otherwise
+# sources nvm and switches to that version. Matching on the version, rather than mere
+# presence, keeps a distro node at the wrong major (Ubuntu's apt 'nodejs' is commonly
+# pulled in as a dependency of something else) from shadowing the repo's Node. Sourcing
+# nvm alone is not enough either — that activates nvm's default alias, which is not
+# necessarily the version this repo wants.
+#
+# This mirrors NODE_INIT in the Makefile; keep the two in sync.
+
+_ni_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+_ni_wanted=$(cat "$_ni_root/web/.nvmrc")
+_ni_found=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+
+if [ "$_ni_found" != "$_ni_wanted" ]; then
+    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    if [ ! -f "$NVM_SH" ]; then
+        echo "Error: node $_ni_wanted required (found '${_ni_found:-none}') and nvm not found at $NVM_SH" >&2
+        echo "Install Node.js or nvm before continuing." >&2
+        exit 1
+    fi
+    # shellcheck source=/dev/null
+    source "$NVM_SH"
+    # Not in a subshell: nvm use only changes PATH for the shell it runs in.
+    nvm use --silent "$_ni_wanted"
+fi
+
+unset _ni_root _ni_wanted _ni_found

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -72,20 +72,9 @@ done
 SDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 cd "$SDIR/.."
 
-# Node.js init: source nvm if node is not already on PATH
-if ! command -v node &>/dev/null; then
-    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-    if [ ! -f "$NVM_SH" ]; then
-        echo "Error: node not found and nvm not found at $NVM_SH" >&2
-        echo "Install Node.js or nvm before running tests." >&2
-        exit 1
-    fi
-    # shellcheck source=/dev/null
-    source "$NVM_SH"
-    # Activate the version specified in web/.nvmrc. Not in a subshell: nvm use
-    # only changes PATH for the shell it runs in.
-    nvm use --silent "$(cat web/.nvmrc)"
-fi
+# Node.js init (see bin/node-init.sh)
+# shellcheck source=/dev/null
+source "$SDIR/node-init.sh"
 
 # Resolve passwords file to absolute path
 if [ -n "$PASSWORDS_FILE" ]; then

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,15 +39,12 @@ brew install go vips pkg-config
 
 ```bash
 # Install Go, vips library and pkg-config dependency (for photogen)
-sudo apt-get install golang-go libvips-dev pkg-config build-essential
-
-# HEIC/HEIF decoding (iPhone photos)
-sudo apt-get install libheif-plugin-libde265
+sudo apt-get install golang-go libvips-dev pkg-config build-essential libheif-plugin-libde265
 ```
 
-Note the package is `libvips-dev`, not `vips` — the headers are needed to compile
-`photogen`. `build-essential` supplies the C compiler that cgo requires, and is often
-already installed.
+Note the package is `libvips-dev`, not `vips` - the headers are needed to compile
+`photogen`. The `build-essential` package supplies the C compiler that `cgo` requires, and is often
+already installed. The `libheif` library is needed for HEIC/HEIF decoding (iPhone photos).
 
 #### A note on apt's Go version
 
@@ -56,13 +53,13 @@ Go 1.22). This is normally fine: Go's `GOTOOLCHAIN` defaults to `auto`, so the f
 command transparently downloads the newer toolchain and everything builds. It does mean the
 first invocation needs network access.
 
-The one thing that does not work under a downloaded toolchain is coverage — it has no
+The one thing that does not work under a downloaded toolchain is coverage - it has no
 `covdata` tool, so `go test -cover` fails with `go: no such tool "covdata"` on packages that
 have no test files. `make test` therefore omits `-cover`. If you want coverage
 (`make test-cover`), install Go from [go.dev↗](https://go.dev/doc/install) instead:
 
 ```bash
-# From the repo root — takes the version straight from go.mod
+# From the repo root - takes the version straight from go.mod
 GO_VERSION=$(awk '/^go /{print $2; exit}' go.mod)
 curl -fsSL -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz
@@ -84,7 +81,7 @@ wsl --install
 That installs Ubuntu by default. Reboot when asked, then clone the repo **inside the WSL
 filesystem** (`~/ddphotos`), not under `/mnt/c/`. Paths under `/mnt/c/` cross the 9p
 filesystem bridge, which is dramatically slower for the many small files `npm install` and
-Go builds touch, and handles symlinks and permissions differently — `bin/export.sh` builds
+Go builds touch. It handles symlinks and permissions differently: `bin/export.sh` builds
 symlink trees and `bin/docker-test.sh` relies on `chmod`.
 
 For Docker, enable Docker Desktop's WSL2 integration for the distro (Settings → Resources →
@@ -93,10 +90,6 @@ WSL Integration), or install Docker Engine inside the distro. With integration e
 
 IntelliJ has WSL support, so you can keep the IDE on the Windows side and point it at the
 project in WSL (`\\wsl$\Ubuntu\home\<you>\ddphotos`), which also gives you a bash terminal.
-
-If you only want to publish a site rather than develop the project, you don't need WSL2 at
-all — the [`ddphotos` Docker tool](DOCKER.md) runs natively on Windows and handles `C:\`
-paths.
 
 ### All platforms
 
@@ -117,7 +110,7 @@ make web-npm-install  # install npm dependencies
 make web-playwright-install  # installs Playwright + Chromium for e2e tests
 ```
 
-## Linux Oddities
+### Linux Oddities
 
 On Linux, `make web-playwright-install` fetches the browser but not the system libraries it
 links against, so a minimal install may fail at launch with a `symbol lookup error` or a
@@ -129,7 +122,7 @@ cd web && sudo env "PATH=$PATH" npx playwright install-deps chromium
 
 The `sudo env "PATH=$PATH"` is needed because plain `sudo` won't have nvm's `node` on its
 PATH. If you would rather not run `npx` under `sudo`, `sudo apt-get install libasound2t64`
-covers the common case on Ubuntu — note that it replaces `liboss4-salsa-asound2`, an OSS4
+covers the common case on Ubuntu. Note that it replaces `liboss4-salsa-asound2`, an OSS4
 compatibility stub (pulled in by some JDK packages) that provides `libasound.so.2` without
 the full ALSA API, which is enough to make Chromium fail to start.
 
@@ -139,8 +132,8 @@ CI all read them. `web/package.json` sets a matching `engines.node`, and with
 `engine-strict=true` in `web/.npmrc` an `npm install` on the wrong Node version
 fails fast rather than silently installing.
 
-If your system already provides a `node` — Ubuntu's `nodejs` package is often pulled in as a
-dependency of something else — the Makefile uses it only when its major version matches
+If your system already provides a `node` (Ubuntu's `nodejs` package is often pulled in as a
+dependency of something else) the Makefile uses it only when its major version matches
 `web/.nvmrc`, and otherwise falls back to nvm. A distro Node at the wrong version will not
 shadow the repo's.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -117,6 +117,8 @@ make web-npm-install  # install npm dependencies
 make web-playwright-install  # installs Playwright + Chromium for e2e tests
 ```
 
+## Linux Oddities
+
 On Linux, `make web-playwright-install` fetches the browser but not the system libraries it
 links against, so a minimal install may fail at launch with a `symbol lookup error` or a
 missing `.so`. Install the OS-level dependencies once:
@@ -141,6 +143,8 @@ If your system already provides a `node` — Ubuntu's `nodejs` package is often 
 dependency of something else — the Makefile uses it only when its major version matches
 `web/.nvmrc`, and otherwise falls back to nvm. A distro Node at the wrong version will not
 shadow the repo's.
+
+### Docker
 
 You may also want to install [Docker↗](https://www.docker.com/get-started/) if
 you don't have it, as it is required for testing site behavior using Apache or nginx.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,8 +71,8 @@ export PATH=$PATH:/usr/local/go/bin
 ### Windows (WSL2)
 
 The developer workflow is driven by a GNU Makefile and bash scripts, so it does not run
-natively in PowerShell. Use [WSL2↗](https://learn.microsoft.com/windows/wsl/install) with
-Ubuntu and follow the Debian/Ubuntu instructions above:
+natively in PowerShell. Set up [WSL2↗](https://learn.microsoft.com/windows/wsl/install) with
+Ubuntu:
 
 ```powershell
 wsl --install
@@ -89,7 +89,11 @@ WSL Integration), or install Docker Engine inside the distro. With integration e
 `docker` talks to Docker Desktop and bind mounts from the WSL filesystem work as expected.
 
 IntelliJ has WSL support, so you can keep the IDE on the Windows side and point it at the
-project in WSL (`\\wsl$\Ubuntu\home\<you>\ddphotos`), which also gives you a bash terminal.
+project in WSL (`\\wsl.localhost\Ubuntu\home\username\ddphotos`), which also gives you a
+bash terminal.
+
+After you have `ddphotos` cloned, follow the Debian/Ubuntu instructions above, then the
+All platforms steps below.
 
 ### All platforms
 
@@ -141,7 +145,8 @@ shadow the repo's.
 
 You may also want to install [Docker↗](https://www.docker.com/get-started/) if
 you don't have it, as it is required for testing site behavior using Apache or nginx.
-On Linux, install Docker Engine and add yourself to the `docker` group
+On Linux, install either Docker Desktop, which manages access for you, or just Docker
+Engine. For Engine, add yourself to the `docker` group
 ([post-install steps↗](https://docs.docker.com/engine/install/linux-postinstall/)) so the
 `make` targets can run it without `sudo`.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,9 +93,9 @@ project in WSL (`\\wsl.localhost\Ubuntu\home\username\ddphotos`), which also giv
 bash terminal.
 
 After you have `ddphotos` cloned, follow the Debian/Ubuntu instructions above, then the
-All platforms steps below.
+All Platforms steps below.
 
-### All platforms
+### All Platforms
 
 ```bash
 # In root of this repo, fetch Go libraries

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -26,7 +26,7 @@ account and an SSH key.
 DD Photos uses Go, Node.js, `libvips`, so they must be installed and configured first.
 Instructions are given for macOS (via [Homebrew↗](https://docs.brew.sh/Installation)) and
 Debian/Ubuntu (`apt`). Other distributions should work with equivalent package manager
-commands (`dnf`, `pacman`). Windows users should use WSL2.
+commands (`dnf`, `pacman`). Windows users should use [WSL2](#windows-wsl2).
 
 ### macOS
 
@@ -49,7 +49,56 @@ Note the package is `libvips-dev`, not `vips` — the headers are needed to comp
 `photogen`. `build-essential` supplies the C compiler that cgo requires, and is often
 already installed.
 
-### Both platforms
+#### A note on apt's Go version
+
+`apt`'s Go is frequently older than the `go` directive in `go.mod` (Ubuntu 24.04 LTS ships
+Go 1.22). This is normally fine: Go's `GOTOOLCHAIN` defaults to `auto`, so the first `go`
+command transparently downloads the newer toolchain and everything builds. It does mean the
+first invocation needs network access.
+
+The one thing that does not work under a downloaded toolchain is coverage — it has no
+`covdata` tool, so `go test -cover` fails with `go: no such tool "covdata"` on packages that
+have no test files. `make test` therefore omits `-cover`. If you want coverage
+(`make test-cover`), install Go from [go.dev↗](https://go.dev/doc/install) instead:
+
+```bash
+# From the repo root — takes the version straight from go.mod
+GO_VERSION=$(awk '/^go /{print $2; exit}' go.mod)
+curl -fsSL -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz
+
+# Add to your shell profile (~/.zshrc or ~/.bashrc)
+export PATH=$PATH:/usr/local/go/bin
+```
+
+### Windows (WSL2)
+
+The developer workflow is driven by a GNU Makefile and bash scripts, so it does not run
+natively in PowerShell. Use [WSL2↗](https://learn.microsoft.com/windows/wsl/install) with
+Ubuntu and follow the Debian/Ubuntu instructions above:
+
+```powershell
+wsl --install
+```
+
+That installs Ubuntu by default. Reboot when asked, then clone the repo **inside the WSL
+filesystem** (`~/ddphotos`), not under `/mnt/c/`. Paths under `/mnt/c/` cross the 9p
+filesystem bridge, which is dramatically slower for the many small files `npm install` and
+Go builds touch, and handles symlinks and permissions differently — `bin/export.sh` builds
+symlink trees and `bin/docker-test.sh` relies on `chmod`.
+
+For Docker, enable Docker Desktop's WSL2 integration for the distro (Settings → Resources →
+WSL Integration), or install Docker Engine inside the distro. With integration enabled,
+`docker` talks to Docker Desktop and bind mounts from the WSL filesystem work as expected.
+
+IntelliJ has WSL support, so you can keep the IDE on the Windows side and point it at the
+project in WSL (`\\wsl$\Ubuntu\home\<you>\ddphotos`), which also gives you a bash terminal.
+
+If you only want to publish a site rather than develop the project, you don't need WSL2 at
+all — the [`ddphotos` Docker tool](DOCKER.md) runs natively on Windows and handles `C:\`
+paths.
+
+### All platforms
 
 ```bash
 # In root of this repo, fetch Go libraries
@@ -67,6 +116,20 @@ make web-npm-install  # install npm dependencies
 # Optional: Install playwright dependencies if running e2e tests
 make web-playwright-install  # installs Playwright + Chromium for e2e tests
 ```
+
+On Linux, `make web-playwright-install` fetches the browser but not the system libraries it
+links against, so a minimal install may fail at launch with a `symbol lookup error` or a
+missing `.so`. Install the OS-level dependencies once:
+
+```bash
+cd web && sudo env "PATH=$PATH" npx playwright install-deps chromium
+```
+
+The `sudo env "PATH=$PATH"` is needed because plain `sudo` won't have nvm's `node` on its
+PATH. If you would rather not run `npx` under `sudo`, `sudo apt-get install libasound2t64`
+covers the common case on Ubuntu — note that it replaces `liboss4-salsa-asound2`, an OSS4
+compatibility stub (pulled in by some JDK packages) that provides `libasound.so.2` without
+the full ALSA API, which is enough to make Chromium fail to start.
 
 The `web/.nvmrc` (Node major version) and `web/.npm-version` (exact npm version) files are the
 single sources of truth for the toolchain versions - the Makefile, Docker build and


### PR DESCRIPTION
Walked through docs/INSTALL.md as a new user on WSL2 (Ubuntu 24.04) and fixed what broke along the way.

Node shadowing: bin/run-tests.sh, bin/docker-test.sh and bin/deploy-photos.sh each did their own nvm setup keyed on whether *any* node was on PATH, so Ubuntu's apt node (v18) was used instead of the repo's Node 24 and the build failed in rolldown on a missing node:util export. PR #92 fixed this rule in the Makefile but not in these scripts. They now share bin/node-init.sh, which applies the same major-version match as NODE_INIT. deploy-photos.sh was worse: it sourced nvm without `nvm use`, silently taking nvm's default alias.

Coverage: `go test -cover` needs the covdata tool, which a toolchain fetched via GOTOOLCHAIN auto-download does not ship, so it fails with `no such tool "covdata"` on packages with no test files. That triggers wherever the installed Go is older than go.mod's directive, e.g. Ubuntu 24.04's Go 1.22. `make test` now omits -cover; coverage moves to a new `make test-cover`, which CI runs since setup-go installs a full distribution.

Docs: add a Windows (WSL2) section to docs/INSTALL.md, a note on apt's Go version, and Playwright system-library guidance (a minimal Ubuntu can have libasound.so.2 supplied by the OSS4 stub liboss4-salsa-asound2, which lacks the full ALSA API and stops Chromium from launching). CLAUDE.md documents node-init.sh as the shell counterpart to NODE_INIT.

Verified on WSL2: build, vet, test, test-cover, sample-photogen, sample-build, dev server, web-sanity-test, sample-test-apache/nginx (22/22 each) and docker-test all pass. Docker Desktop WSL2 bind mounts work, including /tmp.