### PR TITLE
Improve CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-libde265 pkg-config
+        # Via bin/ci-apt-install.sh rather than a bare apt-get: GitHub's runner images pin
+        # their mirror to azure.archive.ubuntu.com, which stalls this step periodically
+        # (once for 66 minutes, until the job timeout killed it). The script bounds apt's
+        # timeouts, retries, and falls back to archive.ubuntu.com. See its header.
+        run: bash bin/ci-apt-install.sh libvips-dev libheif-plugin-libde265 pkg-config
 
       - name: Install ffmpeg
         # The same pinned static build the Docker image fetches on demand, rather than
@@ -72,10 +76,13 @@ jobs:
         run: make web-lint
 
       - name: Install Playwright Chromium
+        # Deliberately no `npx playwright install-deps chromium` here. That runs apt-get
+        # under the hood and was the most frequent victim of the flaky Azure mirror (up to
+        # 479s in a job with no apt step of its own). The ubuntu-latest image preinstalls
+        # Chrome and Firefox, so Chromium's shared libraries are already present. If a
+        # future runner image drops them, this fails loudly at browser launch, not subtly.
+        # (docs/INSTALL.md still documents install-deps for minimal Linux installs.)
         run: make web-playwright-install
-
-      - name: Install Playwright system dependencies
-        run: cd web && npx playwright install-deps chromium
 
       - name: Photogen and build
         run: make sample-photogen sample-build
@@ -99,19 +106,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-libde265 pkg-config
+        # Via bin/ci-apt-install.sh rather than a bare apt-get: GitHub's runner images pin
+        # their mirror to azure.archive.ubuntu.com, which stalls this step periodically
+        # (once for 66 minutes, until the job timeout killed it). The script bounds apt's
+        # timeouts, retries, and falls back to archive.ubuntu.com. See its header.
+        run: bash bin/ci-apt-install.sh libvips-dev libheif-plugin-libde265 pkg-config
 
       - name: Install ffmpeg
-        # The same pinned static build the Docker image fetches on demand, rather than
-        # `apt-get install ffmpeg`: the Debian package pulls ~200 packages and 448MB of
-        # SDL2/X11 via ffplay, which is both slow and a large surface for a flaky apt
-        # mirror to stall on. This is one checksum-verified GitHub download of two
-        # executables. photogen finds them via DDPHOTOS_FFMPEG_DIR (pkg/photogen/video.go).
-        #
-        # Installed under RUNNER_TEMP so the binaries stay out of the checkout. Set here
-        # rather than in a job-level `env:` block because the `runner` context is not
-        # available there; GITHUB_ENV carries it to the later steps, and the local export
-        # covers this step, which GITHUB_ENV does not.
+        # Static build rather than `apt-get install ffmpeg`; see the 'test' job above.
         run: |
           export DDPHOTOS_FFMPEG_DIR="$RUNNER_TEMP/ffmpeg"
           echo "DDPHOTOS_FFMPEG_DIR=$DDPHOTOS_FFMPEG_DIR" >> "$GITHUB_ENV"
@@ -139,10 +141,8 @@ jobs:
         run: cd web && npm ci
 
       - name: Install Playwright Chromium
+        # Deliberately no `npx playwright install-deps chromium`; see the 'test' job above.
         run: make web-playwright-install
-
-      - name: Install Playwright system dependencies
-        run: cd web && npx playwright install-deps chromium
 
       - name: Photogen and build
         run: make sample-photogen sample-build
@@ -182,10 +182,8 @@ jobs:
         run: cd web && npm ci
 
       - name: Install Playwright Chromium
+        # Deliberately no `npx playwright install-deps chromium`; see the 'test' job above.
         run: make web-playwright-install
-
-      - name: Install Playwright system dependencies
-        run: cd web && npx playwright install-deps chromium
 
       - name: Run Docker workflow tests
         run: make docker-test

--- a/bin/ci-apt-install.sh
+++ b/bin/ci-apt-install.sh
@@ -18,6 +18,13 @@
 # mirror is much faster than archive.ubuntu.com from inside Azure when it is healthy, so
 # switching unconditionally would slow down every green run to fix the rare red one.
 #
+# The `timeout` wrapper is the part that actually catches the common case, and it is not
+# redundant with Acquire::*::Timeout. A degraded Azure mirror does not fail, it *trickles*:
+# a PR run measured here spent 199s on this step with a dozen 8-15s stalls mid-download,
+# every one of which recovered. apt returned success, so retries and per-connection
+# timeouts both stayed dormant while the step ran 7x long. Bounding total wall time is the
+# only thing that converts that into a mirror swap instead of a 30-minute job timeout.
+#
 # The apt.conf.d drop-in is written globally rather than passed as -o flags, so that
 # anything else in the job that shells out to apt inherits it too (`npx playwright
 # install-deps` did, before it was dropped from the workflow).
@@ -39,16 +46,27 @@ Acquire::https::Timeout "20";
 Acquire::ForceIPv4 "true";
 EOF
 
+# Per phase, not for the script as a whole. 240s sits above the worst run that still
+# finished on its own (199s) and below the ones that did not (312s, 3943s), so a merely
+# sluggish mirror is ridden out and a broken one is cut off. Override with APT_TIMEOUT.
+# `sudo timeout` rather than `timeout sudo`: the signal has to reach apt-get, not sudo.
+APT_TIMEOUT="${APT_TIMEOUT:-240}"
+
 apt_install() {
-    sudo apt-get update
-    sudo apt-get install -y "$@"
+    sudo timeout "$APT_TIMEOUT" apt-get update
+    sudo timeout "$APT_TIMEOUT" apt-get install -y "$@"
 }
 
 if apt_install "$@"; then
     exit 0
 fi
 
-echo "::warning::apt failed against azure.archive.ubuntu.com; retrying via archive.ubuntu.com"
+echo "::warning::apt failed or exceeded ${APT_TIMEOUT}s against azure.archive.ubuntu.com; retrying via archive.ubuntu.com"
+
+# A timeout can land mid-unpack, which leaves dpkg wedged and makes the retry fail with
+# "dpkg was interrupted" before it ever reaches the network. Cheap to run, no-op otherwise.
+sudo dpkg --configure -a || true
+
 for f in "${SOURCES_FILES[@]}"; do
     if [[ -f "$f" ]]; then
         sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' "$f"

--- a/bin/ci-apt-install.sh
+++ b/bin/ci-apt-install.sh
@@ -36,7 +36,15 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
-# Ubuntu 24.04 runners use the deb822 format; older ones use the one-line sources.list.
+# GitHub's runner images do not name the mirror host in ubuntu.sources at all. They point
+# it at `mirror+file:/etc/apt/apt-mirrors.txt`, a priority-ordered list with Azure first
+# and archive.ubuntu.com already present below it. That fallback is useless to us on its
+# own: apt's mirror method only advances down the list on a hard failure, never on
+# slowness, which is the mode that actually bites here. So the Azure line has to be
+# removed outright rather than merely deprioritised.
+MIRRORLIST=/etc/apt/apt-mirrors.txt
+
+# Older images (and anything not using a mirrorlist) do name the host directly.
 SOURCES_FILES=(/etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list)
 
 sudo tee /etc/apt/apt.conf.d/99-ci-flaky-mirror >/dev/null <<'EOF'
@@ -67,10 +75,32 @@ echo "::warning::apt failed or exceeded ${APT_TIMEOUT}s against azure.archive.ub
 # "dpkg was interrupted" before it ever reaches the network. Cheap to run, no-op otherwise.
 sudo dpkg --configure -a || true
 
+if [[ -f "$MIRRORLIST" ]] && grep -q 'azure\.archive\.ubuntu\.com' "$MIRRORLIST"; then
+    echo "--- $MIRRORLIST before ---"
+    cat "$MIRRORLIST"
+    # Only drop the Azure entry if the list still has somewhere else to fetch from.
+    if grep -v 'azure\.archive\.ubuntu\.com' "$MIRRORLIST" | grep -q '://'; then
+        sudo sed -i '/azure\.archive\.ubuntu\.com/d' "$MIRRORLIST"
+    else
+        echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee "$MIRRORLIST" >/dev/null
+    fi
+    echo "--- $MIRRORLIST after ---"
+    cat "$MIRRORLIST"
+fi
+
 for f in "${SOURCES_FILES[@]}"; do
     if [[ -f "$f" ]]; then
         sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' "$f"
     fi
 done
+
+# Force the retry's `apt-get update` to genuinely re-fetch its indexes from the new mirror
+# rather than reporting Hit off the old ones. The lists are keyed by the mirrorlist URI,
+# not the mirror it resolves to, so editing the list alone would not invalidate them, and a
+# timeout during the update phase can leave a half-written index behind.
+#
+# Deliberately no `apt-get clean`: already-downloaded .debs are checksum-verified against
+# the new indexes, so reusing them is safe and saves re-fetching them over the slower mirror.
+sudo rm -rf /var/lib/apt/lists/*
 
 apt_install "$@"

--- a/bin/ci-apt-install.sh
+++ b/bin/ci-apt-install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Installs apt packages on a GitHub-hosted runner, defensively.
+#
+# GitHub's Ubuntu runner images pin their apt mirror to azure.archive.ubuntu.com, which
+# every GitHub-hosted Linux runner shares and which degrades periodically. Two of apt's
+# defaults turn that into a job-killing stall rather than a quick error:
+#
+#   * Acquire::Retries defaults to 0, so a single failed fetch fails the whole run.
+#   * Acquire::*::Timeout is an *inactivity* timeout, so a mirror that trickles a few
+#     bytes at a time never trips it.
+#
+# Observed here: this step normally takes ~20s, but has taken 312s, and once 3943s (66
+# minutes) before the job hit its timeout-minutes and was killed.
+#
+# So: bound the wait, retry a few times, and if the Azure mirror is still unusable, fall
+# back to archive.ubuntu.com. The fallback is deliberately *only* a fallback. The Azure
+# mirror is much faster than archive.ubuntu.com from inside Azure when it is healthy, so
+# switching unconditionally would slow down every green run to fix the rare red one.
+#
+# The apt.conf.d drop-in is written globally rather than passed as -o flags, so that
+# anything else in the job that shells out to apt inherits it too (`npx playwright
+# install-deps` did, before it was dropped from the workflow).
+#
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $0 <package> [package ...]" >&2
+    exit 1
+fi
+
+# Ubuntu 24.04 runners use the deb822 format; older ones use the one-line sources.list.
+SOURCES_FILES=(/etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list)
+
+sudo tee /etc/apt/apt.conf.d/99-ci-flaky-mirror >/dev/null <<'EOF'
+Acquire::Retries "5";
+Acquire::http::Timeout "20";
+Acquire::https::Timeout "20";
+Acquire::ForceIPv4 "true";
+EOF
+
+apt_install() {
+    sudo apt-get update
+    sudo apt-get install -y "$@"
+}
+
+if apt_install "$@"; then
+    exit 0
+fi
+
+echo "::warning::apt failed against azure.archive.ubuntu.com; retrying via archive.ubuntu.com"
+for f in "${SOURCES_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' "$f"
+    fi
+done
+
+apt_install "$@"

--- a/bin/ci-apt-install.sh
+++ b/bin/ci-apt-install.sh
@@ -54,11 +54,16 @@ Acquire::https::Timeout "20";
 Acquire::ForceIPv4 "true";
 EOF
 
-# Per phase, not for the script as a whole. 240s sits above the worst run that still
-# finished on its own (199s) and below the ones that did not (312s, 3943s), so a merely
-# sluggish mirror is ridden out and a broken one is cut off. Override with APT_TIMEOUT.
+# Per phase, not for the script as a whole. Override with APT_TIMEOUT.
+#
+# 120s is deliberately aggressive. It started at 240s, chosen to ride out a sluggish mirror
+# rather than swap, but measurement showed that reasoning was backwards: when the fallback
+# fired in CI, archive.ubuntu.com finished the whole install in 47-100s, i.e. *faster* than
+# a degraded Azure manages. Swapping is cheap, so waiting to avoid it is the expensive
+# choice. 120s still leaves 4x headroom over a healthy run (~20-30s).
+#
 # `sudo timeout` rather than `timeout sudo`: the signal has to reach apt-get, not sudo.
-APT_TIMEOUT="${APT_TIMEOUT:-240}"
+APT_TIMEOUT="${APT_TIMEOUT:-120}"
 
 apt_install() {
     sudo timeout "$APT_TIMEOUT" apt-get update


### PR DESCRIPTION
## Problem

CI regularly stalls fetching from `azure.archive.ubuntu.com`, sometimes until the job hits
its `timeout-minutes` and is killed. Measured on `main`:

| Run | Job | Step | Duration |
|---|---|---|---|
| 32190537610 | test | Install system dependencies | 21s (healthy baseline) |
| 32170147690 | test-nginx-s3 | Install system dependencies | 312s |
| 32160378973 | test-nginx-s3 | Install system dependencies | **3943s** (66 min, job cancelled) |
| 32170147690 | test-docker | Playwright system dependencies | 479s |
| 32275706406 | test-docker | Playwright system dependencies | 291s |

## Root cause

`azure.archive.ubuntu.com` is the mirror baked into GitHub's runner images and shared by
every GitHub-hosted Linux runner, so it degrades periodically. Nothing in this repo causes
it, but two apt defaults turn a slow mirror into a job-killing stall:

- `Acquire::Retries` defaults to 0, so one failed fetch fails the run.
- `Acquire::*::Timeout` is an *inactivity* timeout, so a mirror that trickles a few bytes
  at a time never trips it.

We had six apt invocations across three jobs. Only two were ours; the other three were
`npx playwright install-deps chromium`, which shells out to apt internally. That is why
`test-docker` stalled despite having no apt step of its own.

## Changes

**1. New `bin/ci-apt-install.sh`, used by both `Install system dependencies` steps.**

- Writes an `apt.conf.d` drop-in: `Retries 5`, 20s http/https timeouts, `ForceIPv4`.
  Global rather than `-o` flags so anything else shelling out to apt inherits it.
- Wraps each apt phase in `timeout` (120s, overridable via `APT_TIMEOUT`). This is the part
  that catches the real failure mode, and it is not redundant with `Acquire::*::Timeout`.
  The bound started at 240s and was lowered after measurement: see below.
- On failure or timeout: emits a `::warning::`, runs `dpkg --configure -a` in case the
  timeout landed mid-unpack, drops the Azure entry from `/etc/apt/apt-mirrors.txt` (see
  below), clears `/var/lib/apt/lists/*` so the retry's `apt-get update` genuinely re-fetches,
  and retries once. It also rewrites the host in `ubuntu.sources` / `sources.list` for
  images that name it directly rather than via a mirrorlist.

The mirror swap is deliberately a fallback only. Azure's mirror is much faster from inside
Azure when healthy, so switching unconditionally would slow every green run to fix the
occasional red one.

**2. Dropped all three `npx playwright install-deps chromium` steps.**

`ubuntu-latest` preinstalls Chrome and Firefox, so Chromium's shared libraries are already
present. If a future runner image drops them this fails loudly at browser launch, not
subtly. `docs/INSTALL.md` still documents `install-deps` for minimal Linux installs, where
it is still the right advice.

Net: apt invocations drop from six to two, and `test-docker` now touches apt zero times.

Also collapsed the duplicated `Install ffmpeg` and Playwright comment blocks so the full
rationale lives once in the `test` job.

## Evidence

**Run 32280485563** (all green) confirmed the `install-deps` removal: no `symbol lookup
error`, no `libasound`, no Playwright "host system is missing dependencies" anywhere in the
log, and e2e timings match baseline.

| Step | Baseline (32190537610) | This branch |
|---|---|---|
| Apache e2e, all variants | 418s | 411s |
| nginx e2e, all variants | 406s | 432s |
| `make docker-test` | 249s | 247s |

That run also captured the failure mode directly. `test` spent 199s on
`Install system dependencies` versus 28s for `test-nginx-s3` on an identical package list,
with a dozen 8-15s stalls mid-download that all recovered. apt returned success, so retries
and per-connection timeouts both stayed dormant. Only bounding total wall time converts
that into a mirror swap, which is why the `timeout` wrapper was added on top of the initial
retry work.

**Run 32285207141** (all green) exercised the fallback for real. `test-nginx-s3` hit the
240s bound and swapped:

```
18:11:27 ##[warning]apt failed or exceeded 240s ... retrying via archive.ubuntu.com
18:11:27 Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
18:11:27 Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
```

The bound worked (339s, not a 30-minute job timeout), but the retry went straight back to
Azure. GitHub's runner images do not name the mirror host in `ubuntu.sources`; they point it
at `mirror+file:/etc/apt/apt-mirrors.txt`. The original `sed` had nothing to match and was a
silent no-op, and the retry only passed because `/var/cache/apt/archives` was warm from the
first attempt. Fixed by editing the mirrorlist itself and clearing the package lists before
the retry.

Note that apt's mirrorlist already lists `archive.ubuntu.com` below Azure. That is not a
substitute for this: apt's mirror method advances down the list only on a hard failure,
never on slowness, which is the mode that actually bites here.

**Run 32288332732** (all green) confirms the corrected fallback. Azure was degraded for a
sustained stretch, so both apt jobs hit the bound and swapped:

```
--- /etc/apt/apt-mirrors.txt before ---
http://azure.archive.ubuntu.com/ubuntu/   priority:1
https://archive.ubuntu.com/ubuntu/        priority:2
https://security.ubuntu.com/ubuntu/       priority:3
--- /etc/apt/apt-mirrors.txt after ---
https://archive.ubuntu.com/ubuntu/        priority:2
https://security.ubuntu.com/ubuntu/       priority:3
```

Mirror references across the run went from 404 Azure / 1 archive in the previous run to 386
archive / 160 azure, so the retry genuinely re-fetched from the new mirror. `Install system
dependencies` came in at 341s and 287s, i.e. the then-240s bound plus a ~50-100s recovery,
versus an unbounded 3943s before this PR.

That recovery time is what prompted lowering the bound to 120s. `archive.ubuntu.com`
finished the entire install in 47-100s, i.e. faster than a degraded Azure manages, so
swapping is cheap and waiting to avoid it is the expensive choice. The original 240s was
picked to ride out a sluggish mirror rather than swap, which the data shows was backwards.
120s still leaves 4x headroom over a healthy run (~20-30s).

**Run 32290420534** (all green) is the no-regression check on the 120s bound. Azure had
partly recovered, so both apt steps finished under the bound without swapping (88s and 60s)
and no warning was emitted. That is the intended behaviour: a moderately slow mirror is
ridden out, only a badly broken one triggers the swap.

## Considered and rejected

`cache-apt-pkgs-action`: it cannot intercept Playwright's internal apt call, which was the
more frequent victim; a cache miss still hits the mirror; and it restores files from a
tarball without replaying dpkg triggers or `ldconfig`, so a bad restore of
`libheif-plugin-libde265` would break HEIC decode silently rather than failing the step.

Running the jobs in a `container:` with the deps baked in would eliminate apt entirely, but
all three jobs drive Docker, so it means docker-in-docker to save ~30s on a good day.
