### PR TITLE
Show video count in album card/header.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Web lint (prettier + eslint)
         run: make web-lint
 
+      - name: Web unit tests (vitest)
+        run: make web-unit-test
+
       - name: Install Playwright Chromium
         # Deliberately no `npx playwright install-deps chromium` here. That runs apt-get
         # under the hood and was the most frequent victim of the flaky Azure mirror (up to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ wrong Node, so a machine whose `nvm` default has drifted cannot silently install
 ```bash
 make build test vet              # Go build, unit tests, static analysis
 make sample-build                # build static site with sample data
+make web-unit-test               # Vitest unit tests for TypeScript helpers in web/src/lib
 make web-sanity-test             # Playwright e2e tests: Apache, no-passwords + all-passwords (quick comprehensive web check)
 make web-playwright-test-apache  # Playwright e2e tests, Apache, no-passwords only
 make docker-test                 # Test 'ddphotos' docker commands
@@ -73,6 +74,8 @@ System dependency required: `brew install vips pkg-config`
 
 ## Testing Practices
 
+- **Pure TypeScript helpers** (`web/src/lib/*.ts`): unit-test them with Vitest as `src/lib/<name>.test.ts`
+  rather than reaching for a browser; `make web-unit-test` runs them, and `web-sanity-test` runs them first
 - **Reproducing frontend bugs**: write a failing Playwright test that demonstrates the bug before fixing it
 - **New UI features**: add a Playwright test covering the new behavior — tests live in `web/tests/`
 - After any UI changes, run `make web-sanity-test` (Apache, no-passwords + all-passwords) as the standard web check

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,11 @@ web-lint:
 web-format:
 	$(NODE_INIT) cd web && npm run format
 
+.PHONY: web-unit-test
+## web-unit-test: run Vitest unit tests for the TypeScript helpers in web/src/lib
+web-unit-test:
+	$(NODE_INIT) cd web && npm run test:unit
+
 .PHONY: web-playwright-install
 ## web-playwright-install: install Playwright and browser binaries (one-time setup)
 web-playwright-install:
@@ -229,8 +234,9 @@ web-playwright-test-all:
 	bin/test-all.sh
 
 .PHONY: web-sanity-test
-## web-sanity-test: quick sanity check — Playwright e2e tests against Apache, no-passwords + all-passwords variants
+## web-sanity-test: quick sanity check — Vitest unit tests, then Playwright e2e against Apache, no-passwords + all-passwords variants
 web-sanity-test:
+	$(MAKE) web-unit-test # pure-function checks first: seconds, and no browser needed
 	bin/run-tests.sh --mode apache
 	$(MAKE) sample-test-apache # also test routing tests against sample, which was just built
 	bin/run-tests.sh --mode apache --passwords sample/config/passwords-all.yaml

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -21,6 +21,7 @@ as defined in `config/defaults.env`.
 | `web-npm-audit-fix`           | Run `npm audit fix` in `web/`                                                                 |
 | `web-lint`                    | Check formatting (prettier) and lint (eslint) in `web/`                                       |
 | `web-format`                  | Reformat `web/` sources with prettier                                                         |
+| `web-unit-test`               | Run Vitest unit tests for the TypeScript helpers in `web/src/lib`                             |
 | `web-npm-run-dev`             | Start Vite dev server and open browser                                                        |
 | `web-npm-run-dev-https`       | Start Vite dev server over HTTPS (required for `crypto.subtle` on mobile/LAN)                 |
 | `web-npm-build`               | Build the static site into `build/$DDPHOTOS_SITE_ID/`                                         |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,13 +2,14 @@
 
 **Note:** This page is for contributors developing DD Photos, not for users building their own sites with it.
 
-There are three ways of testing DD Photos:
+There are four ways of testing DD Photos:
 
 1. **Manual testing** in a browser, against the Vite dev server or a local static build (via Docker)
-2. **Playwright e2e tests** that drive a headless Chromium browser to verify UI behavior
-3. **Apache routing tests** using `curl` to verify `.htaccess` URL routing, redirects, and 404 handling
+2. **Vitest unit tests** for the plain TypeScript helpers in `web/src/lib`, with no browser involved
+3. **Playwright e2e tests** that drive a headless Chromium browser to verify UI behavior
+4. **Apache routing tests** using `curl` to verify `.htaccess` URL routing, redirects, and 404 handling
 
-All three are discussed below.
+All four are discussed below.
 
 ## Manual Testing - Dev
 
@@ -91,6 +92,28 @@ bin/test-photos-server.sh --local 9090                                       # l
 
 The deployment script runs this script automatically after deploying.
 
+## Automated Tests - Vitest Unit Tests
+
+Logic that is a pure function of its inputs does not need a browser, a build or an album
+to test. Those live in `web/src/lib` as plain TypeScript and are covered by Vitest, which
+runs in under a second:
+
+```bash
+make web-unit-test
+```
+
+Tests sit beside the code they cover as `*.test.ts` (e.g. `src/lib/counts.test.ts` for
+`src/lib/counts.ts`) and are table-driven where the code is a set of rules. `web/tests/`
+stays Playwright-only: `vitest.config.ts` narrows its `include` to `src/**/*.test.ts` so the
+two suites cannot pick up each other's files.
+
+Use this for wording, formatting and calculation rules; use Playwright when the thing being
+verified is what the page actually renders. The "n photos · n videos" meta line has both: the
+rules are unit-tested, and `video.spec.ts` checks that the album header and the home page card
+really show them.
+
+For a watch loop while working on a helper, run `npm run test:unit:watch` in `web/`.
+
 ## Automated Tests - Playwright E2E Tests
 
 Playwright runs a real headless Chromium browser against a Docker container (Apache
@@ -125,7 +148,7 @@ Tests are in `web/tests/` and cover:
 | `privacy.spec.ts`     | Privacy page content, back link, scroll restoration on return to home                                                      |
 | `password.spec.ts`    | Site/album prompts, wrong/correct passwords, remember on reload, hints, logout button, `?clear`                            |
 | `css.spec.ts`         | Custom CSS `<link>` injection, `--text-color-2nd` override, album card border-radius                                       |
-| `video.spec.ts`       | Play badge, lightbox `<video>`, space to play/pause, pause on swipe/close, caption hidden while playing, MP4 MIME + ranges |
+| `video.spec.ts`       | Play badge, lightbox `<video>`, space to play/pause, pause on swipe/close, caption hidden while playing, MP4 MIME + ranges, photo/video counts in the meta line |
 
 Navigation tests are fully dynamic - they read album names from the page at runtime and
 work against any site without hardcoding album names.  Several tests require the presence of 
@@ -186,9 +209,9 @@ bin/run-tests.sh --mode dev --test tests/privacy.spec.ts
 
 ### Sanity Check
 
-A good sanity check verifies against Apache (which requires a build), and tests
-both password and no-password sites.  It's quicker than running all 5 variants against
-dev, Apache and nginx:
+A good sanity check runs the unit tests, then verifies against Apache (which requires a
+build), testing both password and no-password sites.  It's quicker than running all 5
+variants against dev, Apache and nginx:
 
 ```bash
 make web-sanity-test

--- a/pkg/photogen/json.go
+++ b/pkg/photogen/json.go
@@ -80,7 +80,8 @@ type PhotoSrcIndex struct {
 type AlbumSummary struct {
 	Slug        string `json:"slug"`
 	Title       string `json:"title"`
-	Count       int    `json:"count"`
+	Count       int    `json:"count"`                 // total media items (photos + videos)
+	VideoCount  int    `json:"videoCount,omitempty"`  // how many of Count are videos
 	Cover       string `json:"cover,omitempty"`       // path to cover image (first photo's thumb, WebP)
 	CoverJpeg   string `json:"coverJpeg,omitempty"`   // path to cover JPEG for OG images (broad crawler support)
 	DateSpan    string `json:"dateSpan"`              // e.g., "Apr 2024" or "Apr - May 2024"
@@ -180,10 +181,17 @@ func (ap *AlbumProcessor) relativeVideoPath(fileName string) string {
 
 // GetAlbumSummary returns summary info for albums.json
 func (ap *AlbumProcessor) GetAlbumSummary() AlbumSummary {
+	videos := 0
+	for _, p := range ap.Photos {
+		if p.IsVideo {
+			videos++
+		}
+	}
 	summary := AlbumSummary{
-		Slug:  ap.AlbumConfig.Slug,
-		Title: ap.AlbumConfig.Name,
-		Count: len(ap.Photos),
+		Slug:       ap.AlbumConfig.Slug,
+		Title:      ap.AlbumConfig.Name,
+		Count:      len(ap.Photos),
+		VideoCount: videos,
 	}
 
 	albumEncrypted := ap.Config.IsAlbumEncrypted(ap.AlbumConfig.Slug)

--- a/pkg/photogen/json_test.go
+++ b/pkg/photogen/json_test.go
@@ -662,6 +662,26 @@ func TestGetAlbumSummary(t *testing.T) {
 		assert.NotEmpty(t, sPublic.Cover)
 	})
 
+	t.Run("count is all media and videoCount is the video share of it", func(t *testing.T) {
+		t.Parallel()
+		// The frontend derives its "n photos · n videos" line from these two, taking the
+		// photo count as count - videoCount, so count must stay the total.
+		s := makeVideoAP(t.TempDir(), nil).GetAlbumSummary()
+		assert.Equal(t, 2, s.Count)
+		assert.Equal(t, 1, s.VideoCount)
+	})
+
+	t.Run("an album with no video omits videoCount from the JSON", func(t *testing.T) {
+		t.Parallel()
+		s := makeAP("myalbum", nil).GetAlbumSummary()
+		assert.Equal(t, 1, s.Count)
+		assert.Zero(t, s.VideoCount)
+
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), "videoCount", "omitempty keeps video-free albums.json unchanged")
+	})
+
 	t.Run("mixed: site+per-album encryption omits cover for per-album album, includes for others", func(t *testing.T) {
 		t.Parallel()
 		// Per-album password takes precedence: the "secret" album has its own password so its

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -35,7 +35,8 @@
 				"svelte-check": "^4.3.6",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.54.0",
-				"vite": "^8.0.16"
+				"vite": "^8.0.16",
+				"vitest": "^4.1.11"
 			},
 			"engines": {
 				"node": "24.x"
@@ -725,10 +726,28 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/esrecurse": {
@@ -1037,6 +1056,119 @@
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+			"integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+			"integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.11",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+			"integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+			"integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.11",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+			"integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/utils": "4.1.11",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+			"integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+			"integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.11",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1092,6 +1224,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1124,6 +1266,16 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1148,6 +1300,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -1233,6 +1392,13 @@
 			"version": "5.8.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
 			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+			"license": "MIT"
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+			"integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
@@ -1527,6 +1693,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1535,6 +1711,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2265,6 +2451,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/photoswipe": {
 			"version": "5.4.4",
 			"resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
@@ -2609,6 +2802,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2631,6 +2831,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/svelte": {
 			"version": "5.55.7",
@@ -2714,6 +2928,23 @@
 				}
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2728,6 +2959,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/totalist": {
@@ -2944,6 +3185,96 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+			"integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.11",
+				"@vitest/mocker": "4.1.11",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/runner": "4.1.11",
+				"@vitest/snapshot": "4.1.11",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.11",
+				"@vitest/browser-preview": "4.1.11",
+				"@vitest/browser-webdriverio": "4.1.11",
+				"@vitest/coverage-istanbul": "4.1.11",
+				"@vitest/coverage-v8": "4.1.11",
+				"@vitest/ui": "4.1.11",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2958,6 +3289,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
+		"test:unit": "vitest run",
+		"test:unit:watch": "vitest",
 		"test:e2e": "playwright test",
 		"screenshots": "node scripts/screenshots.mjs"
 	},
@@ -40,7 +42,8 @@
 		"svelte-check": "^4.3.6",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.54.0",
-		"vite": "^8.0.16"
+		"vite": "^8.0.16",
+		"vitest": "^4.1.11"
 	},
 	"dependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",

--- a/web/src/lib/counts.test.ts
+++ b/web/src/lib/counts.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { mediaCountText, albumMetaText } from '$lib/counts';
+
+describe('mediaCountText', () => {
+	// Every rule the meta line follows, including the singular/plural boundary on each
+	// half independently: an album can hold one video and many photos, or the reverse.
+	const cases: [photos: number, videos: number, expected: string][] = [
+		// No video: the wording albums had before video existed, unchanged.
+		[0, 0, '0 photos'],
+		[1, 0, '1 photo'],
+		[2, 0, '2 photos'],
+		[23, 0, '23 photos'],
+		// Video only: the photo half disappears rather than showing "0 photos".
+		[0, 1, '1 video'],
+		[0, 4, '4 videos'],
+		// Both: each half is pluralized on its own count.
+		[1, 1, '1 photo · 1 video'],
+		[1, 2, '1 photo · 2 videos'],
+		[20, 1, '20 photos · 1 video'],
+		[20, 3, '20 photos · 3 videos']
+	];
+
+	for (const [photos, videos, expected] of cases) {
+		it(`${photos} photos and ${videos} videos reads "${expected}"`, () => {
+			expect(mediaCountText(photos, videos)).toBe(expected);
+		});
+	}
+});
+
+describe('albumMetaText', () => {
+	it('appends the date span after the counts', () => {
+		expect(albumMetaText(20, 1, 'Dec 2004 - Jan 2005')).toBe(
+			'20 photos · 1 video · Dec 2004 - Jan 2005'
+		);
+	});
+
+	it('appends nothing when the album has no dated media', () => {
+		// An album whose photos carry no EXIF date gets an empty dateSpan from photogen,
+		// and albums.json omits it entirely for an empty album, so both arrive here.
+		expect(albumMetaText(3, 0, '')).toBe('3 photos');
+		expect(albumMetaText(3, 0, undefined)).toBe('3 photos');
+		expect(albumMetaText(0, 0, undefined)).toBe('0 photos');
+	});
+
+	it('keeps the separator out of a single-kind album', () => {
+		expect(albumMetaText(0, 2, 'Apr 2024')).toBe('2 videos · Apr 2024');
+	});
+});

--- a/web/src/lib/counts.ts
+++ b/web/src/lib/counts.ts
@@ -1,0 +1,22 @@
+/**
+ * The "3 photos · 1 video · Apr 2024" line shown under an album, shared by the album
+ * cards on the home page and the album page header so the two never drift.
+ *
+ * An album's videos are counted separately from its photos, but only when it has some:
+ * a video-free album reads exactly as it always has ("1 photo", "12 photos"), and an
+ * album that is all video drops the photo half entirely. An empty album is "0 photos".
+ */
+export function mediaCountText(photoCount: number, videoCount: number): string {
+	const photos = `${photoCount} ${photoCount === 1 ? 'photo' : 'photos'}`;
+	const videos = `${videoCount} ${videoCount === 1 ? 'video' : 'videos'}`;
+
+	if (videoCount === 0) return photos;
+	if (photoCount === 0) return videos;
+	return `${photos} · ${videos}`;
+}
+
+/** mediaCountText with the album's date span appended, when it has one. */
+export function albumMetaText(photoCount: number, videoCount: number, dateSpan?: string): string {
+	const counts = mediaCountText(photoCount, videoCount);
+	return dateSpan ? `${counts} · ${dateSpan}` : counts;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -33,7 +33,8 @@ export interface AlbumIndex {
 export interface AlbumSummary {
 	slug: string;
 	title: string;
-	count: number;
+	count: number; // total media items (photos + videos)
+	videoCount?: number; // how many of `count` are videos; omitted when none are
 	cover?: string;
 	coverJpeg?: string;
 	dateSpan: string;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -25,6 +25,7 @@
 	} from '$lib/crypto';
 	import { footerReady } from '$lib/stores';
 	import { navigateCursor, type Direction } from '$lib/navigation';
+	import { albumMetaText } from '$lib/counts';
 	import Lock from 'lucide-svelte/icons/lock';
 	import Image from 'lucide-svelte/icons/image';
 	import CameraOff from 'lucide-svelte/icons/camera-off';
@@ -368,8 +369,11 @@
 							<p class="description">{@html album.description}</p>
 						{/if}
 						<p class="meta">
-							{album.count}
-							{album.count === 1 ? 'photo' : 'photos'}{album.dateSpan ? ` · ${album.dateSpan}` : ''}
+							{albumMetaText(
+								album.count - (album.videoCount ?? 0),
+								album.videoCount ?? 0,
+								album.dateSpan
+							)}
 						</p>
 					</div>
 				</a>

--- a/web/src/routes/albums/[slug]/[[index]]/+page.svelte
+++ b/web/src/routes/albums/[slug]/[[index]]/+page.svelte
@@ -27,6 +27,7 @@
 	} from '$lib/crypto';
 	import { footerReady } from '$lib/stores';
 	import { stripTags } from '$lib/html';
+	import { albumMetaText } from '$lib/counts';
 	import { navigateCursor, type Direction } from '$lib/navigation';
 
 	let { data } = $props();
@@ -110,6 +111,10 @@
 			? photoIndex + 1
 			: null
 	);
+
+	// Media counts for the header line, split so videos are named separately from photos.
+	let videoCount = $derived((album?.photos ?? []).filter((p) => p.kind === 'video').length);
+	let photoCount = $derived((album?.photos ?? []).length - videoCount);
 
 	// Compute layout based on photo aspect ratios
 	let layout = $derived(() => {
@@ -767,10 +772,13 @@
 	});
 </script>
 
+<!-- An album with no description of its own falls back to the site description rather than
+     to a generated sentence about its contents: that sentence only ever appeared for
+     description-less albums, said little beyond a number, and would need maintaining as the
+     kinds of media an album can hold grow. The site description is prose someone wrote. -->
 <OpenGraph
 	title="{albumTitle} | {data.siteConfig.siteName}"
-	description={plainDescription ||
-		(album ? `${album.photos.length} photos from the '${albumTitle}' album` : albumTitle)}
+	description={plainDescription || data.siteConfig.siteDescription}
 	url="{data.siteConfig.siteUrl}/albums/{slug}"
 	siteName={data.siteConfig.siteName}
 	image={album ? `${data.siteConfig.siteUrl}/albums/${slug}/cover.jpg` : undefined}
@@ -812,7 +820,7 @@
 				<p class="description">{@html description}</p>
 			{/if}
 			<p class="meta">
-				{album.photos.length} photos{dateSpan ? ` · ${dateSpan}` : ''}
+				{albumMetaText(photoCount, videoCount, dateSpan)}
 			</p>
 		</header>
 

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -51,6 +51,12 @@ test('album page has correct Open Graph tags', async ({ page }) => {
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /^Antarctica/);
 	await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'website');
+	// The album's own description wins over the site description, which is only the fallback
+	// for an album that has none.
+	await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+		'content',
+		/bottom of the world/
+	);
 	// og:image must be a JPEG (not WebP) — iMessage and many crawlers don't support WebP previews
 	await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
 		'content',

--- a/web/tests/video.spec.ts
+++ b/web/tests/video.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
 	waitForHydration,
 	loadPasswords,
+	unlockSiteIfNeeded,
 	unlockAlbumIfNeeded,
 	findVideo,
 	type FoundVideo
@@ -478,4 +479,32 @@ test('stills in the same album are unaffected', async ({ page, request }) => {
 		// visible. Guards the shared opacity path against a video-only rule leaking out.
 		await expect(caption).toHaveCSS('opacity', '1');
 	}
+});
+
+test('an album holding video counts photos and videos separately', async ({ page, request }) => {
+	test.skip(!video, 'no video published on this site');
+	const v = video!;
+
+	const resp = await request.get(`/albums/${v.slug}/index.json`);
+	const index: { photos: { kind?: string }[] } = await resp.json();
+	const videos = index.photos.filter((p) => p.kind === 'video').length;
+	const stills = index.photos.length - videos;
+
+	// The wording is spelled out rather than imported from $lib/counts so a change to the
+	// shared helper has to be made deliberately in both places.
+	const videoText = `${videos} ${videos === 1 ? 'video' : 'videos'}`;
+	const expected =
+		stills === 0 ? videoText : `${stills} ${stills === 1 ? 'photo' : 'photos'} · ${videoText}`;
+
+	await page.goto(`/albums/${v.slug}`);
+	await unlockAlbumIfNeeded(page, v.slug, pw);
+	await waitForHydration(page);
+	await expect(page.locator('header .meta')).toContainText(expected);
+
+	// The card reads the counts out of albums.json instead of the album index, so it is a
+	// second path to the same line and can drift from the header on its own.
+	await page.goto('/');
+	await unlockSiteIfNeeded(page, pw);
+	await waitForHydration(page);
+	await expect(page.locator(`.album-card[data-slug="${v.slug}"] .meta`)).toContainText(expected);
 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Unit tests for plain TypeScript helpers in src/lib. Deliberately separate from
+// vite.config.ts, which vitest would otherwise pick up: that config loads config/defaults.env,
+// resolves the album directory and installs the SvelteKit plugin, none of which a pure
+// function needs.
+//
+// `include` is narrowed to src for the same reason it cannot be left at the default: the
+// default pattern matches *.spec.ts too, which would hand vitest the Playwright suite in
+// tests/ and fail on the browser fixtures. Unit tests live beside the code they cover;
+// tests/ stays Playwright-only.
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'node'
+	},
+	resolve: {
+		alias: { $lib: resolve(__dirname, 'src/lib') }
+	}
+});


### PR DESCRIPTION
Albums can hold video now, but both count lines still said "n photos" regardless. This
teaches them to name videos separately, and adds a unit test framework for the plain
TypeScript helpers the change introduced.

## Counting rules

The meta line under an album card and in the album page header now reads:

| Album contents | Shows |
|---|---|
| photos only | `n photo` / `n photos` (unchanged) |
| photos + videos | `n photos · n videos` |
| videos only | `n videos` |
| empty | `0 photos` |

Each half is pluralized on its own count, so `1 photo · 2 videos` is a real case. The date
span still follows when present: `20 photos · 1 video · Dec 2004 - Jan 2005`.

The two call sites shared no code before. They do now: `web/src/lib/counts.ts` holds
`mediaCountText()` and `albumMetaText()`, used by both the home page card and the album
page header, so the wording cannot drift between them.

## Where the counts come from

The card and the header read different data, so both needed a source for the split:

- **Album page header** derives it from the album index it already has, counting
  `photos[].kind === 'video'`.
- **Home page card** reads `albums.json`, which had only a total. `AlbumSummary` gains
  `videoCount` (`pkg/photogen/json.go`), with the photo count derived as
  `count - videoCount`.

`count` keeps its existing meaning of *total* media items, and `videoCount` is `omitempty`,
so a site with no video produces a byte-identical `albums.json`. A Go test pins both.

## Open Graph description

An album with no `description` of its own used to get a generated
`"n photos from the '<title>' album"` as its `og:description`. That is dropped in favor of
the site description. It only ever appeared for description-less albums, said little beyond
a number, and would have needed maintaining as the kinds of media an album can hold grow;
the site description is prose someone actually wrote. `site_description` is required by
config validation, so the fallback cannot land on an empty string.

This also removes the tag's dependence on decryption state — it no longer branches on
whether the album index has been decrypted yet.

## Vitest

The counting rules are a pure function of two integers, which needed a browser, a build and
an album to test under Playwright. They no longer do:

```bash
make web-unit-test        # ~0.3s, no browser
```

- `web/vitest.config.ts` is deliberately separate from `vite.config.ts`, which loads
  `config/defaults.env`, resolves the albums directory and installs the SvelteKit plugin —
  none of which a pure function needs. Its `include` is narrowed to `src/**/*.test.ts`,
  because the default pattern also matches `*.spec.ts` and would hand the Playwright suite
  in `web/tests/` to Vitest.
- Unit tests live beside the code they cover (`src/lib/counts.test.ts`). `web/tests/` stays
  Playwright-only.
- `vitest` is the one new dependency, dev-only. `npm audit` reports the same four
  pre-existing low advisories (`cookie` via `@sveltejs/kit`) and nothing new.
- Wired into CI in the `test` job after `web-lint`, and into `make web-sanity-test`, which
  now runs the unit tests first so a wording regression fails before Docker starts.

## Tests

- **Vitest** (13): table-driven coverage of every counting rule, both plural boundaries, and
  the date-span join including empty and `undefined` spans.
- **Playwright** (`video.spec.ts`): an album holding video shows the split counts in both the
  header and its home page card — two separate data paths to the same line.
- **Playwright** (`smoke.spec.ts`): `og:description` is the album's own description, pinning
  that it still wins over the site-description fallback.
- **Go** (`json_test.go`): `count` is the total and `videoCount` its video share; a
  video-free album omits `videoCount` from the JSON entirely.

Docs updated: `docs/TESTING.md` (three ways of testing became four), `docs/MAKEFILE.md`,
and `CLAUDE.md` for the convention that pure helpers get a Vitest file rather than a browser
test.
