### PR TITLE
Allow HTML in captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Website features:
 - Each photo has a shareable permalink (e.g., `/albums/patagonia/5`) accessible via a copy-to-clipboard button.
 - Optional hero image: a full-width banner at the top of the home page, specified in
   `albums.yaml` with a configurable crop position (top/center/bottom).
-- Optional `HTML` title, subtitle, and site overview.
+- Optional `HTML` title, subtitle, and site overview. Photo captions accept inline
+  `HTML` too, including links (clickable in the lightbox).
 - Optional password protection: encrypt individual albums or the entire site. Passwords
   are never stored server-side, decryption happens in-browser using the Web Crypto API.
   Optional hints can be shown in the password dialog. A logout button clears stored

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ too, which is why I've open-sourced it.
 
 ## Overview
 
-A DD Photos [site]([site↗](https://ddphotos.donohoe.info)) has a home page, with all of your albums,
+A DD Photos [site↗](https://ddphotos.donohoe.info) has a home page, with all of your albums,
 and their description. You can easily switch between dark and light themes.  Click/touch an 
 album, and you see a grid of all photos/videos.  Click/touch a photo/video to see the full size version and
 a caption, if it has one. You can easily swipe between photos/video (or use arrow keys on a laptop).
@@ -132,7 +132,7 @@ Website features:
   passwords on encrypted sites.
 - Dark/light theme toggle.
 - Custom CSS override: specify a CSS file in `albums.yaml` to restyle the site without
-  modifying the source code.
+  modifying the source code (see [Custom CSS](docs/CUSTOM-CSS.md)).
 - OpenGraph tags for rich link previews when sharing album or photo URLs on social media
   or messaging apps. The hero image (if configured) or an album cover JPEG is used as
   the preview image.
@@ -186,6 +186,7 @@ These documents are primarily meant for users of DD Photos:
 | [Docker Mode](docs/DOCKER.md)                          | Docker workflow: init, photogen, run, build, serve, deploy, upgrade                  |
 | [Configuration](docs/CONFIGURATION.md)                 | `albums.yaml`, `customization.yaml`, `site.env`, and how config reaches the frontend |
 | [Photogen](docs/PHOTOGEN.md)                           | `photogen` CLI: flags, photo descriptions, video, recursive albums                   |
+| [Custom CSS](docs/CUSTOM-CSS.md)                       | Restyling the site: custom properties, class names, specificity, examples            |
 | [Rebuilding a Site](docs/SCRAPE.md)                    | Turn a deployed site back into a config directory you can build                      |
 | [Deployment](docs/DEPLOY.md)                           | Deployment via rsync and S3+CloudFront                                               |
 | [Web Server Configuration](docs/DEPLOYMENT-SERVERS.md) | Apache, nginx, CloudFront, and Cloudflare Pages routing rules                        |

--- a/docker/init/config/custom.css
+++ b/docker/init/config/custom.css
@@ -6,6 +6,10 @@
  *
  * This example colors the .accent class differently per theme.
  * Used in site_overview_html: Welcome to my <span class="accent">photo gallery</span>.
+ *
+ * Full guide — available custom properties, the class names worth targeting, and why
+ * some overrides need !important:
+ * https://github.com/dougdonohoe/ddphotos/blob/main/docs/CUSTOM-CSS.md
  */
 
 [data-theme="light"] .accent {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -182,6 +182,11 @@ site-wide as a `<link>` after the built-in styles, so any rules inside it take e
 normal cascade overrides. Redefining CSS custom properties (e.g. `--bg-color`,
 `--text-color-2nd`) is the cleanest approach — no specificity battles needed.
 
+See **[Custom CSS](CUSTOM-CSS.md)** for the full guide: the available custom properties,
+the class names worth targeting, why some overrides need `!important` (Svelte scopes most
+built-in rules, which raises their specificity above yours), how to iterate in about a
+second without reprocessing photos, and worked examples.
+
 ### Password Protection
 
 Encryption is enabled by adding a `passwords:` entry under `settings:` pointing to a

--- a/docs/CUSTOM-CSS.md
+++ b/docs/CUSTOM-CSS.md
@@ -1,0 +1,482 @@
+# Custom CSS
+
+DD Photos ships one styling hook: a single CSS file of your own, injected site-wide after
+the built-in styles. It is enough to recolor the site, restyle album cards, or change how
+captions look, without forking the code.
+
+This page covers how to turn it on, how to iterate on it, and — the part that trips people
+up — how to write a rule that actually wins against the built-in one.
+
+- [Turning it on](#turning-it-on)
+- [The edit/see-it loop](#the-editsee-it-loop)
+- [Themes](#themes)
+- [Level 1: redefine a custom property](#level-1-redefine-a-custom-property)
+- [Level 2: override a rule](#level-2-override-a-rule)
+- [Finding what to target](#finding-what-to-target)
+- [Element reference](#element-reference)
+- [Worked examples](#worked-examples)
+- [Gotchas](#gotchas)
+
+---
+
+## Turning it on
+
+Name your file in `albums.yaml` under `settings:`, as a path relative to the config
+directory:
+
+```yaml
+settings:
+  css: custom.css
+```
+
+`photogen` copies it to the site output as `custom.css`, and the frontend injects it on
+every page:
+
+```html
+<link rel="stylesheet" href="/albums/custom.css" />
+```
+
+That `<link>` comes **after** the built-in styles, which matters for the cascade — see
+[Level 2](#level-2-override-a-rule).
+
+The file is never encrypted, even on a password-protected site. Do not put anything
+private in a comment.
+
+The `-css` flag overrides `settings.css` at run time, which is how the sample site and the
+`custom-css` test variant inject
+[`sample/config/custom-example.css`](../sample/config/custom-example.css) without
+committing it into `albums.yaml`:
+
+```bash
+bin/photogen -css sample/config/custom-example.css -index -doit
+```
+
+Docker mode's `ddphotos init` writes a starter
+[`config/custom.css`](../docker/init/config/custom.css) and already points `settings.css`
+at it, so you can start editing immediately.
+
+## The edit/see-it loop
+
+The browser reads the **copy** in the albums output directory, not your config file, so an
+edit is not live until `photogen` copies it across. The copy happens during index
+generation, so you can skip resizing entirely and get a sub-second turnaround:
+
+```bash
+./ddphotos photogen -- -index -doit    # Docker mode
+bin/photogen -index -doit              # developer mode
+```
+
+> Docker mode note: `ddphotos photogen` with no extra arguments adds `-doit` for you, but
+> passing your own flags after `--` does not, so include `-doit` yourself. Without it, you
+> get a dry run that reports `DRYRUN: would copy ... custom.css` and writes nothing.
+
+Then reload the page. Both the dev server and a built site serve the file from
+`/albums/custom.css`, so no restart or rebuild is needed. If your browser holds on to an
+old copy, hard-refresh.
+
+## Themes
+
+The theme is an attribute on `<html>`, set by the theme toggle:
+
+| Theme | Selector                    |
+|-------|-----------------------------|
+| Dark  | `:root[data-theme="dark"]`  |
+| Light | `:root[data-theme="light"]` |
+
+Dark is the default: the base values live on a bare `:root`, and the light theme redefines
+them under `:root[data-theme='light']`. Write your own rules the same way — put the value
+you want most of the time on `:root`, then override it for light:
+
+```css
+:root {
+    --text-color-2nd: #2a9d8f;
+}
+
+:root[data-theme='light'] {
+    --text-color-2nd: #1b6b62;
+}
+```
+
+**Set both, or you will only change one theme.** All nine palette properties below are
+defined twice by the built-in styles: once on `:root` and again on
+`:root[data-theme='light']`. The second selector is more specific, so a custom rule that
+only sets `:root` is overridden in light mode and appears to do nothing there. This is the
+single most common reason a color override "only half works".
+
+That trap is specific to the palette. For anything that is not one of those properties, a
+rule with no theme selector applies to both themes, which is usually what you want.
+
+## Level 1: redefine a custom property
+
+This is the path to reach for first. The site's palette is a handful of CSS custom
+properties on `:root`, and redefining one changes every place it is used at once. There is
+no specificity fight, because you are not overriding a rule — you are changing an input to
+one.
+
+| Property            | Used for                                                                  |
+|---------------------|---------------------------------------------------------------------------|
+| `--bg-color`        | Page background                                                           |
+| `--bg-secondary`    | Raised surfaces: album cards, modals, the back-to-top button              |
+| `--text-color`      | Body text                                                                 |
+| `--text-color-2nd`  | The accent (gold by default): album descriptions on cards and album pages |
+| `--text-muted`      | De-emphasized text: photo counts, date ranges, the footer                 |
+| `--border-color`    | Card and modal borders, dividers                                          |
+| `--shadow-color`    | Box shadows                                                               |
+| `--link-color`      | Default link color site-wide                                              |
+| `--img-placeholder` | The block of color behind a photo before it fades in                      |
+
+Two more are worth knowing about:
+
+| Property        | Effect                                                                                                                         |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `--focus-color` | Outline color on a focused grid tile. Read with a `#0066cc` fallback and never defined, so it exists purely for you to set     |
+| `--pswp-bg`     | Lightbox backdrop, PhotoSwipe's own variable. Set to `#000` on `.pswp` (not `:root`), so override it as `.pswp { --pswp-bg: }` |
+
+## Level 2: override a rule
+
+When no custom property covers what you want, you target a class directly. This is where
+custom CSS gets confusing, and the reason is worth understanding rather than working around
+by sprinkling `!important` everywhere.
+
+### Why a rule can lose despite coming last
+
+The site is built with Svelte, which **scopes** component styles by appending a generated
+class to the selector. A rule written in the source as:
+
+```css
+.album-card {
+    border-radius: 8px;
+}
+```
+
+is compiled to:
+
+```css
+.album-card.svelte-1uha8ag {
+    border-radius: 8px;
+}
+```
+
+That is two classes, not one. Your `.album-card { ... }` is one class, so it loses on
+specificity no matter that `custom.css` is injected afterward. Source order only breaks
+ties between rules of *equal* specificity.
+
+Not every built-in rule is scoped, though. Rules the source marks `:global(...)` compile
+with no added class, and those you can override with a plain matching selector:
+
+| Written in the source     | Compiles to                     | Beat it with                        |
+|---------------------------|---------------------------------|-------------------------------------|
+| `.album-card`             | `.album-card.svelte-HASH`       | `!important`, or add specificity    |
+| `:global(.pswp-caption)`  | `.pswp-caption`                 | the same selector — you come later  |
+
+A useful shortcut: everything belonging to the **lightbox** (`.pswp*`, `.pswp-caption`,
+`.pswp-video`) is global and easy to override. Everything in the **page** (`.album-card`,
+`.gallery`, `.photo`, `.photo-caption`, `.hero`) is scoped and needs help.
+
+Two further wrinkles worth knowing:
+
+- **Descendants cost nothing.** Svelte tags descendant parts of a selector with
+  `:where(.svelte-HASH)`, which adds zero specificity. So `.photo:hover .photo-caption`
+  compiles to `.photo.svelte-HASH:hover .photo-caption:where(.svelte-HASH)` — the extra
+  class lands on `.photo` only.
+- **Setting a property nobody set is free.** Specificity only decides between rules
+  competing for the *same* property. If no built-in rule sets `display` on an element,
+  your low-specificity rule setting `display` wins by default. This is why the caption
+  example below needs no `!important`.
+
+### How to win
+
+In order of preference:
+
+1. **Redefine a custom property** ([Level 1](#level-1-redefine-a-custom-property)). No
+   contest at all.
+2. **Use an `id`.** An id outranks any number of classes. `album_nav` links accept an `id:`
+   in `customization.yaml` for exactly this reason — see
+   [album_nav](CONFIGURATION.md#album_nav).
+3. **Repeat the class.** `.album-card.album-card { ... }` is valid CSS that matches the
+   same elements while counting as two classes, which ties the built-in
+   `.album-card.svelte-HASH` — and a tie goes to whichever came last, which is you. Add a
+   third repeat if you are up against a `:hover` rule.
+4. **Reach for `!important`.** It always works, but it also means the next rule you write
+   for the same element has to escalate too. Fine as a targeted tool, unpleasant as a habit.
+
+### Watch the pseudo-classes
+
+A `:hover` or `:focus-visible` rule carries one more class of specificity than its base
+rule, so overriding the base is not enough — the hover rule still wins on hover. Repeat the
+pseudo-class in your override:
+
+```css
+.pswp-caption a,
+.pswp-caption a:hover,
+.pswp-caption a:focus-visible {
+    text-decoration-thickness: 1px;
+}
+```
+
+Without the last two selectors the underline would snap back to the built-in thickness the
+moment the pointer touched it.
+
+## Finding what to target
+
+Open the site, right-click the thing you want to change, and choose **Inspect**. In the
+Styles panel you will see the winning rule and its selector — including the
+`.svelte-HASH` part if it is scoped, which tells you immediately which of the two cases
+above you are in. Write your selector without the hash.
+
+You can also test a rule live: edit it in DevTools until it looks right, then paste it into
+`custom.css`. If a property shows struck through in DevTools, something more specific is
+beating it.
+
+## Element reference
+
+The class names below are stable and safe to target. Anything not listed here is an
+implementation detail that may be renamed.
+
+**Scoped?** answers "will a plain one-class selector lose?" A `yes` means the built-in
+rules carry at least one extra class of specificity — sometimes on the element itself
+(`.album-card.svelte-HASH`), sometimes on an ancestor (`header.svelte-HASH
+.site-subtitle`). Either way you need one of the tactics in
+[How to win](#how-to-win). A `no` means a matching selector is enough, because
+`custom.css` comes later.
+
+**Targeting one album or one photo.** Two data attributes exist for this, and both add a
+point of specificity for free:
+
+| Attribute                  | On            | Example                              |
+|----------------------------|---------------|--------------------------------------|
+| `data-slug="<album-slug>"` | `.album-card` | `.album-card[data-slug='patagonia']` |
+| `data-index="<0-based>"`   | `.photo`      | `.photo[data-index='0']`             |
+
+**Site chrome (every page):**
+
+| Selector                   | Element                                              | Scoped? |
+|----------------------------|------------------------------------------------------|---------|
+| `.top-controls`            | Container for the theme toggle and logout button     | yes     |
+| `.theme-toggle`            | Dark/light toggle button                             | yes     |
+| `.control-btn`             | Logout button on encrypted sites                     | yes     |
+| `footer`                   | Site footer                                          | yes     |
+| `.footer-link`             | Links in the footer (Privacy, source)                | yes     |
+| `.about-btn`               | "About this site" button in the footer               | yes     |
+| `.back-to-top`             | Floating back-to-top button                          | yes     |
+| `.modal`, `.modal-overlay` | The About dialog                                     | yes     |
+
+**Home page:**
+
+| Selector                    | Element                                        | Scoped? |
+|-----------------------------|------------------------------------------------|---------|
+| `.hero`, `.hero-overlay`    | Hero banner and the text laid over it          | yes     |
+| `.site-subtitle`            | `site_subtitle_html`                           | yes     |
+| `.site-overview`            | `site_overview_html`                           | yes     |
+| `.albums`                   | The album card grid                            | yes     |
+| `.album-card`               | One album card                                 | yes     |
+| `.album-info`               | Title/description/meta block inside a card     | yes     |
+| `.album-info .description`  | Album description on a card                    | yes     |
+| `.album-info .meta`         | Photo count and date range on a card           | yes     |
+
+**Album page:**
+
+| Selector              | Element                                          | Scoped? |
+|-----------------------|--------------------------------------------------|---------|
+| `.album-nav`          | Header nav (the `← Albums` link, or `album_nav`) | yes     |
+| `header .description` | Album description under the title                | yes     |
+| `header .meta`        | Photo count and date range under the title       | yes     |
+| `.gallery`            | The justified photo grid                         | yes     |
+| `.photo`              | One grid tile (a `<button>`)                     | yes     |
+| `.photo-caption`      | Caption overlay on a grid tile                   | yes     |
+| `.video-badge`        | Play badge and duration on a video tile          | yes     |
+
+**Lightbox** (all global — a plain selector is enough):
+
+| Selector                   | Element                                       |
+|----------------------------|-----------------------------------------------|
+| `.pswp`                    | The lightbox root                             |
+| `.pswp__bg`                | The backdrop                                  |
+| `.pswp__top-bar`           | Counter, zoom, copy-link and close controls   |
+| `.pswp__button--arrow`     | Previous/next arrows                          |
+| `.pswp__button--copy-link` | Copy-permalink button                         |
+| `.pswp-caption`            | Caption under the photo                       |
+| `.pswp-caption--video`     | Caption on a video slide (taller gradient)    |
+| `.pswp-video`              | The `<video>` element                         |
+
+**Password-protected sites:**
+
+| Selector         | Element                                          | Scoped? |
+|------------------|--------------------------------------------------|---------|
+| `.overlay`       | Full-screen password prompt                      | yes     |
+| `.hint`          | Password hint text in the prompt                 | yes     |
+| `.ddp-lock-icon` | Lock icon on a locked album's card               | no      |
+
+## Worked examples
+
+### A class you invent yourself
+
+The simplest case, and the one the starter `custom.css` demonstrates. The `*_html` settings
+in `albums.yaml` accept arbitrary HTML, so you can introduce your own class and style it
+with no specificity concerns at all — nothing else in the site defines it:
+
+```yaml
+settings:
+  site_overview_html: 'Welcome to my <span class="accent">photo gallery</span>.'
+```
+
+```css
+[data-theme="light"] .accent {
+    color: #1a7f4b;
+}
+
+[data-theme="dark"] .accent {
+    color: #4ade80;
+}
+```
+
+This works for photo captions in `photogen.txt` too, which accept the same inline HTML.
+See [HTML in captions](PHOTOGEN.md#html-in-captions).
+
+### Recolor plus a shape change
+
+[`sample/config/custom-example.css`](../sample/config/custom-example.css) does one of each.
+The accent swap is a custom property, so it needs nothing special. The border radius fights
+a scoped rule, so it needs `!important`:
+
+```css
+/* Swap the golden accent to teal, both themes */
+:root {
+    --text-color-2nd: #2a9d8f;
+}
+
+:root[data-theme='light'] {
+    --text-color-2nd: #1b6b62;
+}
+
+/* Rounder album cards */
+.album-card {
+    border-radius: 16px !important;
+}
+```
+
+### Styling captions differently in the grid and the lightbox
+
+A caption is rendered in two places with two different class names, so each can be styled
+on its own. This hides links in the grid (where they are not clickable anyway, since the
+whole tile opens the lightbox) while keeping them in the lightbox with a hairline underline:
+
+```css
+/* Grid overlay: drop the link, keep the surrounding prose */
+.photo-caption a {
+    display: none;
+}
+
+/* Lightbox: thinner underline than the built-in one */
+.pswp-caption a,
+.pswp-caption a:hover,
+.pswp-caption a:focus-visible {
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+}
+```
+
+Both rules are lower specificity than the built-in ones, and both still work — for the two
+different reasons from [Level 2](#level-2-override-a-rule). The grid rule sets `display`,
+which no built-in rule sets, so there is nothing to lose to. The lightbox rules match a
+`:global` selector exactly, so they win on source order, and the `:hover` and
+`:focus-visible` selectors are repeated because the built-in hover rule would otherwise
+outrank the base one.
+
+Note that hiding a caption link is purely visual: the tile's `aria-label` still reads the
+full caption text, so the visible and screen-reader text will differ.
+
+### Always show grid captions
+
+DD Photos reveals a grid caption on hover, and already shows it unconditionally on touch
+devices via `@media (hover: none)`. To show it everywhere, only the resting `opacity` and
+`transform` need overriding — the gradient, the white centered text, the positioning and
+`pointer-events` are all already the default:
+
+```css
+.gallery .photo .photo-caption {
+    opacity: 1;
+    transform: none;
+}
+```
+
+The base rule compiles to `.photo-caption.svelte-HASH`, which is two classes.
+`.gallery .photo .photo-caption` is three, so it wins outright rather than by source order.
+
+Because the caption has a `transition` on both properties, a change here fades in rather
+than snapping. That also means DevTools shows the old value if you read the computed style
+in the same tick you add the rule — wait for the transition before concluding it did not
+work.
+
+### Shift the hero's focal point
+
+The hero is a hard 1600×250 crop, so a tall subject can end up out of frame. The image is
+positioned by CSS rather than baked in, which means you can slide the visible window
+without recropping:
+
+```css
+.hero {
+    background-position: 10% center !important;
+}
+```
+
+The `!important` is doing real work here: the built-in `.hero { background-position: center }`
+compiles to two classes and would otherwise win. `.hero.hero { background-position: 10% center }`
+is an equivalent fix without `!important`, per [How to win](#how-to-win) — both are
+verified to work.
+
+Note this only moves the crop window. To change the crop itself, use the `crop:` key on the
+hero config, which takes `top`, `center` or `bottom`. See
+[Hero Image](CONFIGURATION.md#hero-image).
+
+### Fit an odd-shaped cover to its card
+
+Album cards force covers into a 3:2 box with `object-fit: cover`, which center-crops. That
+is right for most photos and wrong for a portrait or a panorama, where it cuts off the
+subject. Switch that one album to `contain` so the whole image fits, letterboxed against
+the card background:
+
+```css
+.album-card[data-slug='patagonia'] img {
+    object-fit: contain;
+}
+```
+
+`.album-card[data-slug='…'] img` and the built-in `.album-card.svelte-HASH img` have the
+same specificity, so this wins on source order, no `!important` needed. Other album cards
+are untouched.
+
+## Gotchas
+
+**Never write `.svelte-HASH` in a selector.** The hash is derived from the component's
+style block, so it changes whenever that component's CSS changes — including on a routine
+upgrade. A selector containing one silently stops matching.
+
+**Grid captions do not receive clicks.** `.photo-caption` is `pointer-events: none` and
+marked `inert`, because it lives inside the tile's `<button>`. Styling a link there to look
+clickable will not make it clickable. See
+[HTML in captions](PHOTOGEN.md#html-in-captions).
+
+**The lightbox caption is positioned from JavaScript.** Its `bottom`, `left` and `right`
+are measured and set inline on every slide change and resize to match the displayed photo's
+box, so overriding those three in CSS will not stick. The same applies to `opacity` (it is
+driven to `0` while a video plays and while zoomed) and to `padding-bottom` on a video
+slide, which is set from the height of the browser's control bar. Colors, fonts, the
+background gradient and the remaining padding are all yours.
+
+**PhotoSwipe animates opacity.** Rules that set `opacity` on `.pswp__bg` or the top bar can
+interfere with the open/close transitions.
+
+**Mobile shows captions permanently.** Under `@media (hover: none)` grid captions are
+always visible rather than revealed on hover, so check any caption change at a narrow
+viewport too.
+
+**Nothing validates your CSS.** `photogen` copies the file verbatim; a syntax error is
+silently dropped by the browser at the point of the mistake. If a rule seems to do nothing,
+check the ones above it in the file.
+
+---
+
+See also: [Custom CSS in Configuration](CONFIGURATION.md#custom-css) ·
+[album_nav](CONFIGURATION.md#album_nav) ·
+[HTML in captions](PHOTOGEN.md#html-in-captions)

--- a/docs/PHOTOGEN.md
+++ b/docs/PHOTOGEN.md
@@ -109,14 +109,43 @@ a caption need no escaping.
 
 Descriptions are stored in `index.json` and used as:
 
-- `alt` text on grid and lightbox images
 - Hover caption overlay in the grid (desktop)
 - Always-visible caption in the grid (mobile)
 - Caption overlaid on the photo in the lightbox
+- `alt` text on grid and lightbox images, and the grid tile's `aria-label`, in each
+  case with any HTML tags stripped (see below)
 
 To also use the file for **sort order** (instead of EXIF date), set
 `manual_sort_order: true` on the album entry in `albums.yaml`. Photos not
 listed in `photogen.txt` are sorted by date and appended at the end.
+
+### HTML in captions
+
+`photogen.txt` is written by the site owner, so captions may contain **inline HTML** and
+it is rendered rather than escaped, the same way `site_title_html` and album descriptions
+are:
+
+```
+Patagonia-042 First view of <b>Torres del Paine</b> at sunrise.
+Patagonia-107 Route notes are on <a href="https://example.com/pass">my blog</a>.
+```
+
+Supported: `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<small>`, `<code>`, `<span>`, `<br>`
+and `<a>`.
+
+**Block elements such as `<div>`, `<p>`, `<ul>` and `<h1>` are not supported** and will
+break the caption layout. There is no sanitizer; a caption is inserted as written.
+
+Two behaviors differ by location:
+
+- **Links are clickable in the lightbox only**, and always open in a new tab so the
+  lightbox is not torn down. You do not need to write `target="_blank"` yourself.
+- **In the grid**, a caption renders its formatting but is not interactive: the whole
+  tile is a single click target that opens the lightbox. A link there is styled but
+  inert.
+
+Because `alt` text and the tile's `aria-label` cannot render markup, they use the caption
+with its tags stripped.
 
 ## Video
 

--- a/sample/config/custom-example.css
+++ b/sample/config/custom-example.css
@@ -7,7 +7,9 @@
    frontend injects it site-wide as a <link> after the built-in styles.
 
    CSS custom properties are the cleanest override path: they cascade naturally
-   and cover both dark and light themes with minimal specificity issues. */
+   and cover both dark and light themes with minimal specificity issues.
+
+   Full guide: docs/CUSTOM-CSS.md */
 
 /* Swap the golden accent (album descriptions, highlights) to teal */
 :root {

--- a/sample/source/antarctica/photogen.txt
+++ b/sample/source/antarctica/photogen.txt
@@ -3,7 +3,7 @@ icebergs_25 Very cool iceberg. No pun intended.
 icebergs_16 Land must be nearby.
 icebergs_40 Last one in is a rotten egg!
 icebergs_44 Penguin colony on an iceberg.
-sunset_02 Sunset comes late in this part of the world.
+sunset_02 Sunset comes late in <b>this</b> part of the world, thanks to the <a href="https://en.wikipedia.org/wiki/Midnight_sun">midnight sun</a>.
 devil_is_adelies_04 Adelie penguins coming back from a swim.
 devil_is_adelies_10 Those salt and pepper spots are all penguins. About 20,000 pairs of Adelie's.
 devil_is_adelies_27 Closer shot of Adelie's and their chicks.

--- a/web/src/lib/html.ts
+++ b/web/src/lib/html.ts
@@ -1,0 +1,17 @@
+/**
+ * Strip HTML tags, for slots that can only hold plain text.
+ *
+ * Owner-authored HTML (site title/subtitle/overview, album descriptions, photogen.txt
+ * captions) is rendered with `{@html}` where it appears as body text, but the same
+ * strings also feed `alt`, `aria-label` and `<meta>` attributes, where markup would be
+ * shown verbatim. Those slots run through here first.
+ *
+ * Not a sanitizer: it makes trusted HTML readable as text, and is not a defense against
+ * untrusted input.
+ *
+ * Accepts undefined so callers can pass an optional field (a photo has no description
+ * unless photogen.txt gave it one) straight through.
+ */
+export function stripTags(html: string | undefined): string {
+	return html ? html.replace(/<[^>]*>/g, '') : '';
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -364,7 +364,7 @@
 					<div class="album-info">
 						<h2>{album.title}</h2>
 						{#if album.description}
-							<!-- eslint-disable-next-line svelte/no-at-html-tags -- album photogen.txt, HTML is intentional -->
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -- albums.yaml description, HTML is intentional -->
 							<p class="description">{@html album.description}</p>
 						{/if}
 						<p class="meta">

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -26,6 +26,7 @@
 		tryDecrypt
 	} from '$lib/crypto';
 	import { footerReady } from '$lib/stores';
+	import { stripTags } from '$lib/html';
 	import { navigateCursor, type Direction } from '$lib/navigation';
 
 	let { data } = $props();
@@ -51,7 +52,7 @@
 	// (needed for site-encrypted sites where albums.enc.json is not fetched server-side).
 	let albumTitle = $derived(album?.title ?? data.albumData.albumTitle);
 	let description = $derived(data.albumData.description || album?.description || '');
-	let plainDescription = $derived(description.replace(/<[^>]*>/g, ''));
+	let plainDescription = $derived(stripTags(description));
 	let dateSpan = $derived(data.albumData.dateSpan || album?.dateSpan || '');
 	// Header navigation configured via customizations.album_nav; empty means the default
 	// "← Albums" link. Rides in config.json, so it is available before any decryption.
@@ -140,7 +141,7 @@
 	// Accessible label for a grid tile. Videos say so, since the play badge is aria-hidden
 	// and a screen reader would otherwise have no way to tell a clip from a still.
 	function photoLabel(photo: Photo): string {
-		const base = photo.description || photo.fileName;
+		const base = stripTags(photo.description) || photo.fileName;
 		if (photo.kind !== 'video') return base;
 		const length = photo.duration ? `, ${formatDuration(photo.duration)}` : '';
 		return `Video: ${base}${length}`;
@@ -172,7 +173,7 @@
 			w: photo.width,
 			h: photo.height,
 			msrc: `/albums/${slug}/${photo.src.grid}`, // thumbnail for loading
-			alt: photo.description || photo.fileName,
+			alt: stripTags(photo.description) || photo.fileName,
 			caption: photo.description || '',
 			videoSrc: photo.src.video ? `/albums/${slug}/${photo.src.video}` : undefined,
 			posterSrc: `/albums/${slug}/${photo.src.full}`
@@ -498,6 +499,16 @@
 				const el = document.createElement('div');
 				el.className = 'pswp-caption';
 				el.style.display = 'none';
+				// A caption lives inside an item holder, so PhotoSwipe's pointer handling on
+				// pswp.element sees events on it and treats them as a drag or a tap on the
+				// slide. Stop link events there so a click actually follows the href; anything
+				// else in the caption still reaches PhotoSwipe, keeping swipe and drag-to-close
+				// working over the caption area.
+				const stopLinkEvent = (e: Event) => {
+					if ((e.target as Element).closest('a')) e.stopPropagation();
+				};
+				el.addEventListener('pointerdown', stopLinkEvent);
+				el.addEventListener('click', stopLinkEvent);
 				holder.el.appendChild(el);
 			});
 
@@ -536,7 +547,14 @@
 						el.style.display = 'none';
 						return;
 					}
-					el.textContent = item.caption;
+					el.innerHTML = item.caption;
+					// Caption links always open a new tab: navigating in place tears down the
+					// lightbox, losing the visitor's place in the album. Set unconditionally
+					// rather than only when absent, so photogen.txt needs no boilerplate.
+					el.querySelectorAll('a').forEach((a) => {
+						a.target = '_blank';
+						a.rel = 'noopener';
+					});
 					el.style.display = '';
 					// A video caption's box reaches the bottom of the media exactly like a
 					// photo's; what differs is that its text is held above the browser's
@@ -790,7 +808,7 @@
 			{@render headerNav()}
 			<h1>{albumTitle}</h1>
 			{#if description}
-				<!-- eslint-disable-next-line svelte/no-at-html-tags -- album photogen.txt, HTML is intentional -->
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -- albums.yaml description, HTML is intentional -->
 				<p class="description">{@html description}</p>
 			{/if}
 			<p class="meta">
@@ -837,7 +855,7 @@
 					     The `loaded` class drives the fade-in transition in CSS. -->
 					<img
 						src={imageSrcs[i]}
-						alt={photo.description || photo.fileName}
+						alt={stripTags(photo.description) || photo.fileName}
 						width={box.width}
 						height={box.height}
 						loading={slowMode ? undefined : 'lazy'}
@@ -857,7 +875,12 @@
 						</div>
 					{/if}
 					{#if photo.description}
-						<div class="photo-caption">{photo.description}</div>
+						<!-- inert because this sits inside the tile's <button>: a caption <a> would
+						     otherwise be interactive content nested in a button (invalid HTML) and
+						     add a tab stop per captioned tile. The button's aria-label already
+						     carries the caption text, so nothing is lost by hiding it from AT. -->
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -- photogen.txt caption, HTML is intentional -->
+						<div class="photo-caption" inert>{@html photo.description}</div>
 					{/if}
 				</button>
 			{/each}
@@ -1054,6 +1077,15 @@
 		pointer-events: none;
 	}
 
+	/* Caption links. In the grid they are styled but not clickable: the container is
+	   pointer-events: none and the whole tile is one click target that opens the lightbox,
+	   which is where a caption is meant to be read (and where its links work). */
+	.photo-caption :global(a) {
+		color: inherit;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
 	.photo:hover .photo-caption,
 	.photo:focus .photo-caption {
 		opacity: 1;
@@ -1180,6 +1212,21 @@
 		pointer-events: none;
 		z-index: 10;
 		transition: opacity 0.3s ease;
+	}
+
+	/* Lightbox caption links are the one clickable thing in a caption, so they opt back in
+	   to pointer events that the container above turns off. The container keeps
+	   pointer-events: none so swipe and drag-to-close still work over the caption's text. */
+	:global(.pswp-caption a) {
+		pointer-events: auto;
+		color: inherit;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	:global(.pswp-caption a:hover),
+	:global(.pswp-caption a:focus-visible) {
+		text-decoration-thickness: 2px;
 	}
 
 	/* Video caption. The box reaches the bottom of the media like the photo rule above, but

--- a/web/tests/captions.spec.ts
+++ b/web/tests/captions.spec.ts
@@ -1,11 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { waitForHydration, loadPasswords, unlockAlbumIfNeeded, albumExists } from './helpers';
+import {
+	waitForHydration,
+	loadPasswords,
+	unlockAlbumIfNeeded,
+	albumExists,
+	findHtmlCaption,
+	type FoundHtmlCaption
+} from './helpers';
 
 const pw = loadPasswords();
 
 let hasAntarctica = true;
+let htmlCaption: FoundHtmlCaption | null = null;
 test.beforeAll(async ({ request }) => {
 	hasAntarctica = await albumExists(request, 'antarctica');
+	htmlCaption = await findHtmlCaption(request);
 });
 
 // Caption tests verify the rendering mechanism works (rAF fix, animate=false fix),
@@ -152,4 +161,93 @@ test('caption updates when navigating to prev/next photo', async ({ page }) => {
 	// Caption for *this* photo may or may not exist — just assert the lightbox
 	// is still open and didn't crash.
 	await expect(page.locator('.pswp')).toBeVisible();
+});
+
+// HTML in captions. photogen.txt is written by the site owner, so its markup is rendered
+// rather than escaped — but only where a caption is body text. The `alt` and `aria-label`
+// built from the same string are plain-text slots and get the tags stripped, and grid
+// captions stay non-interactive so a tile remains a single click target.
+//
+// Driven by whatever the site publishes (see findHtmlCaption), so it is a no-op on a site
+// with no HTML captions rather than a hardcoded fixture assertion.
+
+test('grid caption renders HTML, while alt text stays plain', async ({ page }) => {
+	test.skip(!htmlCaption, 'no caption with HTML on this site');
+	const found = htmlCaption!;
+
+	await page.goto(`/albums/${found.slug}`);
+	await unlockAlbumIfNeeded(page, found.slug, pw);
+	await waitForHydration(page);
+
+	const tile = page.locator('.photo').nth(found.index);
+	const caption = tile.locator('.photo-caption');
+
+	// A real element, not the literal "<b>" that escaping would produce.
+	await expect(caption.locator('b, strong, i, em, a').first()).toBeAttached();
+	await expect(caption).not.toContainText('<');
+
+	// The same caption feeds alt and aria-label, which cannot render markup.
+	expect(await tile.locator('img').getAttribute('alt')).not.toContain('<');
+	expect(await tile.getAttribute('aria-label')).not.toContain('<');
+});
+
+test('grid caption is inert, so its links add no tab stops', async ({ page }) => {
+	test.skip(!htmlCaption, 'no caption with HTML on this site');
+	const found = htmlCaption!;
+	test.skip(!/<a[\s>]/i.test(found.description), 'caption has no link');
+
+	await page.goto(`/albums/${found.slug}`);
+	await unlockAlbumIfNeeded(page, found.slug, pw);
+	await waitForHydration(page);
+
+	// `inert` removes the subtree from the tab order and the a11y tree. Without it a
+	// caption <a> would be interactive content nested inside the tile's <button>.
+	const caption = page.locator('.photo').nth(found.index).locator('.photo-caption');
+	await expect(caption).toHaveAttribute('inert', /.*/);
+
+	const focusedTag = await page.evaluate(() => {
+		const link = document.querySelector('.photo-caption a') as HTMLElement | null;
+		link?.focus();
+		return document.activeElement?.tagName ?? '';
+	});
+	expect(focusedTag).not.toBe('A');
+});
+
+test('lightbox caption renders HTML, its links open in a new tab, alt stays plain', async ({
+	page
+}) => {
+	test.skip(!htmlCaption, 'no caption with HTML on this site');
+	const found = htmlCaption!;
+
+	await page.goto(`/albums/${found.slug}`);
+	await unlockAlbumIfNeeded(page, found.slug, pw);
+	await waitForHydration(page);
+
+	await page.locator('.photo').nth(found.index).click();
+	await expect(page.locator('.pswp')).toBeVisible();
+
+	// Scope to the current slide. All three item holders (prev/current/next) carry a
+	// caption, and only this photo's has HTML in it — aria-hidden="false" is what marks
+	// the active holder (see the vertical-drag test above).
+	const current = page.locator('.pswp__item[aria-hidden="false"]');
+	const caption = current.locator('.pswp-caption');
+	await expect(caption).toBeVisible();
+	await expect(caption).not.toContainText('<');
+	await expect(caption.locator('b, strong, i, em, a').first()).toBeAttached();
+
+	if (/<a[\s>]/i.test(found.description)) {
+		const link = caption.locator('a').first();
+		// Forced in updateAll(): following a link in place would tear down the lightbox.
+		await expect(link).toHaveAttribute('target', '_blank');
+		await expect(link).toHaveAttribute('rel', 'noopener');
+		// The caption container is pointer-events: none; links opt back in.
+		await expect(link).toHaveCSS('pointer-events', 'auto');
+	}
+
+	// PhotoSwipe writes the data source's alt onto the slide image. Video slides have
+	// no <img>, so only check when the found item is a still.
+	const img = current.locator('.pswp__img').first();
+	if ((await img.count()) > 0) {
+		expect(await img.getAttribute('alt')).not.toContain('<');
+	}
 });

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -311,3 +311,51 @@ export async function findVideo(request: APIRequestContext): Promise<FoundVideo 
 		return null;
 	}
 }
+
+/**
+ * A caption containing HTML, found in the published album data.
+ */
+export interface FoundHtmlCaption {
+	slug: string;
+	index: number; // 0-based position in the album, matching .photo nth()
+	description: string; // raw caption, markup included
+}
+
+/**
+ * Find a photo whose photogen.txt caption contains HTML.
+ *
+ * Content-driven like findVideo: captions are site data, so the test asks the published
+ * index.json what is there rather than hardcoding a fixture. The sample site has one
+ * (antarctica/sunset_02); a site with no HTML captions gets a null and the caller turns
+ * that into a test.skip.
+ *
+ * Encrypted variants publish index.enc.json, so this returns null there, exactly as
+ * findVideo does.
+ */
+export async function findHtmlCaption(
+	request: APIRequestContext
+): Promise<FoundHtmlCaption | null> {
+	try {
+		const albumsResp = await request.get('/albums/albums.json');
+		if (!albumsResp.ok()) return null;
+		const albums: { slug: string; count: number }[] = await albumsResp.json();
+
+		for (const album of albums) {
+			if (!album.count) continue;
+			const resp = await request.get(`/albums/${album.slug}/index.json`);
+			if (!resp.ok()) continue;
+			const index: { photos: { description?: string }[] } = await resp.json();
+
+			for (let i = 0; i < index.photos.length; i++) {
+				const description = index.photos[i].description;
+				// `<` followed by a letter: a tag, not a stray less-than in prose.
+				if (description && /<[a-z]/i.test(description)) {
+					return { slug: album.slug, index: i, description };
+				}
+			}
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
Photo captions in `photogen.txt` are written by the site owner, the same as
`site_title_html`, `site_subtitle_html`, `site_overview_html` and album descriptions, all
of which already render as HTML. Captions were the one owner-authored string still
escaped, so a line like

```
img_042 This is a <b>test</b> of a <a href="https://www.ddpoker.com">link</a>.
```

showed its tags verbatim in both the grid overlay and the lightbox. This renders them
instead.

No Go changes. `parsePhotogenLine` / `loadPhotoDescriptions` already pass caption text
through verbatim into `PhotoIndex.Description`; all the escaping happened at the two
Svelte leaves.

## Behavior

| | Grid overlay | Lightbox |
|---|---|---|
| Inline formatting | renders | renders |
| Links | styled, not clickable | clickable, always a new tab |

The grid overlay lives inside the tile's `<button class="photo">`, so a clickable caption
link there would be interactive content nested in a button (invalid HTML) and would add a
tab stop per captioned tile. The caption `<div>` is marked `inert`, which drops the
subtree from the tab order and the accessibility tree without changing how it looks. The
button's `aria-label` already carries the caption text, so nothing is lost. Clicking
anywhere on a tile still opens the lightbox, which is where a caption is meant to be read.

Lightbox links are forced to `target="_blank" rel="noopener"` at render time, so following
one does not tear down the lightbox and lose the visitor's place in the album, and
`photogen.txt` needs no boilerplate to get that.

Only inline HTML is in scope. Block elements are documented as unsupported rather than
enforced, matching how the existing HTML fields work. There is no sanitizer.

## Notable details

**Tags leaking into plain-text slots.** The same caption string also feeds `alt`,
`aria-label` and the OpenGraph `<meta>` description, where markup would be shown literally.
New `web/src/lib/html.ts` exports `stripTags()`, which those four call sites now share
(one of them was already doing this with a local regex). It is explicitly not a sanitizer:
it makes trusted HTML readable as text.

**PhotoSwipe swallowing link clicks.** A lightbox caption sits inside an item holder, so
pointer events on it reach PhotoSwipe's gesture handler on `pswp.element` and get treated
as a drag or a tap on the slide. `pointerdown` and `click` are stopped only when the target
is inside an `<a>`; everything else in the caption still reaches PhotoSwipe, so swipe and
drag-to-close keep working over the caption area. The trade-off is that a drag starting on
the link itself does nothing.

**Pointer events.** The lightbox caption container keeps `pointer-events: none` for the
reason above; links opt back in with `pointer-events: auto`.

**Underline weight.** Caption links are underlined at a pinned `text-decoration-thickness:
1px` in both places, rather than the default `auto`. `auto` scales with font size, and the
two captions are different sizes (0.78rem in the grid, up to 1.2rem in the lightbox), so
`auto` drew a visibly heavier line in the lightbox for what should look like the same link.
The lightbox hover state still doubles it to 2px, which is the only affordance marking a
caption link as clickable.

## Custom CSS

The two captions have distinct class names, `.photo-caption` and `.pswp-caption`, so a
site's `custom.css` can style each independently. Verified against a live site: hiding
`.photo-caption a` and restyling `.pswp-caption a` both work, neither needing `!important`.

Checking that turned up how opaque custom CSS is in general. The existing documentation was
four sentences in `CONFIGURATION.md`, which told you the file gets injected after the
built-in styles but not the thing that actually matters: Svelte scopes component styles, so
a built-in `.album-card` compiles to `.album-card.svelte-1uha8ag`, and a plain
`.album-card` rule in `custom.css` loses on specificity no matter that it comes later. The
one existing hint was a `!important` and a comment in `sample/config/custom-example.css`.

New **`docs/CUSTOM-CSS.md`** is the full guide:

- **Turning it on** — `settings.css`, the `-css` flag, where the `<link>` lands, and that
  the file is never encrypted.
- **The edit/see-it loop** — the browser reads the copy in the albums output, not the
  config file, so `photogen -index -doit` re-copies it in about a second without
  reprocessing photos. Includes the Docker-mode wrinkle that flags passed after `--` drop
  the implicit `-doit`.
- **Themes** — the dark-default / light-override structure, and the trap that follows from
  it: every palette property is defined twice, and `:root[data-theme='light']` outranks a
  custom `:root`, so setting only `:root` silently changes dark mode alone.
- **Level 1: custom properties** — all nine palette variables and what each is used for,
  plus `--focus-color` (read with a fallback, never defined) and `--pswp-bg`.
- **Level 2: overriding a rule** — the scoped-vs-`:global` split, with the compiled output
  shown. Rule of thumb: everything in the lightbox (`.pswp*`) is global and easy to
  override, everything in the page is scoped and needs help. Also covers why descendants
  cost nothing (Svelte wraps them in `:where()`), why setting a property no built-in rule
  sets is free, and why `:hover` rules need their selector repeated.
- **Element reference** — five tables of stable class names, each marked with whether a
  plain one-class selector will lose.
- **Worked examples** — six of them: styling a class you invented in `site_overview_html`
  or a caption, the recolor-plus-shape-change from `custom-example.css`, the grid/lightbox
  caption split, always-show grid captions, shifting the hero's focal point, and switching
  one album's cover to `object-fit: contain` for a portrait or panorama. Each says which
  tactic it is using and why.
- **Gotchas** — never write `.svelte-HASH` in a selector (it changes on any style edit),
  the lightbox caption's geometry is set inline from JS, grid captions are
  `pointer-events: none`, and nothing validates the file.

Every example and specificity claim is checked against a running site rather than asserted:
`.album-card` at one class does nothing while `.album-card.album-card` works without
`!important`; a `:root`-only custom property change leaves light mode untouched; a plain
`.hero` loses to the built-in `background-position` while both `!important` and `.hero.hero`
win; `.album-card[data-slug='…'] img` retargets one cover and leaves the rest alone; and
`.gallery .photo .photo-caption` pins captions open. The "Scoped?" columns come from reading
the compiled CSS, which is what caught that `.site-subtitle` is only ever styled as a
descendant and that `.ddp-lock-icon` is global and belongs to a locked album card.

The reference section also documents the two per-item hooks that were previously
undiscoverable: `data-slug` on `.album-card` and `data-index` on `.photo`.

`CONFIGURATION.md` keeps its section and links out to the new page. Both example CSS files
gain a header comment pointing at it, since `docker/init/config/custom.css` is the first
one a Docker user opens.

## Sample data

`sample/source/antarctica/photogen.txt` gains inline HTML and a link on one caption, so the
out-of-the-box sample site demonstrates the feature and the e2e tests have real data to
assert against.

## Tests

`findHtmlCaption()` in `web/tests/helpers.ts` is modeled on the existing `findVideo()`:
it walks the published album JSON and returns the first caption containing markup, or
`null`. Three tests in `captions.spec.ts` use it with the established
`test.skip(!found, ...)` pattern, so they stay a no-op on sites without HTML captions and
skip on encrypted variants where `index.enc.json` is unreadable. They assert on structure,
not on literal caption strings, per that file's convention:

- grid caption renders HTML while `alt` stays plain
- grid caption is `inert`, so its links add no tab stops
- lightbox caption renders HTML, its links open in a new tab, `alt` stays plain
- caption links use the same 1px underline in both places, and the lightbox hover doubles it

The lightbox test scopes to `.pswp__item[aria-hidden="false"]`, since PhotoSwipe keeps
three item holders (prev/current/next) and each has its own caption.

## Verification

`npm run lint` and `npm run check` clean. `make web-sanity-test` green on both variants
(61 passed no-passwords; 53 passed all-passwords with the four new tests correctly
skipped). Manual pass against the Apache container confirmed the grid/lightbox split, the
forced new tab with the lightbox still open underneath, and that horizontal drag and
drag-to-close still work when started on caption text.

## Docs

`docs/PHOTOGEN.md` gains an "HTML in captions" subsection listing the supported inline tags,
stating that block elements are unsupported with no sanitizer, and documenting the two
location-dependent behaviors.

`docs/CUSTOM-CSS.md` is new (see above). `docs/CONFIGURATION.md` links to it from its
Custom CSS section.

`README.md` extends the existing HTML bullet to mention captions, adds `Custom CSS` to the
documentation index and to the custom-CSS feature bullet, and fixes a doubled link in the
Overview section that rendered as broken markdown:

```
-A DD Photos [site]([site↗](https://ddphotos.donohoe.info)) has a home page
+A DD Photos [site↗](https://ddphotos.donohoe.info) has a home page
```



