### PR TITLE
Check version drift; nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
   pull_request:
     branches:
       - main
+  # Nightly, to catch drift rather than code changes. Everything this repo pins exactly
+  # (web/.nvmrc, web/.npm-version, package-lock.json, the Go toolchain in go.mod) is
+  # already covered by the push and pull_request runs. What a scheduled run adds is the
+  # part that still floats underneath us: the ffmpeg `latest` release, the
+  # debian:bookworm-slim and golang:1.25-bookworm base images, the ubuntu-latest runner
+  # image, the actions at @v4/@v5, apt packages, and Playwright's browser downloads.
+  # Those break on a calendar rather than on a commit, and without this the first person
+  # to find out is whoever opens the next PR.
+  #
+  # Deliberately not on the hour: GitHub queues scheduled runs across all Actions and
+  # drops them under load, and the top of the hour is the worst of it. Two other
+  # constraints worth knowing: a scheduled run only ever uses the default branch (editing
+  # the cron on a PR branch changes nothing until it merges), and GitHub disables the
+  # schedule on a public repo after 60 days with no activity, warning by email first.
+  schedule:
+    - cron: '17 5 * * *'
+      timezone: "America/New_York"
+  # So the nightly path can be exercised without waiting until 5am.
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -190,3 +209,51 @@ jobs:
 
       - name: Run Docker workflow tests
         run: make docker-test
+
+  # A red X on a 5am run that nobody is watching needs somewhere to land: GitHub only
+  # emails the owner, and the run scrolls off the Actions tab. bin/ci-open-issue.sh files
+  # it as an issue, or comments on the open one if the same failure is already tracked.
+  #
+  # Scheduled runs only. On a push or a PR the person who triggered it is already looking
+  # at the result, and an issue would be noise.
+  #
+  # `issues: write` is all this needs, and the built-in GITHUB_TOKEN carries it -- no PAT,
+  # no secret to rotate. The grant has to be explicit because this repo's default workflow
+  # permission is read-only, and it is scoped to this job so the three test jobs above
+  # keep the read-only token they run with today.
+  report-nightly-failure:
+    needs: [test, test-nginx-s3, test-docker]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Open or update the nightly failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cat > "$RUNNER_TEMP/nightly-failure.md" <<EOF
+          The nightly run of this workflow failed.
+
+          | Job | Result |
+          | --- | --- |
+          | test | ${{ needs.test.result }} |
+          | test-nginx-s3 | ${{ needs.test-nginx-s3.result }} |
+          | test-docker | ${{ needs.test-docker.result }} |
+
+          No commit landed to cause this, so the likely culprit is something outside the
+          repo moving: the floating ffmpeg \`latest\` release, a base image
+          (\`debian:bookworm-slim\`, \`golang:1.25-bookworm\`), the \`ubuntu-latest\`
+          runner image, an apt mirror, or a Playwright browser download. A genuinely flaky
+          test is the other possibility -- re-run the workflow to tell them apart.
+
+          [Failing run]($RUN_URL)
+          EOF
+          bash bin/ci-open-issue.sh nightly-ci "Nightly CI is failing" "$RUNNER_TEMP/nightly-failure.md"

--- a/.github/workflows/version-drift.yml
+++ b/.github/workflows/version-drift.yml
@@ -1,0 +1,74 @@
+name: Version Drift
+
+# Nightly check that web/.nvmrc and web/.npm-version have not fallen behind upstream.
+#
+# Those two files hold exact versions deliberately (see CLAUDE.md): a floating tag like
+# `node:24` means the same commit builds a different image depending on the day, and an
+# upstream regression then arrives with no commit to bisect. The cost of pinning exactly
+# is losing the one thing a floating tag gave us for free -- finding out that a fix or a
+# security release shipped.
+#
+# Dependabot cannot restore that. It has no .nvmrc ecosystem, and its docker ecosystem
+# cannot see a version in docker/Dockerfile's `FROM node:${NODE_VERSION}-bookworm-slim`
+# because there is no literal tag there to bump. Renovate could, via its `nvm` manager,
+# at the price of another bot with write access; bin/check-versions.sh is the same signal
+# in one script that also spells out what to edit.
+#
+# Kept out of ci.yml on purpose: this reports on the outside world rather than testing the
+# code, and it must not turn a PR red because Node shipped a patch release.
+#
+# Scheduled runs only ever use the default branch, and GitHub disables the schedule on a
+# public repo after 60 days with no activity (warning by email first).
+
+on:
+  schedule:
+    - cron: '37 5 * * *'
+      timezone: "America/New_York"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # `issues: write` on the built-in GITHUB_TOKEN is all the issue needs: no PAT, no
+    # secret to rotate. It has to be requested explicitly because this repo's default
+    # workflow permission is read-only.
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Compare pinned Node and npm versions against upstream
+        id: check
+        # Exit codes: 0 current, 1 behind, 2 the check itself could not run. Only 2 is a
+        # workflow failure; 1 is the expected day the answer is "yes, there is a newer
+        # one" and is handled by the next step. Hence, `set +e` and the explicit test:
+        # under the default `set -e` the step would go red every time a pin drifted.
+        run: |
+          set +e
+          bash bin/check-versions.sh > "$RUNNER_TEMP/version-report.md"
+          status=$?
+          cat "$RUNNER_TEMP/version-report.md"
+          {
+            echo "## Version drift"
+            echo
+            cat "$RUNNER_TEMP/version-report.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          [ "$status" -le 1 ]
+
+      - name: Open or update the version drift issue
+        if: steps.check.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash bin/ci-open-issue.sh version-drift \
+            "Pinned Node or npm version is behind upstream" \
+            "$RUNNER_TEMP/version-report.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,13 @@ wrong Node, so a machine whose `nvm` default has drifted cannot silently install
 deliberately a major range (`24.x`), not the exact version, so routine patch bumps to `web/.nvmrc`
 do not need a second edit. **When bumping `web/.nvmrc` to a new major, bump `engines.node` too.**
 
+Pinning exactly costs the one thing a floating tag gave for free: notice that a bugfix or security
+release shipped. `bin/check-versions.sh` replaces it, comparing both files against
+`nodejs.org/dist/index.json` and the npm registry. `.github/workflows/version-drift.yml` runs it
+nightly and opens a `version-drift` issue; `make check-versions` runs it locally. It never edits a
+file. Dependabot cannot do this job: it has no `.nvmrc` ecosystem, and its `docker` ecosystem cannot
+see a version in `FROM node:${NODE_VERSION}-bookworm-slim` because there is no literal tag to bump.
+
 ## Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ web-nvm-install:
 	@test -f "$(NVM_SH)" || { echo "nvm not found at $(NVM_SH). Install it from https://github.com/nvm-sh/nvm#installing-and-updating"; exit 1; }
 	$(NVM_INIT) cd web && nvm install && npm install -g npm@$$(cat .npm-version)
 
+.PHONY: check-versions
+## check-versions: report whether the Node/npm versions pinned in web/ are behind upstream
+check-versions:
+	@bin/check-versions.sh; s=$$?; test $$s -le 1
+
 .PHONY: web-npm-install
 ## web-npm-install: install npm dependencies in web/
 web-npm-install:

--- a/bin/check-versions.sh
+++ b/bin/check-versions.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Reports when the Node or npm version this repo pins has fallen behind upstream.
+#
+# web/.nvmrc and web/.npm-version hold *exact* versions on purpose (see CLAUDE.md). A
+# floating tag like `node:24` means the same commit builds a different image depending on
+# the day you built it, and an upstream regression then arrives with no commit to bisect.
+# Node 24.2.0 broke recursive fs.cpSync onto Docker bind mounts exactly that way.
+#
+# The cost of pinning exactly is that nothing tells you when a bugfix or security release
+# ships. Dependabot cannot fill that gap: it has no .nvmrc ecosystem (requested since
+# 2020), and its docker ecosystem cannot read docker/Dockerfile's
+# `FROM node:${NODE_VERSION}-bookworm-slim` because there is no literal tag there to bump.
+# So this script does the comparison, and .github/workflows/version-drift.yml runs it
+# nightly and opens an issue.
+#
+# It deliberately does not edit anything. Bumping Node is a decision that CI then tests,
+# not something that lands unattended.
+#
+# Exit codes:
+#   0  every pin is current
+#   1  at least one pin is behind (the markdown report on stdout says which)
+#   2  the check itself could not run (missing tool, network, unexpected upstream shape)
+#
+# Usage: bin/check-versions.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 2
+
+fail() {
+    echo "Error: $*" >&2
+    exit 2
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required (brew install jq)"
+
+NODE_PINNED=$(tr -d '[:space:]' < web/.nvmrc) || fail "cannot read web/.nvmrc"
+NPM_PINNED=$(tr -d '[:space:]' < web/.npm-version) || fail "cannot read web/.npm-version"
+ENGINES_NODE=$(jq -r '.engines.node // empty' web/package.json) || fail "cannot read web/package.json"
+[ -n "$NODE_PINNED" ] || fail "web/.nvmrc is empty"
+[ -n "$NPM_PINNED" ] || fail "web/.npm-version is empty"
+
+NODE_MAJOR=${NODE_PINNED%%.*}
+case "$NODE_MAJOR" in
+    ''|*[!0-9]*) fail "web/.nvmrc does not start with a major version: '$NODE_PINNED'" ;;
+esac
+
+# A full template containing a path, not GNU's -p or a bare -t prefix: macOS ships BSD
+# mktemp, and this is the spelling both accept (same reasoning as bin/docker-test.sh).
+DIST=$(mktemp "${TMPDIR:-/tmp}/node-dist-index.XXXXXXXX") || fail "mktemp failed"
+trap '/bin/rm -f "$DIST"' EXIT
+
+# The full release index, ~1500 entries back to v0.1.14. Small enough (~250KB) that
+# filtering locally is simpler than hunting for a per-line endpoint.
+curl -fsSL --retry 3 --retry-delay 2 --max-time 60 -o "$DIST" \
+    https://nodejs.org/dist/index.json || fail "could not fetch https://nodejs.org/dist/index.json"
+
+# Newest release on the pinned major's line, with its release date. index.json happens to
+# arrive newest-first, but sort numerically rather than depend on that: a string sort puts
+# 24.9.0 above 24.20.0.
+read -r NODE_NEWEST NODE_NEWEST_DATE <<<"$(jq -r --argjson major "$NODE_MAJOR" '
+    [ .[]
+      | { version: (.version | ltrimstr("v")), date: .date }
+      | . + { parts: (.version | split(".") | map(tonumber)) }
+      | select(.parts[0] == $major) ]
+    | sort_by(.parts) | last
+    | if . == null then "" else "\(.version) \(.date)" end' "$DIST")" \
+    || fail "could not parse the Node release index"
+[ -n "$NODE_NEWEST" ] || fail "no Node $NODE_MAJOR.x releases found in the release index"
+
+# Highest major that carries an LTS codename, so a new LTS line does not go unnoticed.
+NEWEST_LTS_MAJOR=$(jq -r '
+    [ .[] | select(.lts != false) | .version | ltrimstr("v") | split(".") | .[0] | tonumber ]
+    | max // empty' "$DIST") || fail "could not parse LTS lines from the Node release index"
+
+NPM_NEWEST=$(curl -fsSL --retry 3 --retry-delay 2 --max-time 60 \
+    https://registry.npmjs.org/npm/latest | jq -r '.version // empty') \
+    || fail "could not fetch the current npm version from the registry"
+[ -n "$NPM_NEWEST" ] || fail "the npm registry returned no version"
+
+drift=0
+report=""
+add() { report+="$1"$'\n'; }
+
+add "### Node (\`web/.nvmrc\`)"
+add ""
+if [ "$NODE_PINNED" = "$NODE_NEWEST" ]; then
+    add "Current: pinned \`$NODE_PINNED\`, newest on the ${NODE_MAJOR}.x line."
+else
+    drift=1
+    add "**Behind.** Pinned \`$NODE_PINNED\`; newest on the ${NODE_MAJOR}.x line is"
+    add "\`$NODE_NEWEST\` (released $NODE_NEWEST_DATE)."
+    add ""
+    add "Changelog: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V${NODE_MAJOR}.md"
+    add ""
+    add "To take it: edit \`web/.nvmrc\`, run \`make web-nvm-install\`, and let CI test it."
+    add "Nothing else hardcodes the version (Makefile, \`bin/node-init.sh\`, \`bin/docker-push.sh\`,"
+    add "\`docker/Dockerfile\` and the workflows all read that file)."
+fi
+add ""
+
+if [ -n "$NEWEST_LTS_MAJOR" ] && [ "$NEWEST_LTS_MAJOR" -gt "$NODE_MAJOR" ]; then
+    drift=1
+    add "### Node major line"
+    add ""
+    add "**A newer LTS line exists.** Pinned on ${NODE_MAJOR}.x; ${NEWEST_LTS_MAJOR}.x is now LTS."
+    add ""
+    add "A major bump also needs \`engines.node\` in \`web/package.json\` (currently \`$ENGINES_NODE\`)"
+    add "changed by hand; it is a major range on purpose so patch bumps do not need a second edit."
+    add ""
+fi
+
+add "### npm (\`web/.npm-version\`)"
+add ""
+if [ "$NPM_PINNED" = "$NPM_NEWEST" ]; then
+    add "Current: pinned \`$NPM_PINNED\`, which is \`npm@latest\`."
+else
+    drift=1
+    add "**Behind.** Pinned \`$NPM_PINNED\`; \`npm@latest\` is \`$NPM_NEWEST\`."
+    add ""
+    add "To take it: edit \`web/.npm-version\` and run \`make web-nvm-install\`."
+fi
+
+printf '%s' "$report"
+exit "$drift"

--- a/bin/ci-open-issue.sh
+++ b/bin/ci-open-issue.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Files the result of a scheduled workflow as a GitHub issue.
+#
+# A nightly run has nobody watching it. The only thing GitHub does on its own is email the
+# repo owner, which is easy to lose, and the run itself scrolls off the Actions tab. An
+# issue survives until someone closes it.
+#
+# Re-runs comment on the open issue carrying the same label rather than opening a second
+# one, so a problem that persists for a week is one thread and not seven issues.
+#
+# Usage: bin/ci-open-issue.sh <label> <title> <body-file>
+#
+# Requires the `gh` CLI (preinstalled on GitHub runners) with GH_TOKEN set, and
+# `issues: write` on the job. The default GITHUB_TOKEN is enough -- no PAT and no secret --
+# but this repo's default workflow permission is read-only, so the job must ask for it:
+#
+#     permissions:
+#       contents: read
+#       issues: write
+#
+# The repo is taken from the git remote that actions/checkout sets up, so this also works
+# when run by hand from a local clone.
+
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $(basename "$0") <label> <title> <body-file>" >&2
+    exit 2
+fi
+
+LABEL=$1
+TITLE=$2
+BODY_FILE=$3
+
+[ -r "$BODY_FILE" ] || { echo "Error: cannot read body file '$BODY_FILE'" >&2; exit 2; }
+
+BODY=$(cat "$BODY_FILE")
+
+# Link back to the run that produced this, when there is one.
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+    BODY="$BODY
+
+---
+From [\`${GITHUB_WORKFLOW:-workflow}\` run ${GITHUB_RUN_ID}](${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) on $(date -u '+%Y-%m-%d %H:%M UTC')."
+fi
+
+# Idempotent: succeeds the first time, errors harmlessly every night after. Created here
+# rather than assumed so a fork gets the same behavior with no manual repo setup.
+gh label create "$LABEL" --color FBCA04 --description "Opened automatically by a scheduled workflow" >/dev/null 2>&1 || true
+
+EXISTING=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
+
+if [ -n "$EXISTING" ]; then
+    echo "Commenting on existing issue #$EXISTING"
+    gh issue comment "$EXISTING" --body "$BODY"
+else
+    echo "Opening a new issue"
+    gh issue create --label "$LABEL" --title "$TITLE" --body "$BODY"
+fi

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -15,6 +15,7 @@ as defined in `config/defaults.env`.
 | `mod-tidy`                    | Run `go mod tidy` to clean up imports                                                         |
 | `clean-cache`                 | Run `go clean -cache` (useful after a vips library upgrade)                                   |
 | `vet`                         | Run `go vet` static analysis                                                                  |
+| `check-versions`              | Report whether the Node/npm versions pinned in `web/` are behind upstream                     |
 | `web-nvm-install`             | Install the Node version in `web/.nvmrc` and the npm version in `web/.npm-version`            |
 | `web-npm-install`             | Install npm dependencies in `web/`                                                            |
 | `web-npm-audit`               | Run `npm audit` in `web/`                                                                     |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -281,6 +281,28 @@ The workflow in [.github/workflows/ci.yml](../.github/workflows/ci.yml) runs on 
 request to `main`. See that file for all the tests it runs.  Tests are configured to run in parallel
 to minimize CI run time.
 
+It also runs nightly at 5:17am Eastern. A push or pull request run tests the code; the nightly run
+tests everything the repo does *not* pin. Node, npm, `package-lock.json` and the Go toolchain are
+pinned exactly, but the ffmpeg `latest` release, the `debian:bookworm-slim` and `golang:1.25-bookworm`
+base images, the `ubuntu-latest` runner image, apt packages and Playwright's browser downloads all
+move on their own. Those break on a calendar rather than on a commit, so without a scheduled run the
+first person to find out is whoever opens the next PR. When a nightly run fails, the
+`report-nightly-failure` job opens a GitHub issue labeled `nightly-ci` (or comments on the open one)
+via [bin/ci-open-issue.sh](../bin/ci-open-issue.sh), because nobody is watching a 5am run and the
+notification email is easy to miss. Push and pull request runs skip that job.
+
+The workflow in [.github/workflows/version-drift.yml](../.github/workflows/version-drift.yml) runs
+[bin/check-versions.sh](../bin/check-versions.sh) nightly and opens a `version-drift` issue when the
+versions in `web/.nvmrc` or `web/.npm-version` have fallen behind upstream. Pinning those exactly is
+deliberate, and the cost of it is that nothing otherwise tells you a bugfix or security release
+shipped; Dependabot cannot fill the gap (it has no `.nvmrc` ecosystem, and cannot see a version in
+`FROM node:${NODE_VERSION}-bookworm-slim`). It never edits a file: bumping Node is a deliberate
+change that CI then tests. Run the same check locally with `make check-versions`.
+
+Both schedules only ever run on the default branch, so a cron edit on a branch does nothing until it
+merges, and GitHub disables scheduled workflows on a public repo after 60 days of inactivity. Both
+can be triggered by hand from the Actions tab (`workflow_dispatch`).
+
 The workflow in [.github/workflows/docker-release.yml](../.github/workflows/docker-release.yml)
 runs when a new git version tag is created.  If this succeeds,
 [.github/workflows/deploy-sample-sites.yml](../.github/workflows/deploy-sample-sites.yml) is


### PR DESCRIPTION
Adds two scheduled workflows: a nightly run of the existing CI, and a nightly check that the
Node and npm versions pinned in `web/` have not fallen behind upstream. Both file a GitHub
issue when they have something to say.

## Why

Push and pull request runs test the code. Nothing tests the parts of the build that move on
their own.

After #100 this repo pins Node, npm, `package-lock.json` and the Go toolchain exactly. What
still floats underneath: the ffmpeg `latest` release (floating by design now, and the largest
exposure), the `debian:bookworm-slim` and `golang:1.25-bookworm` base images, the
`ubuntu-latest` runner image, the actions at `@v4`/`@v5`, apt packages, and Playwright's
browser downloads. Those break on a calendar rather than on a commit, so today the first
person to find out is whoever opens the next PR. That is exactly how the ffmpeg 404 in #100
surfaced.

Pinning exactly also costs the one thing a floating tag gave for free: notice that a bugfix
or security release shipped. Dependabot cannot fill that gap. It has no `.nvmrc` ecosystem
(open request since 2020), and its `docker` ecosystem cannot see a version in
`FROM node:${NODE_VERSION}-bookworm-slim` because there is no literal tag there to bump.
Renovate could, via its `nvm` manager, at the price of another bot with write access on the
repo. `bin/check-versions.sh` is the same signal in one script that also spells out what to
edit.

## Changes

**`.github/workflows/ci.yml`** gains a `schedule:` trigger at 5:17am Eastern, plus
`workflow_dispatch` so the nightly path can be exercised without waiting until 5am:

```yaml
  schedule:
    - cron: '17 5 * * *'
      timezone: "America/New_York"
```

Deliberately not on the hour: GitHub queues scheduled runs across all of Actions and drops
them under load, and the top of the hour is the worst of it.

A new `report-nightly-failure` job, gated `if: failure() && github.event_name == 'schedule'`,
files the result as an issue labeled `nightly-ci` with a per-job result table and a link to
the run. Nobody is watching a 5am run, GitHub only emails the owner, and the run scrolls off
the Actions tab. Push and pull request runs skip the job, since whoever triggered those is
already looking at the result.

**`bin/check-versions.sh`** compares `web/.nvmrc` against `nodejs.org/dist/index.json` and
`web/.npm-version` against the npm registry, and writes a markdown report saying what to edit.
Exit codes are `0` current, `1` behind, `2` the check itself could not run. It also flags a
newer LTS major line, with the reminder that `engines.node` in `web/package.json` needs a hand
edit in that case. It never modifies a file: bumping Node stays a deliberate change that CI
then tests.

**`.github/workflows/version-drift.yml`** runs that script nightly at 5:37am Eastern, writes
the report to the job summary, and opens a `version-drift` issue only on exit 1. Kept out of
`ci.yml` on purpose: it reports on the outside world rather than testing the code, and it must
not turn a PR red because Node shipped a patch release.

**`bin/ci-open-issue.sh`** is shared by both. It comments on the open issue carrying the same
label rather than opening a second one, so a problem that persists for a week is one thread
and not seven issues. It creates the label itself, so a fork gets the same behavior with no
manual repo setup.

**`make check-versions`** runs the same check locally. Docs updated in `docs/TESTING.md`,
`docs/MAKEFILE.md`, and the Node section of `CLAUDE.md`.

## Permissions

No PAT and no new secret. The built-in `GITHUB_TOKEN` can open issues, but this repo's default
workflow permission is read-only:

```
$ gh api repos/dougdonohoe/ddphotos/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

so the grant has to be explicit. `issues: write` is scoped to the two reporting jobs, leaving
the three test jobs on the read-only token they run with today. `deploy-sample-sites.yml`
already elevates the same way for `id-token: write`.

## Verification

* Both workflows validate clean against the SchemaStore `github-workflow.json` schema, which
  also confirms `timezone` is a real field on `schedule` rather than a silently ignored one.
* `bin/check-versions.sh` exercised through all four paths: current (0), behind (1), older LTS
  major (1, including the `engines.node` note), and both error cases (2).
* `bin/ci-open-issue.sh` driven through a `gh` shim for the create and the comment branches;
  the run-link footer renders correctly in both.
* The nightly-failure heredoc verified by extracting it from the YAML and substituting the
  `${{ }}` expressions, confirming the backtick escaping does not trip command substitution.
* Both scripts are shellcheck clean, and `mktemp` uses the full-path-template spelling that
  `bin/docker-test.sh` already documents as the portable one (macOS ships BSD mktemp).

Running the check against `main` today already reports drift, so the first nightly run will
have something to say:

> **Behind.** Pinned `24.19.0`; newest on the 24.x line is `24.20.0` (released 2026-08-26).

## Notes

Neither schedule does anything until this merges: scheduled runs only ever use the default
branch, so a cron edit on a branch is inert. GitHub also disables scheduled workflows on a
public repo after 60 days with no activity, warning by email first. Both workflows can be
triggered by hand from the Actions tab.
