### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,21 @@ jobs:
         # timeouts, retries, and falls back to archive.ubuntu.com. See its header.
         run: bash bin/ci-apt-install.sh libvips-dev libheif-plugin-libde265 pkg-config
 
+      # Restoring ffmpeg turns the download below into a no-op (do-install-ffmpeg.sh exits
+      # early when both binaries are present), saving ~8s.
+      #
+      # Deliberately not restored on `schedule` or `workflow_dispatch`. Catching drift in
+      # the floating ffmpeg `latest` release is one of the stated reasons the nightly run
+      # exists, and a cache hit would hide exactly that. Same reasoning for the Playwright
+      # cache below. Push and pull_request runs are the ones where the seconds matter and
+      # where a stale-but-working ffmpeg is fine.
+      - name: Cache ffmpeg
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ffmpeg
+          key: ffmpeg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('docker/do-install-ffmpeg.sh') }}
+
       - name: Install ffmpeg
         # The same pinned static build the Docker image fetches on demand, rather than
         # `apt-get install ffmpeg`: the Debian package pulls ~200 packages and 448MB of
@@ -89,11 +104,26 @@ jobs:
       - name: Install npm dependencies
         run: cd web && npm ci
 
+      # Keyed on package-lock.json because the browser build Playwright wants is pinned by
+      # the @playwright/test version. Not restored on the nightly; see "Cache ffmpeg" above.
+      - name: Cache Playwright browsers
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+
       # test-cover rather than test: setup-go installs a full Go distribution, so the
       # `covdata` tool is present and coverage works. `make test` drops -cover so it also
       # works with a toolchain fetched via GOTOOLCHAIN auto-download (see the Makefile).
       - name: Go build, test, vet
         run: make build test-cover vet
+        env:
+          # The race detector is 67s of this step's 102s, so it runs on the nightly rather
+          # than on every push. See the RACE comment in the Makefile for what that costs.
+          # The blank branch is a single space, not an empty string: an empty string is
+          # falsy to `&&`/`||`, so GitHub would fall through and always pick '-race'.
+          RACE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '-race' || ' ' }}
 
       - name: Web lint (prettier + eslint)
         run: make web-lint
@@ -116,11 +146,15 @@ jobs:
       - name: Run Apache routing tests
         run: make web-docker-build-apache sample-test-apache
 
-      - name: Run Apache Playwright e2e tests (all password variants)
-        run: bin/test-all.sh --mode apache --ci
-
+      # Before the e2e step, not after. bin/test-all.sh shares the "sample" site directory
+      # across five of its six variants (see its header), so it rewrites albums/sample and
+      # build/sample as it goes. This step and bin/s3-test.sh both assume the plain sample
+      # site that "Photogen and build" produced, so they have to read it first.
       - name: Run rsync deploy test
         run: make sample-rsync-test
+
+      - name: Run Apache Playwright e2e tests (all password variants)
+        run: bin/test-all.sh --mode apache
 
   # Split out nginx/s3 tests to run in parallel
   test-nginx-s3:
@@ -137,6 +171,15 @@ jobs:
         # (once for 66 minutes, until the job timeout killed it). The script bounds apt's
         # timeouts, retries, and falls back to archive.ubuntu.com. See its header.
         run: bash bin/ci-apt-install.sh libvips-dev libheif-plugin-libde265 pkg-config
+
+      - name: Cache ffmpeg
+        # Not restored on the nightly, so it still exercises a fresh download; see the
+        # 'test' job above.
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ffmpeg
+          key: ffmpeg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('docker/do-install-ffmpeg.sh') }}
 
       - name: Install ffmpeg
         # Static build rather than `apt-get install ffmpeg`; see the 'test' job above.
@@ -166,6 +209,14 @@ jobs:
       - name: Install npm dependencies
         run: cd web && npm ci
 
+      - name: Cache Playwright browsers
+        # Not restored on the nightly; see the 'test' job above.
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+
       - name: Install Playwright Chromium
         # Deliberately no `npx playwright install-deps chromium`; see the 'test' job above.
         run: make web-playwright-install
@@ -176,14 +227,17 @@ jobs:
       - name: Run nginx routing tests
         run: make web-docker-build-nginx sample-test-nginx
 
-      - name: Run nginx Playwright e2e tests (all password variants)
-        run: bin/test-all.sh --mode nginx --ci
-
+      # Both deploy tests run before the e2e step, which rewrites albums/sample and
+      # build/sample; see the same note in the 'test' job. bin/s3-test.sh in particular
+      # hardcodes SITE_ID=sample and asserts on plaintext album JSON.
       - name: Run nginx rsync deploy test
         run: make sample-rsync-test-nginx
 
       - name: Run S3 deploy test
         run: make sample-s3-test
+
+      - name: Run nginx Playwright e2e tests (all password variants)
+        run: bin/test-all.sh --mode nginx
 
   # Docker-mode tests of 'ddphotos' can run in parallel
   test-docker:
@@ -207,10 +261,25 @@ jobs:
       - name: Install npm dependencies
         run: cd web && npm ci
 
+      - name: Cache Playwright browsers
+        # Not restored on the nightly; see the 'test' job above.
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+
       - name: Install Playwright Chromium
         # Deliberately no `npx playwright install-deps chromium`; see the 'test' job above.
         run: make web-playwright-install
 
+      # `make docker-build`, which bin/docker-test.sh runs, is ~100s of this job with no
+      # layer cache behind it: docker/Dockerfile installs apt packages and compiles the Go
+      # binary from scratch every time. A buildx cache was tried and dropped. It saves no
+      # wall clock, because this job is well under the critical path set by 'test', and
+      # buildx's type=gha backend needs ACTIONS_RUNTIME_TOKEN exported by a third-party
+      # action, while type=local needs an export-and-swap dance around actions/cache.
+      # Revisit if this job ever becomes the longest one.
       - name: Run Docker workflow tests
         run: make docker-test
 

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,23 @@ GO_PKGS := ./cmd/... ./pkg/...
 build:
 	go build -ldflags "-X main.repoRoot=$(PWD)" $(GO_PKGS)
 
+# RACE is the race-detector flag, overridable so CI can drop it. -race catches data races
+# in the concurrent resize and metadata workers. It needs cgo, which is already required by
+# govips, and roughly doubles the runtime: 67s of the 102s that `make build test-cover vet`
+# spends on a 2 vCPU runner.
+#
+# Default on, so `make test` locally is unchanged and nobody has to remember a flag. CI
+# clears it on push and pull_request and leaves the default on the nightly schedule, where
+# an extra minute costs nothing and a failure lands as a tracked issue via
+# bin/ci-open-issue.sh. The trade-off is that a race introduced in a PR is caught that
+# night rather than on the PR itself.
+#
+# `?=` rather than `=` is what makes the override work: an environment variable counts as
+# already defined, so ci.yml's `env: RACE:` wins, while a plain `make test` gets -race.
+RACE ?= -race
+
 .PHONY: test
-## test: run `go test` (with the race detector)
-# -race catches data races in the concurrent resize and metadata workers. It needs cgo,
-# which is already required by govips, and roughly doubles the runtime.
+## test: run `go test` (with the race detector; RACE= to disable)
 #
 # -cover is deliberately NOT here: it needs the `covdata` tool, which a toolchain fetched
 # via GOTOOLCHAIN auto-download does not supply, so `go test -cover` fails with
@@ -79,12 +92,12 @@ build:
 # go.mod — e.g. Ubuntu 24.04, whose apt golang-go is 1.22 and downloads 1.25 on demand.
 # Use `make test-cover` for coverage; it needs a real Go install (see docs/INSTALL.md).
 test:
-	go test -v -race $(GO_PKGS)
+	go test -v $(RACE) $(GO_PKGS)
 
 .PHONY: test-cover
 ## test-cover: run `go test` with coverage (needs a full Go install, not a downloaded toolchain)
 test-cover:
-	go test -v -race -cover $(GO_PKGS)
+	go test -v $(RACE) -cover $(GO_PKGS)
 
 .PHONY: vet
 ## vet: run `go vet`

--- a/bin/deploy-photos.sh
+++ b/bin/deploy-photos.sh
@@ -10,6 +10,7 @@ SKIP_BUILD=false
 SKIP_PRE_DEPLOY=false
 SKIP_RSYNC=false
 SKIP_PLAYWRIGHT=false
+PLAYWRIGHT_SMOKE=false
 SKIP_SERVER_TEST=false
 DRY_RUN=false
 S3_MODE=false
@@ -25,6 +26,7 @@ while [[ $# -gt 0 ]]; do
         --no-pre-deploy-tests) SKIP_PRE_DEPLOY=true; shift ;;
         --no-rsync)          SKIP_RSYNC=true; shift ;;
         --no-playwright)     SKIP_PLAYWRIGHT=true; shift ;;
+        --playwright-smoke)  PLAYWRIGHT_SMOKE=true; shift ;;
         --no-server-test)    SKIP_SERVER_TEST=true; shift ;;
         --dry-run)           DRY_RUN=true; shift ;;
         --s3)                S3_MODE=true; shift ;;
@@ -55,11 +57,29 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-pre-deploy-tests  Skip pre-deploy server and Playwright tests" >&2
             echo "  --no-rsync             Skip rsync/S3 sync and post-deploy steps" >&2
             echo "  --no-playwright        Skip Playwright tests (pre- and post-deploy)" >&2
+            echo "  --playwright-smoke     Run only the @deploy-tagged Playwright tests" >&2
             echo "  --no-server-test       Skip server tests (pre- and post-deploy)" >&2
             exit 1
             ;;
     esac
 done
+
+# --playwright-smoke narrows both Playwright runs to the tests tagged @deploy: the ones that
+# fail when the *deployed tree* is wrong rather than when the app is. Those are the checks
+# bin/test-photos-server.sh cannot make, since it only curls for status codes: the home page
+# and grid rendering from deployed JSON, an OG image resolving to a real .jpg, grid WebPs
+# actually decoding, and the MP4 arriving as video/mp4 with byte ranges.
+#
+# Off by default. A real deploy wants the whole suite against the live site; this exists for
+# bin/rsync-test.sh, where the point is to prove deploy-photos.sh moved the right bytes to
+# the right places, and re-running 87 app tests against a container costs ~38s to prove
+# nothing the other variants have not already proven.
+PLAYWRIGHT_ARGS=()
+PLAYWRIGHT_SMOKE_LABEL=""
+if [ "$PLAYWRIGHT_SMOKE" = true ]; then
+    PLAYWRIGHT_ARGS=(--grep @deploy)
+    PLAYWRIGHT_SMOKE_LABEL=" (@deploy subset)"
+fi
 
 # --server selects the image used for the pre-deploy local tests only. It has no effect on
 # what gets deployed: both servers are fed the identical two-source tree (see docs/DEPLOY.md).
@@ -231,8 +251,8 @@ _pre_deploy() {
         if [ "$SKIP_PLAYWRIGHT" = true ]; then
             echo "Skipping pre-deploy Playwright tests (--no-playwright)"
         else
-            echo "Running pre-deploy Playwright e2e tests..."
-            npx playwright test
+            echo "Running pre-deploy Playwright e2e tests${PLAYWRIGHT_SMOKE_LABEL}..."
+            npx playwright test "${PLAYWRIGHT_ARGS[@]}"
         fi
     fi
 }
@@ -274,8 +294,8 @@ _post_deploy() {
     elif [ "$DRY_RUN" = true ]; then
         echo "DRY RUN: skipping Playwright tests against production"
     else
-        echo "Running Playwright e2e tests against production $SITE_URL..."
-        PLAYWRIGHT_BASE_URL="$SITE_URL" npx playwright test
+        echo "Running Playwright e2e tests${PLAYWRIGHT_SMOKE_LABEL} against production $SITE_URL..."
+        PLAYWRIGHT_BASE_URL="$SITE_URL" npx playwright test "${PLAYWRIGHT_ARGS[@]}"
     fi
 }
 

--- a/bin/rsync-test.sh
+++ b/bin/rsync-test.sh
@@ -77,4 +77,4 @@ until curl -s -o /dev/null "http://localhost:$HTTP_PORT"; do sleep 1; done
 # Run full deploy: photogen → build → rsync → post-deploy server tests + Playwright.
 # RSYNC_RSH tells rsync which SSH command to use (custom port + test key).
 export RSYNC_RSH="ssh -i $TEST_KEY -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-bin/deploy-photos.sh --no-pre-deploy-tests --server "$SERVER" --config-dir "$TEMP_CONFIG"
+bin/deploy-photos.sh --no-pre-deploy-tests --playwright-smoke --server "$SERVER" --config-dir "$TEMP_CONFIG"

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -2,7 +2,7 @@
 # Run Playwright tests against one variant of the sample site.
 #
 # Usage:
-#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--test <file>] [--ci]
+#   bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--test <file>] [--site-id <id>]
 #
 # --passwords  Path to a passwords file (e.g. sample/config/passwords-all.yaml).
 #              Omit for the no-password variant.
@@ -18,8 +18,12 @@
 #              all    — dev, apache, and nginx
 # --test       Run only the specified test file (passed directly to Playwright).
 #              e.g. --test tests/privacy.spec.ts
-# --ci         Skip photogen if albums/<site-id> already exists; skip npm build if build/ exists.
-#              Speeds up CI by reusing output from a prior run or step.
+# --site-id    Albums directory to generate into, overriding the derived one. See the
+#              "Site ID" comment below for why bin/test-all.sh shares one across variants.
+#
+# Note for anyone editing .github/workflows/ci.yml: with a shared --site-id this script
+# rewrites albums/sample and build/sample, so the rsync and S3 deploy steps, which assume
+# the plain sample site, must run *before* the step that calls bin/test-all.sh.
 
 set -eo pipefail
 
@@ -27,10 +31,10 @@ PASSWORDS_FILE=""
 CSS_FILE=""
 CUSTOMIZATION_FILE=""
 MODE="all"
-CI_MODE=false
+SITE_ID_OVERRIDE=""
 
 usage() {
-    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--ci]"
+    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--site-id <id>]"
     echo ""
     echo "Options:"
     echo "  --passwords <file>  Path to a passwords file (e.g. sample/config/passwords-all.yaml)."
@@ -46,7 +50,7 @@ usage() {
     echo "                        nginx  — static build + Docker/nginx on port 8084"
     echo "                        all    — dev, apache, and nginx"
     echo "  --test <file>       Run only a specific test file (e.g. tests/privacy.spec.ts)."
-    echo "  --ci                Skip photogen if albums/<site-id> exists; skip npm build if build/ exists."
+    echo "  --site-id <id>      Albums directory to generate into, overriding the derived one."
     echo "  --help, -?          Show this help message and exit."
 }
 
@@ -60,7 +64,8 @@ while [[ $# -gt 0 ]]; do
         --customization=*) CUSTOMIZATION_FILE="${1#*=}"; shift ;;
         --mode)        MODE="$2"; shift 2 ;;
         --mode=*)      MODE="${1#*=}"; shift ;;
-        --ci)          CI_MODE=true; shift ;;
+        --site-id)     SITE_ID_OVERRIDE="$2"; shift 2 ;;
+        --site-id=*)   SITE_ID_OVERRIDE="${1#*=}"; shift ;;
         --test)        TEST_FILTER="$2"; shift 2 ;;
         --test=*)      TEST_FILTER="${1#*=}"; shift ;;
         --help|-\?)    usage; exit 0 ;;
@@ -94,30 +99,48 @@ if [ -n "$CSS_FILE" ]; then
     [ -f "$CSS_FILE" ] || { echo "Error: CSS file not found: $CSS_FILE" >&2; exit 1; }
 fi
 
-# Derive site-id from flags.
-# Convention: passwords-all.yaml -> site-id "sample-pw-all"
-#             passwords-uganda.yaml -> site-id "sample-pw-uganda"
-#             --css <file> -> site-id "sample-css"
-#             --customization customization-album-nav.yaml -> site-id "sample-album-nav"
-#             (no flags) -> site-id "sample"
+# --- Site ID ---
+#
+# The albums directory this variant's media lands in. Variants that encrypt the same set
+# of albums can share one, which is what bin/test-all.sh does via --site-id, and it is the
+# single biggest saving in CI: a shared directory already holds every WebP and MP4, so
+# photogen skips the resize and the ffmpeg transcode entirely and only rewrites the JSON.
+#
+# Safe to share because media bytes never depend on encryption, CSS or customization.
+# What encryption changes is output *filenames*: Config.PhotoOutputName
+# (pkg/photogen/config.go) HMACs the name only for albums that actually have a password,
+# so two variants encrypting the same albums produce identically named, byte-identical
+# media. It stays safe across runs because -clean normalizes the directory to the current
+# variant every time: everything photogen writes is registered with TrackFile, and
+# CleanOutputDir removes whatever the previous variant left behind, top-level files
+# (custom.css, albums.enc.json) included. Anything ever written *without* a TrackFile call
+# would survive into the next variant and be served, which is the one way this breaks.
+#
+# The derivation below is the fallback for a direct invocation, where a self-describing
+# directory is more useful than a shared one:
+#   passwords-all.yaml -> "sample-pw-all", passwords-uganda.yaml -> "sample-pw-uganda",
+#   --css -> "sample-css", customization-album-nav.yaml -> "sample-album-nav",
+#   no flags -> "sample"
 SITE_ID="sample"
 PHOTOGEN_FLAGS=(-config-dir sample/config -resize -index -clean -doit)
 if [ -n "$PASSWORDS_FILE" ]; then
     BASENAME=$(basename "$PASSWORDS_FILE" .yaml)  # e.g. "passwords-all"
-    VARIANT="${BASENAME#passwords-}"               # e.g. "all"
-    SITE_ID="sample-pw-${VARIANT}"
-    PHOTOGEN_FLAGS=(-config-dir sample/config -resize -index -clean -passwords "$PASSWORDS_FILE" -site-id "$SITE_ID" -doit)
+    SITE_ID="sample-pw-${BASENAME#passwords-}"     # e.g. "sample-pw-all"
+    PHOTOGEN_FLAGS+=(-passwords "$PASSWORDS_FILE")
 fi
 if [ -n "$CSS_FILE" ]; then
     SITE_ID="sample-css"
-    PHOTOGEN_FLAGS=(-config-dir sample/config -resize -index -clean -css "$CSS_FILE" -site-id "$SITE_ID" -doit)
+    PHOTOGEN_FLAGS+=(-css "$CSS_FILE")
 fi
 if [ -n "$CUSTOMIZATION_FILE" ]; then
-    BASENAME=$(basename "$CUSTOMIZATION_FILE" .yaml)   # e.g. "customization-album-nav"
-    VARIANT="${BASENAME#customization-}"                # e.g. "album-nav"
-    SITE_ID="sample-${VARIANT}"
-    PHOTOGEN_FLAGS=(-config-dir sample/config -resize -index -clean -customization "$CUSTOMIZATION_FILE" -site-id "$SITE_ID" -doit)
+    BASENAME=$(basename "$CUSTOMIZATION_FILE" .yaml)  # e.g. "customization-album-nav"
+    SITE_ID="sample-${BASENAME#customization-}"        # e.g. "sample-album-nav"
+    PHOTOGEN_FLAGS+=(-customization "$CUSTOMIZATION_FILE")
 fi
+if [ -n "$SITE_ID_OVERRIDE" ]; then
+    SITE_ID="$SITE_ID_OVERRIDE"
+fi
+PHOTOGEN_FLAGS+=(-site-id "$SITE_ID")
 
 ALBUMS_DIR="$(pwd)/albums"
 
@@ -139,14 +162,14 @@ trap cleanup EXIT
 trap 'exit 130' INT TERM
 
 # --- photogen (done once, shared across all modes) ---
-if $CI_MODE && [ -d "$ALBUMS_DIR/$SITE_ID" ]; then
-    echo ""
-    echo "=== [--ci] Skipping photogen: $ALBUMS_DIR/$SITE_ID already exists ==="
-else
-    echo ""
-    echo "=== Generating sample data (site-id: $SITE_ID) ==="
-    go run cmd/photogen/photogen.go "${PHOTOGEN_FLAGS[@]}"
-fi
+#
+# Always run, even when the site directory already exists. It is cheap when it does (every
+# output is present, so photogen stats and skips it), and skipping it outright would leave
+# the previous variant's config.json, albums.json and custom.css in place, quietly testing
+# the wrong site.
+echo ""
+echo "=== Generating sample data (site-id: $SITE_ID) ==="
+go run cmd/photogen/photogen.go "${PHOTOGEN_FLAGS[@]}"
 
 # --- helper: run Playwright against a base URL ---
 run_playwright() {
@@ -197,16 +220,14 @@ run_dev() {
 
 # --- apache mode ---
 run_apache() {
-    if $CI_MODE && [ -d "$(pwd)/build/$SITE_ID" ]; then
-        echo ""
-        echo "=== [apache] [--ci] Skipping npm build: build/$SITE_ID already exists ==="
-    else
-        echo ""
-        echo "=== [apache] Building static site '$SITE_ID' ==="
-        # Explicit error check: set -e is suppressed inside functions called via ||
-        # (see run_apache || OVERALL_EXIT=$? below), so failures must be caught manually.
-        (cd web && DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
-    fi
+    # Always rebuild, for the same reason photogen always runs: hooks.server.ts reads
+    # /albums/*.json off disk during pre-rendering and bakes it into the HTML, so the
+    # static build belongs to one variant even when the site ID is shared.
+    echo ""
+    echo "=== [apache] Building static site '$SITE_ID' ==="
+    # Explicit error check: set -e is suppressed inside functions called via ||
+    # (see run_apache || OVERALL_EXIT=$? below), so failures must be caught manually.
+    (cd web && DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
 
     # Build Docker image if missing or stale
     "$SDIR/docker-check.sh" --build || return 1
@@ -230,14 +251,10 @@ run_apache() {
 
 # --- nginx mode ---
 run_nginx() {
-    if $CI_MODE && [ -d "$(pwd)/build/$SITE_ID" ]; then
-        echo ""
-        echo "=== [nginx] [--ci] Skipping npm build: build/$SITE_ID already exists ==="
-    else
-        echo ""
-        echo "=== [nginx] Building static site '$SITE_ID' ==="
-        (cd web && DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
-    fi
+    # Always rebuild; see run_apache.
+    echo ""
+    echo "=== [nginx] Building static site '$SITE_ID' ==="
+    (cd web && DDPHOTOS_ALBUMS_DIR="$ALBUMS_DIR" DDPHOTOS_SITE_ID="$SITE_ID" npm run build) || return 1
 
     # Build Docker image if missing or stale
     "$SDIR/docker-check.sh" --server nginx --build || return 1

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -20,6 +20,9 @@
 #              e.g. --test tests/privacy.spec.ts
 # --site-id    Albums directory to generate into, overriding the derived one. See the
 #              "Site ID" comment below for why bin/test-all.sh shares one across variants.
+# --skip-video Set PLAYWRIGHT_SKIP_VIDEO, which skips web/tests/video.spec.ts. For a
+#              variant whose transcoded MP4s are byte-identical to a variant that already
+#              covers them; see the note above the run_variant calls in bin/test-all.sh.
 #
 # Note for anyone editing .github/workflows/ci.yml: with a shared --site-id this script
 # rewrites albums/sample and build/sample, so the rsync and S3 deploy steps, which assume
@@ -32,9 +35,10 @@ CSS_FILE=""
 CUSTOMIZATION_FILE=""
 MODE="all"
 SITE_ID_OVERRIDE=""
+SKIP_VIDEO=false
 
 usage() {
-    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--site-id <id>]"
+    echo "Usage: bin/run-tests.sh [--passwords <file>] [--css <file>] [--customization <file>] [--mode dev|apache|nginx|all] [--site-id <id>] [--skip-video]"
     echo ""
     echo "Options:"
     echo "  --passwords <file>  Path to a passwords file (e.g. sample/config/passwords-all.yaml)."
@@ -51,6 +55,7 @@ usage() {
     echo "                        all    — dev, apache, and nginx"
     echo "  --test <file>       Run only a specific test file (e.g. tests/privacy.spec.ts)."
     echo "  --site-id <id>      Albums directory to generate into, overriding the derived one."
+    echo "  --skip-video        Skip video.spec.ts (its MP4s are covered by another variant)."
     echo "  --help, -?          Show this help message and exit."
 }
 
@@ -66,6 +71,7 @@ while [[ $# -gt 0 ]]; do
         --mode=*)      MODE="${1#*=}"; shift ;;
         --site-id)     SITE_ID_OVERRIDE="$2"; shift 2 ;;
         --site-id=*)   SITE_ID_OVERRIDE="${1#*=}"; shift ;;
+        --skip-video)  SKIP_VIDEO=true; shift ;;
         --test)        TEST_FILTER="$2"; shift 2 ;;
         --test=*)      TEST_FILTER="${1#*=}"; shift ;;
         --help|-\?)    usage; exit 0 ;;
@@ -179,6 +185,7 @@ run_playwright() {
         export PLAYWRIGHT_BASE_URL="$base_url"
         [ -n "$PASSWORDS_FILE" ] && export PLAYWRIGHT_PASSWORDS_FILE="$PASSWORDS_FILE"
         [ -n "$CSS_FILE" ] && export PLAYWRIGHT_CUSTOM_CSS="true"
+        [ "$SKIP_VIDEO" = true ] && export PLAYWRIGHT_SKIP_VIDEO="true"
         npx playwright test ${TEST_FILTER:+"$TEST_FILTER"}
     )
 }

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -2,26 +2,49 @@
 # Run Playwright tests against all sample site variants:
 #   1. No passwords (plain site)
 #   2. passwords-all.yaml (entire site encrypted + Uganda per-album)
-#   3. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)
-#   4. custom-css (sample/config/custom-example.css injected)
-#   5. album-nav (customization.yaml replacing the album page's "← Albums" link)
-#   6. passwords-uganda.yaml (Uganda album only)
+#   3. config-extras: passwords-keyonly.yaml + custom CSS + album-nav customization
+#   4. passwords-uganda.yaml (Uganda album only)
 #
 # Usage:
 #   bin/test-all.sh [--mode dev|apache|nginx|all]
 #
 # Passes --mode through to bin/run-tests.sh (default: all).
 #
-# Site IDs are assigned per variant rather than derived, so five of the six share one
-# albums directory and photogen has no media left to generate for them. What decides the
-# grouping is which albums each variant encrypts, and nothing else (see the "Site ID"
-# comment in bin/run-tests.sh):
+#
+# --- Why four variants and not six ---
+#
+# keyonly, custom-css and album-nav used to be three separate runs. Diffing their generated
+# sites against the plain one shows why they no longer are: each differs from plain by a
+# single config.json field, and nothing else. Every WebP, MP4 and index.json is identical.
+#
+#   variant             entries differing from the plain site
+#   passwords-keyonly   1   config.json gains "keyId"
+#   custom-css          2   config.json gains "customCss", plus custom.css itself
+#   album-nav           1   config.json gains "albumNav"
+#   passwords-uganda    89  Uganda HMAC'd, no cover.jpg, albums.json differs
+#   passwords-all       278 all three albums HMAC'd, albums.enc.json, no covers
+#
+# The three fields are orthogonal, so one run with all three set covers what the three
+# separate runs did. Measured: the union of the three runs was 69 tests, the combined run
+# is 67, and the only two it drops are the negative assertions ("CSS link is NOT present
+# when not configured", "default back link when album_nav is not configured"), which still
+# run in every other variant. That took ~114s off each e2e job.
+#
+# What it gives up: "css alone" and "album-nav alone" are no longer exercised. Plain covers
+# neither-configured and this covers both-configured, so only the exactly-one combinations
+# are untested. Split it back out if that ever matters.
+#
+#
+# --- Site IDs ---
+#
+# Assigned per variant rather than derived, so three of the four share one albums directory
+# and photogen has no media left to generate for them. What decides the grouping is which
+# albums each variant encrypts, and nothing else (see the "Site ID" comment in
+# bin/run-tests.sh):
 #
 #   variant              the-way  uganda  antarctica   site ID
 #   no passwords          plain    plain    plain      sample
-#   passwords-keyonly     plain    plain    plain      sample     (protects nothing)
-#   custom-css            plain    plain    plain      sample
-#   album-nav             plain    plain    plain      sample
+#   config-extras         plain    plain    plain      sample
 #   passwords-uganda      plain    HMAC     plain      sample     (runs last, see below)
 #   passwords-all         HMAC     HMAC     HMAC       sample-pw-all
 #
@@ -38,10 +61,8 @@ usage() {
     echo "Runs Playwright tests against all sample site variants:"
     echo "  1. No passwords (plain site)"
     echo "  2. passwords-all.yaml (entire site + Uganda album encrypted)"
-    echo "  3. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)"
-    echo "  4. custom-css (sample/config/custom-example.css injected)"
-    echo "  5. album-nav (customization.yaml replacing the album page's \"← Albums\" link)"
-    echo "  6. passwords-uganda.yaml (Uganda album only)"
+    echo "  3. config-extras (passwords-keyonly.yaml + custom CSS + album-nav customization)"
+    echo "  4. passwords-uganda.yaml (Uganda album only)"
     echo ""
     echo "Options:"
     echo "  --mode <mode>  Server to test against: dev, apache, nginx, or all (default: all)."
@@ -76,16 +97,22 @@ run_variant() {
     bin/run-tests.sh "$@" --mode "$MODE"
 }
 
-# passwords-uganda runs last of the five sharing "sample". It is the only one of them
+# passwords-uganda runs last of the three sharing "sample". It is the only one of them
 # whose media set differs (HMAC'd Uganda rather than plain), so running it anywhere else
 # in the order would have -clean delete Uganda's WebPs and the next variant regenerate
 # them, paying that twice instead of once.
-run_variant "no passwords"           --site-id sample
-run_variant "passwords-all.yaml"     --site-id sample-pw-all --passwords sample/config/passwords-all.yaml
-run_variant "passwords-keyonly.yaml" --site-id sample        --passwords sample/config/passwords-keyonly.yaml
-run_variant "custom-css"             --site-id sample        --css sample/config/custom-example.css
-run_variant "album-nav"              --site-id sample        --customization sample/config/customization-album-nav.yaml
-run_variant "passwords-uganda.yaml"  --site-id sample        --passwords sample/config/passwords-uganda.yaml
+#
+# PLAYWRIGHT_SKIP_VIDEO on the last two: their video outputs are byte-identical to the
+# plain site's (same sources, same encode settings, same filenames), so the video suite is
+# re-testing files it already tested. passwords-all skips it on its own, because a locked
+# site publishes no discoverable video. See web/tests/video.spec.ts.
+run_variant "no passwords"          --site-id sample
+run_variant "passwords-all.yaml"    --site-id sample-pw-all --passwords sample/config/passwords-all.yaml
+run_variant "config-extras"         --site-id sample --skip-video \
+    --passwords sample/config/passwords-keyonly.yaml \
+    --css sample/config/custom-example.css \
+    --customization sample/config/customization-album-nav.yaml
+run_variant "passwords-uganda.yaml" --site-id sample --skip-video --passwords sample/config/passwords-uganda.yaml
 
 echo ""
 echo "All variants passed."

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -2,31 +2,46 @@
 # Run Playwright tests against all sample site variants:
 #   1. No passwords (plain site)
 #   2. passwords-all.yaml (entire site encrypted + Uganda per-album)
-#   3. passwords-uganda.yaml (Uganda album only)
-#   4. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)
-#   5. custom-css (sample/config/custom-example.css injected)
-#   6. album-nav (customization.yaml replacing the album page's "← Albums" link)
+#   3. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)
+#   4. custom-css (sample/config/custom-example.css injected)
+#   5. album-nav (customization.yaml replacing the album page's "← Albums" link)
+#   6. passwords-uganda.yaml (Uganda album only)
 #
 # Usage:
-#   bin/test-all.sh [--mode dev|apache|nginx|all] [--ci]
+#   bin/test-all.sh [--mode dev|apache|nginx|all]
 #
-# Passes --mode and --ci through to bin/run-tests.sh (default: all).
+# Passes --mode through to bin/run-tests.sh (default: all).
+#
+# Site IDs are assigned per variant rather than derived, so five of the six share one
+# albums directory and photogen has no media left to generate for them. What decides the
+# grouping is which albums each variant encrypts, and nothing else (see the "Site ID"
+# comment in bin/run-tests.sh):
+#
+#   variant              the-way  uganda  antarctica   site ID
+#   no passwords          plain    plain    plain      sample
+#   passwords-keyonly     plain    plain    plain      sample     (protects nothing)
+#   custom-css            plain    plain    plain      sample
+#   album-nav             plain    plain    plain      sample
+#   passwords-uganda      plain    HMAC     plain      sample     (runs last, see below)
+#   passwords-all         HMAC     HMAC     HMAC       sample-pw-all
+#
+# passwords-all needs its own directory: a site-wide password encrypts every album, so
+# every output filename is HMAC'd and none of the plain media is reusable.
 
 set -eo pipefail
 
 MODE="all"
-CI_FLAG=""
 
 usage() {
-    echo "Usage: bin/test-all.sh [--mode dev|apache|nginx|all] [--ci]"
+    echo "Usage: bin/test-all.sh [--mode dev|apache|nginx|all]"
     echo ""
     echo "Runs Playwright tests against all sample site variants:"
     echo "  1. No passwords (plain site)"
     echo "  2. passwords-all.yaml (entire site + Uganda album encrypted)"
-    echo "  3. passwords-uganda.yaml (Uganda album only)"
-    echo "  4. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)"
-    echo "  5. custom-css (sample/config/custom-example.css injected)"
-    echo "  6. album-nav (customization.yaml replacing the album page's \"← Albums\" link)"
+    echo "  3. passwords-keyonly.yaml (passwords file with no effective password — nothing encrypted)"
+    echo "  4. custom-css (sample/config/custom-example.css injected)"
+    echo "  5. album-nav (customization.yaml replacing the album page's \"← Albums\" link)"
+    echo "  6. passwords-uganda.yaml (Uganda album only)"
     echo ""
     echo "Options:"
     echo "  --mode <mode>  Server to test against: dev, apache, nginx, or all (default: all)."
@@ -34,7 +49,6 @@ usage() {
     echo "                   apache — static build + Docker/Apache on port 8083"
     echo "                   nginx  — static build + Docker/nginx on port 8084"
     echo "                   all    — dev, apache, and nginx"
-    echo "  --ci           Skip photogen if albums/<site-id> exists; skip npm build if build/ exists."
     echo "  --help, -?     Show this help message and exit."
 }
 
@@ -42,7 +56,6 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --mode)        MODE="$2"; shift 2 ;;
         --mode=*)      MODE="${1#*=}"; shift ;;
-        --ci)          CI_FLAG="--ci"; shift ;;
         --help|-\?)    usage; exit 0 ;;
         *) echo "Unknown flag: $1" >&2; exit 1 ;;
     esac
@@ -60,15 +73,19 @@ run_variant() {
     echo "###############################################################"
     echo "# Variant: $label"
     echo "###############################################################"
-    bin/run-tests.sh "$@" --mode "$MODE" $CI_FLAG
+    bin/run-tests.sh "$@" --mode "$MODE"
 }
 
-run_variant "no passwords"
-run_variant "passwords-all.yaml"     --passwords sample/config/passwords-all.yaml
-run_variant "passwords-uganda.yaml"  --passwords sample/config/passwords-uganda.yaml
-run_variant "passwords-keyonly.yaml" --passwords sample/config/passwords-keyonly.yaml
-run_variant "custom-css"             --css sample/config/custom-example.css
-run_variant "album-nav"              --customization sample/config/customization-album-nav.yaml
+# passwords-uganda runs last of the five sharing "sample". It is the only one of them
+# whose media set differs (HMAC'd Uganda rather than plain), so running it anywhere else
+# in the order would have -clean delete Uganda's WebPs and the next variant regenerate
+# them, paying that twice instead of once.
+run_variant "no passwords"           --site-id sample
+run_variant "passwords-all.yaml"     --site-id sample-pw-all --passwords sample/config/passwords-all.yaml
+run_variant "passwords-keyonly.yaml" --site-id sample        --passwords sample/config/passwords-keyonly.yaml
+run_variant "custom-css"             --site-id sample        --css sample/config/custom-example.css
+run_variant "album-nav"              --site-id sample        --customization sample/config/customization-album-nav.yaml
+run_variant "passwords-uganda.yaml"  --site-id sample        --passwords sample/config/passwords-uganda.yaml
 
 echo ""
 echo "All variants passed."

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -11,7 +11,7 @@ as defined in `config/defaults.env`.
 |-------------------------------|-----------------------------------------------------------------------------------------------|
 | `help`                        | Show all available make targets (default when running `make`)                                 |
 | `build`                       | Compile all Go binaries                                                                       |
-| `test`                        | Run Go unit tests (with the race detector)                                                    |
+| `test`                        | Run Go unit tests (with the race detector; `RACE=` to disable, as CI does on PRs)             |
 | `mod-tidy`                    | Run `go mod tidy` to clean up imports                                                         |
 | `clean-cache`                 | Run `go clean -cache` (useful after a vips library upgrade)                                   |
 | `vet`                         | Run `go vet` static analysis                                                                  |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -137,17 +137,17 @@ make web-playwright-test-dev
 
 Tests are in `web/tests/` and cover:
 
-| File                  | What it tests                                                                                                              |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------|
-| `smoke.spec.ts`       | Home page album listing, album page metadata, grid renders, Open Graph tags                                                |
-| `captions.spec.ts`    | Lightbox caption rendering: grid click, permalink direct load, prev/next nav                                               |
-| `url.spec.ts`         | URL updates on photo open/navigate/close; permalink URL preserved on load                                                  |
-| `navigation.spec.ts`  | Cross-album client-side navigation shows correct photos, title, description                                                |
-| `back-nav.spec.ts`    | Browser back button behavior: closes lightbox, restores URL, handles reload                                                |
-| `back-to-top.spec.ts` | Back-to-top button visibility and scroll behavior                                                                          |
-| `privacy.spec.ts`     | Privacy page content, back link, scroll restoration on return to home                                                      |
-| `password.spec.ts`    | Site/album prompts, wrong/correct passwords, remember on reload, hints, logout button, `?clear`                            |
-| `css.spec.ts`         | Custom CSS `<link>` injection, `--text-color-2nd` override, album card border-radius                                       |
+| File                  | What it tests                                                                                                                                                   |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `smoke.spec.ts`       | Home page album listing, album page metadata, grid renders, Open Graph tags                                                                                     |
+| `captions.spec.ts`    | Lightbox caption rendering: grid click, permalink direct load, prev/next nav                                                                                    |
+| `url.spec.ts`         | URL updates on photo open/navigate/close; permalink URL preserved on load                                                                                       |
+| `navigation.spec.ts`  | Cross-album client-side navigation shows correct photos, title, description                                                                                     |
+| `back-nav.spec.ts`    | Browser back button behavior: closes lightbox, restores URL, handles reload                                                                                     |
+| `back-to-top.spec.ts` | Back-to-top button visibility and scroll behavior                                                                                                               |
+| `privacy.spec.ts`     | Privacy page content, back link, scroll restoration on return to home                                                                                           |
+| `password.spec.ts`    | Site/album prompts, wrong/correct passwords, remember on reload, hints, logout button, `?clear`                                                                 |
+| `css.spec.ts`         | Custom CSS `<link>` injection, `--text-color-2nd` override, album card border-radius                                                                            |
 | `video.spec.ts`       | Play badge, lightbox `<video>`, space to play/pause, pause on swipe/close, caption hidden while playing, MP4 MIME + ranges, photo/video counts in the meta line |
 
 Navigation tests are fully dynamic - they read album names from the page at runtime and
@@ -164,21 +164,21 @@ Playwright directly (e.g. via `deploy-photos.sh`).
 Password and CSS tests are gated by environment variables so they only run against
 the appropriate site variant:
 
-| Variable                       | Set by               | Effect                                         |
-|--------------------------------|----------------------|------------------------------------------------|
-| `PLAYWRIGHT_PASSWORDS_FILE`    | `bin/run-tests.sh`   | Path to passwords file; enables password tests |
-| `PLAYWRIGHT_CUSTOM_CSS`        | `bin/run-tests.sh`   | Set to `true`; enables CSS tests               |
+| Variable                    | Set by                          | Effect                                         |
+|-----------------------------|---------------------------------|------------------------------------------------|
+| `PLAYWRIGHT_PASSWORDS_FILE` | `bin/run-tests.sh`              | Path to passwords file; enables password tests |
+| `PLAYWRIGHT_CUSTOM_CSS`     | `bin/run-tests.sh`              | Set to `true`; enables CSS tests               |
+| `PLAYWRIGHT_SKIP_VIDEO`     | `bin/run-tests.sh --skip-video` | Skips `video.spec.ts`; see below               |
 
 Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants automatically.
-`bin/test-all.sh` runs six variants: no passwords, `passwords-all.yaml`,
-`passwords-keyonly.yaml` (a passwords file that declares no effective password, so nothing is
-encrypted), `custom-css` (with `sample/config/custom-example.css` injected), `album-nav` (with
-`sample/config/customization-album-nav.yaml`, which replaces each album page's "← Albums" link),
-and `passwords-uganda.yaml`.
+`bin/test-all.sh` runs four variants: no passwords, `passwords-all.yaml`, `config-extras`
+(`passwords-keyonly.yaml`, which declares no effective password, plus
+`sample/config/custom-example.css` and `sample/config/customization-album-nav.yaml`), and
+`passwords-uganda.yaml`.
 
 #### Shared site IDs
 
-Five of those six variants generate into the same albums directory, `albums/sample`. Only
+Three of those four variants generate into the same albums directory, `albums/sample`. Only
 `passwords-all.yaml` gets its own (`albums/sample-pw-all`). This is the single biggest saving
 in CI: a directory that already holds every WebP and MP4 leaves photogen with nothing to
 resize and no video to transcode, so a variant costs a few seconds instead of ~40, and the
@@ -192,9 +192,7 @@ identically named, byte-identical media.
 | Variant                  | the-way | uganda | antarctica | Site ID         |
 |--------------------------|---------|--------|------------|-----------------|
 | no passwords             | plain   | plain  | plain      | `sample`        |
-| `passwords-keyonly.yaml` | plain   | plain  | plain      | `sample`        |
-| `custom-css`             | plain   | plain  | plain      | `sample`        |
-| `album-nav`              | plain   | plain  | plain      | `sample`        |
+| `config-extras`          | plain   | plain  | plain      | `sample`        |
 | `passwords-uganda.yaml`  | plain   | HMAC   | plain      | `sample`        |
 | `passwords-all.yaml`     | HMAC    | HMAC   | HMAC       | `sample-pw-all` |
 
@@ -215,17 +213,70 @@ A direct `bin/run-tests.sh` invocation still derives a self-describing site ID
 (`sample-css`, `sample-pw-uganda`, and so on), which is more useful when inspecting the
 output of one variant. Pass `--site-id` to override it.
 
+#### Why `config-extras` is one variant and not three
+
+`passwords-keyonly`, `custom-css` and `album-nav` used to be three separate runs. Diffing
+their generated sites against the plain one shows why they no longer are. Each differs from
+plain by a single `config.json` field and nothing else, while the two encrypted variants are
+genuinely different sites:
+
+| Variant             | Entries differing from the plain site                      |
+|---------------------|------------------------------------------------------------|
+| `passwords-keyonly` | 1: `config.json` gains `"keyId"`                           |
+| `custom-css`        | 2: `config.json` gains `"customCss"`, plus `custom.css`    |
+| `album-nav`         | 1: `config.json` gains `"albumNav"`                        |
+| `passwords-uganda`  | 89: Uganda HMAC'd, no `cover.jpg`, `albums.json` differs   |
+| `passwords-all`     | 278: all three albums HMAC'd, `albums.enc.json`, no covers |
+
+The three fields are orthogonal, so one run with all three set covers what the three runs
+did. Measured: the union of the three was 69 tests, the combined run is 67, and the only two
+it drops are the negative assertions ("CSS link is NOT present when not configured",
+"default back link when `album_nav` is not configured"), which still run in every other
+variant. What it gives up is "css alone" and "album-nav alone": plain covers
+neither-configured and `config-extras` covers both-configured, so only the exactly-one
+combinations are untested. Split it back out if that ever matters.
+
+#### Skipping `video.spec.ts` where it is redundant
+
+`video.spec.ts` is the most expensive spec in the suite (~14-17s of a ~34s run). A
+transcoded MP4 depends only on its source and the encode settings: encryption changes the
+output *filename*, never the bytes, and CSS and customization touch neither. So every
+unencrypted variant publishes byte-identical video.
+
+`bin/test-all.sh` therefore passes `--skip-video` (which sets `PLAYWRIGHT_SKIP_VIDEO`) on
+`config-extras` and `passwords-uganda`, leaving the no-passwords variant to cover it.
+`passwords-all` skips the spec on its own, because a fully locked site publishes no
+discoverable video. Unset is the default, so a direct `npx playwright test` still runs
+everything.
+
+#### The `@deploy` tag
+
+`bin/rsync-test.sh` used to re-run all 87 tests against the deployed container, ~38s to
+prove nothing the other variants had not already proven. It now passes
+`--playwright-smoke` to `bin/deploy-photos.sh`, which narrows both Playwright runs to
+`--grep @deploy`: the tests that fail when the *deployed tree* is wrong rather than when the
+app is, covering what `bin/test-photos-server.sh` cannot, since that only curls for status
+codes.
+
+The tag is off by default. A real deploy still runs the whole suite against the live site.
+
+One of the tagged tests is new. `album page renders photos in the grid` renders from
+`index.json` alone, so a tile is visible whether its WebP exists, which meant no test
+in the suite failed when album media was missing. `album page grid images actually load`
+polls `naturalWidth`, and is the one assertion that does. Verified by deleting every
+Antarctica grid WebP from a served site: the old test still passed, the new one failed.
+
 ```bash
-# Run all 6 variants against dev + Apache + nginx (default; recommended locally)
+# Run all 4 variants against dev + Apache + nginx (default; recommended locally)
 bin/test-all.sh
 
-# Run all 6 variants against Apache only (mirrors CI)
+# Run all 4 variants against Apache only (mirrors CI)
 bin/test-all.sh --mode apache
 
-# Run all 6 variants against nginx only
+# Run all 4 variants against nginx only
 bin/test-all.sh --mode nginx
 
-# Run all 6 variants against dev server, Apache, and nginx
+# Run all 4 variants against dev server, Apache, and nginx
 bin/test-all.sh --mode all
 
 # Run a single variant against Apache (no password)
@@ -250,7 +301,7 @@ bin/run-tests.sh --mode dev --test tests/privacy.spec.ts
 ### Sanity Check
 
 A good sanity check runs the unit tests, then verifies against Apache (which requires a
-build), testing both password and no-password sites.  It's quicker than running all 5
+build), testing both password and no-password sites.  It's quicker than running all 4
 variants against dev, Apache and nginx:
 
 ```bash

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -170,10 +170,50 @@ the appropriate site variant:
 | `PLAYWRIGHT_CUSTOM_CSS`        | `bin/run-tests.sh`   | Set to `true`; enables CSS tests               |
 
 Use `bin/run-tests.sh` or `bin/test-all.sh` to run tests across all variants automatically.
-`bin/test-all.sh` runs six variants: no passwords, `passwords-all.yaml`, `passwords-uganda.yaml`,
+`bin/test-all.sh` runs six variants: no passwords, `passwords-all.yaml`,
 `passwords-keyonly.yaml` (a passwords file that declares no effective password, so nothing is
-encrypted), `custom-css` (with `sample/config/custom-example.css` injected), and `album-nav` (with
-`sample/config/customization-album-nav.yaml`, which replaces each album page's "← Albums" link).
+encrypted), `custom-css` (with `sample/config/custom-example.css` injected), `album-nav` (with
+`sample/config/customization-album-nav.yaml`, which replaces each album page's "← Albums" link),
+and `passwords-uganda.yaml`.
+
+#### Shared site IDs
+
+Five of those six variants generate into the same albums directory, `albums/sample`. Only
+`passwords-all.yaml` gets its own (`albums/sample-pw-all`). This is the single biggest saving
+in CI: a directory that already holds every WebP and MP4 leaves photogen with nothing to
+resize and no video to transcode, so a variant costs a few seconds instead of ~40, and the
+sample videos are transcoded twice per CI job instead of six times.
+
+It works because media bytes do not depend on encryption, CSS or customization. What
+encryption changes is output *filenames*: `Config.PhotoOutputName` HMACs the name only for
+albums that actually have a password, so variants encrypting the same set of albums produce
+identically named, byte-identical media.
+
+| Variant                  | the-way | uganda | antarctica | Site ID         |
+|--------------------------|---------|--------|------------|-----------------|
+| no passwords             | plain   | plain  | plain      | `sample`        |
+| `passwords-keyonly.yaml` | plain   | plain  | plain      | `sample`        |
+| `custom-css`             | plain   | plain  | plain      | `sample`        |
+| `album-nav`              | plain   | plain  | plain      | `sample`        |
+| `passwords-uganda.yaml`  | plain   | HMAC   | plain      | `sample`        |
+| `passwords-all.yaml`     | HMAC    | HMAC   | HMAC       | `sample-pw-all` |
+
+Sharing stays correct because photogen runs with `-clean` on every variant, which normalizes
+the directory to that variant: everything it writes is registered with `TrackFile`, and
+`CleanOutputDir` deletes whatever the previous variant left behind, top-level files
+(`custom.css`, `albums.enc.json`) included. Two consequences worth knowing:
+
+- **The static build is rebuilt for every variant.** `handleFetch` in `web/src/hooks.server.ts`
+  reads `/albums/*.json` off disk during pre-rendering and bakes it into the HTML, so
+  `build/sample` belongs to one variant even though the site ID is shared.
+- **`bin/test-all.sh` leaves `albums/sample` and `build/sample` holding the last variant it
+  ran.** Anything that assumes the plain sample site, such as `make sample-rsync-test` and
+  `make sample-s3-test`, has to run before it. `.github/workflows/ci.yml` orders its steps
+  that way. Run `make sample-photogen sample-build` to get back to the plain site.
+
+A direct `bin/run-tests.sh` invocation still derives a self-describing site ID
+(`sample-css`, `sample-pw-uganda`, and so on), which is more useful when inspecting the
+output of one variant. Pass `--site-id` to override it.
 
 ```bash
 # Run all 6 variants against dev + Apache + nginx (default; recommended locally)
@@ -290,6 +330,18 @@ first person to find out is whoever opens the next PR. When a nightly run fails,
 `report-nightly-failure` job opens a GitHub issue labeled `nightly-ci` (or comments on the open one)
 via [bin/ci-open-issue.sh](../bin/ci-open-issue.sh), because nobody is watching an overnight run and the
 notification email is easy to miss. Push and pull request runs skip that job.
+
+That split is also why two things are deliberately slower on the nightly than on a PR:
+
+- **The ffmpeg and Playwright browser caches are not restored on `schedule` or
+  `workflow_dispatch`.** Catching drift in the floating ffmpeg `latest` release and in
+  Playwright's browser downloads is a stated reason the nightly exists, and a cache hit
+  would hide exactly that. On a push or pull request the download is a pure cost, so it is
+  cached there.
+- **The Go race detector runs on the nightly only.** `-race` is ~67s of the ~102s that
+  `make build test-cover vet` takes on a runner. The workflow passes `RACE=` on push and
+  pull request and leaves the Makefile default on the schedule, so a race introduced in a
+  PR surfaces that night as a `nightly-ci` issue rather than on the PR itself.
 
 The workflow in [.github/workflows/version-drift.yml](../.github/workflows/version-drift.yml) runs
 [bin/check-versions.sh](../bin/check-versions.sh) nightly at 05:37 UTC and opens a `version-drift` issue when the

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -11,14 +11,18 @@ test.beforeAll(async ({ request }) => {
 	hasAntarctica = await albumExists(request, 'antarctica');
 });
 
-test('home page lists albums including known overlap albums', async ({ page }) => {
-	test.skip(!hasAntarctica, 'antarctica album not present');
-	await page.goto('/');
-	await unlockSiteIfNeeded(page, pw);
-	// Spot-check albums present in both sample and prod
-	await expect(page.locator('.album-card', { hasText: 'Antarctica' })).toBeVisible();
-	await expect(page.locator('.album-card', { hasText: 'Uganda' })).toBeVisible();
-});
+test(
+	'home page lists albums including known overlap albums',
+	{ tag: '@deploy' },
+	async ({ page }) => {
+		test.skip(!hasAntarctica, 'antarctica album not present');
+		await page.goto('/');
+		await unlockSiteIfNeeded(page, pw);
+		// Spot-check albums present in both sample and prod
+		await expect(page.locator('.album-card', { hasText: 'Antarctica' })).toBeVisible();
+		await expect(page.locator('.album-card', { hasText: 'Uganda' })).toBeVisible();
+	}
+);
 
 test('home page album cards show description', async ({ page }) => {
 	test.skip(!hasAntarctica, 'antarctica album not present');
@@ -37,12 +41,32 @@ test('album page shows title, description, and photo count', async ({ page }) =>
 	await expect(page.locator('.meta')).toContainText(/\d+ photos/);
 });
 
-test('album page renders photos in the grid', async ({ page }) => {
+test('album page renders photos in the grid', { tag: '@deploy' }, async ({ page }) => {
 	test.skip(!hasAntarctica, 'antarctica album not present');
 	await page.goto('/albums/antarctica');
 	await unlockAlbumIfNeeded(page, 'antarctica', pw);
 	// At least one photo button should be present
 	await expect(page.locator('.photo').first()).toBeVisible();
+});
+
+// The test above proves the grid renders, but it renders from index.json alone: a tile is
+// visible whether its WebP exists. That distinction does not matter much in dev,
+// where the images sit next to the JSON, but it is exactly what a deploy gets wrong, since
+// bin/deploy-photos.sh syncs album media and album metadata in separate passes. Decoding
+// the image is the only assertion in the suite that fails when the bytes are missing, which
+// is why this carries @deploy.
+test('album page grid images actually load', { tag: '@deploy' }, async ({ page }) => {
+	test.skip(!hasAntarctica, 'antarctica album not present');
+	await page.goto('/albums/antarctica');
+	await unlockAlbumIfNeeded(page, 'antarctica', pw);
+
+	const img = page.locator('.photo img').first();
+	await expect(img).toBeVisible();
+	// naturalWidth stays 0 for an <img> whose src 404s or decodes as something other than
+	// an image, so this catches a missing or corrupt WebP that toBeVisible() does not.
+	await expect
+		.poll(() => img.evaluate((el: HTMLImageElement) => el.naturalWidth), { timeout: 10_000 })
+		.toBeGreaterThan(0);
 });
 
 test('album page has correct Open Graph tags', async ({ page }) => {
@@ -90,18 +114,22 @@ test('?boom on home page shows 500 error card', async ({ page }) => {
 	await expect(page.locator('.card-title')).toContainText('500 Error');
 });
 
-test('home page has Open Graph image tag pointing to a JPEG', async ({ page }) => {
-	// In the pw-all variant every album is encrypted, so the home page derives no OG
-	// cover image (it only uses non-encrypted albums). Skip rather than expect a tag
-	// that won't be present by design.
-	test.skip(!!pw.all, 'pw-all: all albums encrypted, no home OG image available');
+test(
+	'home page has Open Graph image tag pointing to a JPEG',
+	{ tag: '@deploy' },
+	async ({ page }) => {
+		// In the pw-all variant every album is encrypted, so the home page derives no OG
+		// cover image (it only uses non-encrypted albums). Skip rather than expect a tag
+		// that won't be present by design.
+		test.skip(!!pw.all, 'pw-all: all albums encrypted, no home OG image available');
 
-	await page.goto('/');
-	await unlockSiteIfNeeded(page, pw);
-	// Must be a JPEG for iMessage / crawler compatibility — not WebP.
-	// May be hero.jpg (when a hero is configured) or an album cover.jpg.
-	await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /\.jpg$/);
-});
+		await page.goto('/');
+		await unlockSiteIfNeeded(page, pw);
+		// Must be a JPEG for iMessage / crawler compatibility — not WebP.
+		// May be hero.jpg (when a hero is configured) or an album cover.jpg.
+		await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /\.jpg$/);
+	}
+);
 
 test('lightbox top bar has a shade behind its controls', async ({ page }) => {
 	test.skip(!hasAntarctica, 'antarctica album not present');

--- a/web/tests/video.spec.ts
+++ b/web/tests/video.spec.ts
@@ -10,10 +10,28 @@ import {
 
 const pw = loadPasswords();
 
+// This is the most expensive spec in the suite (~14-17s of a ~34s run), and a transcoded
+// MP4 depends only on its source and the encode settings. Encryption changes the output
+// *filename*, never the bytes, and CSS and customization touch neither. So every
+// unencrypted variant of the sample site publishes byte-identical video, and running this
+// spec against each of them re-tests the same files.
+//
+// bin/test-all.sh therefore sets PLAYWRIGHT_SKIP_VIDEO on the variants whose MP4s are
+// already covered by the no-passwords variant, via bin/run-tests.sh --skip-video. Unset
+// (the default) runs everything, so a direct `npx playwright test` is unaffected.
+//
+// Skipped in beforeEach rather than by leaving `video` null, so the reported reason says
+// what actually happened instead of claiming the site publishes no video.
+const skipVideo = !!process.env.PLAYWRIGHT_SKIP_VIDEO;
+test.beforeEach(() => {
+	test.skip(skipVideo, 'PLAYWRIGHT_SKIP_VIDEO: these MP4s are covered by another variant');
+});
+
 // Discovered once: video tests run against whatever the site actually publishes rather
 // than a hardcoded album, matching how the rest of the suite handles optional content.
 let video: FoundVideo | null = null;
 test.beforeAll(async ({ request }) => {
+	if (skipVideo) return;
 	video = await findVideo(request);
 });
 
@@ -40,23 +58,27 @@ function currentVideo(page: import('@playwright/test').Page) {
 	return currentSlide(page).locator('.pswp-video');
 }
 
-test('the mp4 is served with a video content type and byte ranges', async ({ request }) => {
-	test.skip(!video, 'no video published on this site');
-	const v = video!;
+test(
+	'the mp4 is served with a video content type and byte ranges',
+	{ tag: '@deploy' },
+	async ({ request }) => {
+		test.skip(!video, 'no video published on this site');
+		const v = video!;
 
-	// Both matter and neither is automatic in dev: without a video/* content type the
-	// browser will not treat the response as media, and without range support seeking
-	// does nothing and Safari refuses to play the file at all.
-	const full = await request.get(v.videoUrl);
-	expect(full.ok()).toBe(true);
-	expect(full.headers()['content-type']).toBe('video/mp4');
-	expect(full.headers()['accept-ranges']).toBe('bytes');
+		// Both matter and neither is automatic in dev: without a video/* content type the
+		// browser will not treat the response as media, and without range support seeking
+		// does nothing and Safari refuses to play the file at all.
+		const full = await request.get(v.videoUrl);
+		expect(full.ok()).toBe(true);
+		expect(full.headers()['content-type']).toBe('video/mp4');
+		expect(full.headers()['accept-ranges']).toBe('bytes');
 
-	const ranged = await request.get(v.videoUrl, { headers: { Range: 'bytes=0-99' } });
-	expect(ranged.status()).toBe(206);
-	expect(ranged.headers()['content-range']).toMatch(/^bytes 0-99\/\d+$/);
-	expect((await ranged.body()).length).toBe(100);
-});
+		const ranged = await request.get(v.videoUrl, { headers: { Range: 'bytes=0-99' } });
+		expect(ranged.status()).toBe(206);
+		expect(ranged.headers()['content-range']).toMatch(/^bytes 0-99\/\d+$/);
+		expect((await ranged.body()).length).toBe(100);
+	}
+);
 
 test('the transcoded mp4 starts with its moov atom so playback can begin early', async ({
 	request


### PR DESCRIPTION
Cuts the CI critical path, mostly by removing four of the five redundant photogen runs each
job does, plus a few smaller wins.

Measured starting point (run 33266953029): the `test` job at 12m08, of which the Apache
e2e step was 431s (59%). Inside that step, five full photogen runs at ~41s apiece accounted
for ~205s.

## Share site IDs across the e2e variants

Media bytes never depend on encryption, CSS or customization. What encryption changes is
output *filenames*: `Config.PhotoOutputName` HMACs the name only for albums that actually
have a password. So variants encrypting the same set of albums produce identically named,
byte-identical media and can share one albums directory.

| Variant | the-way | uganda | antarctica | Site ID |
| --- | --- | --- | --- | --- |
| no passwords | plain | plain | plain | `sample` |
| `passwords-keyonly.yaml` | plain | plain | plain | `sample` |
| `custom-css` | plain | plain | plain | `sample` |
| `album-nav` | plain | plain | plain | `sample` |
| `passwords-uganda.yaml` | plain | HMAC | plain | `sample` |
| `passwords-all.yaml` | HMAC | HMAC | HMAC | `sample-pw-all` |

Five of the six now share `albums/sample`, so photogen finds every WebP and MP4 already
present and only rewrites the JSON. `passwords-all` keeps its own directory, because a
site-wide password HMACs every album and none of the plain media is reusable.

Sharing stays correct because `-clean` normalizes the directory to the current variant on
every run: everything photogen writes is registered via `TrackFile`, and `CleanOutputDir`
deletes whatever the previous variant left behind, top-level files (`custom.css`,
`albums.enc.json`) included.

`passwords-uganda` runs last of the five sharing `sample`. It is the only one of them whose
media set differs, so running it earlier would have `-clean` drop Uganda's WebPs and the
next variant regenerate them, paying that twice instead of once.

Side effect worth noting: ffmpeg transcodes drop from 6 per job to 2.

(Round 2 below collapses the `passwords-keyonly`, `custom-css` and `album-nav` rows of that
table into a single `config-extras` variant, leaving four. The site-ID rule is unchanged.)

## Remove `--ci`

Both of its skips had to go, and it existed only to dodge the cost removed above:

- Skipping photogen would leave the previous variant's `config.json`, `albums.json` and
  `custom.css` in place, quietly testing the wrong site.
- Skipping the npm build would serve stale HTML. `handleFetch` in
  `web/src/hooks.server.ts` reads `/albums/*.json` off disk during pre-rendering and bakes
  it in, so the static build belongs to one variant even when the site ID is shared.

`bin/run-tests.sh` gains `--site-id` to override the derived ID, which `bin/test-all.sh`
supplies per variant. A direct invocation still derives a self-describing one
(`sample-css`, `sample-pw-uganda`), which is more useful when inspecting one variant.

## Move the deploy tests ahead of the e2e step

`bin/test-all.sh` now rewrites `albums/sample` and `build/sample` as it goes, and
`bin/s3-test.sh` hardcodes `SITE_ID=sample` and asserts on plaintext album JSON. The rsync
and S3 steps now run right after the routing tests, against exactly what `Photogen and
build` produced.

## Cache ffmpeg and the Playwright browsers

`actions/cache` on `$RUNNER_TEMP/ffmpeg` and `~/.cache/ms-playwright`, restored on `push`
and `pull_request` only. Catching drift in the floating ffmpeg `latest` release and in
Playwright's browser downloads is a stated reason the nightly run exists, and a cache hit
would hide exactly that.

## Race detector on the nightly only

`RACE ?= -race` in the Makefile, used by both `test` and `test-cover`, so `make test`
locally is unchanged. `ci.yml` clears it on `push` and `pull_request` and leaves the
default on the schedule. `-race` is ~67s of the Go step's ~102s. The trade-off is that a
race introduced in a PR surfaces that night as a `nightly-ci` issue rather than on the PR.

## Verification (at the end of round 1)

- `bin/test-all.sh` (6 variants against dev, Apache and nginx): 18/18 runs, 0 failures
- `bin/test-all.sh --mode apache` (mirrors CI): 6/6 variants
- `make sample-rsync-test` and `make sample-s3-test` against a pristine `sample` site,
  matching the new step order
- `make build test vet`, `make web-lint`, `make web-unit-test`

A repeat photogen into a populated site directory takes 0.55s and reports
`0 items, 0 videos` on all three albums. Switching variants within `albums/sample` emits
the expected `removed:` lines, and the `passwords-uganda` variant swaps Uganda's 43 plain
WebPs for 42 HMAC'd ones in 2.1s while leaving `the-way/video/ocean.mp4` untouched.

---

# Round 2: the Playwright runs

The e2e step was still six serial Playwright passes. Two mechanical checks identified what
was redundant: diffing the generated sites (identical bytes cannot test different behavior)
and building a per-test matrix from the CI log to find tests unique to a single run.

Both said the same thing. Of 87 distinct tests, 35 ran in all seven passes and another 24 in
six of seven, while the variant-specific specs (password, css, album-nav) cost 17.9s across
every run combined. The cost was the generic suite repeating, not the variant coverage.

## Collapse three variants into `config-extras`

`passwords-keyonly`, `custom-css` and `album-nav` each differ from the plain site by a
single `config.json` field and nothing else:

| Variant | Entries differing from the plain site |
| --- | --- |
| `passwords-keyonly` | 1: `config.json` gains `"keyId"` |
| `custom-css` | 2: `config.json` gains `"customCss"`, plus `custom.css` |
| `album-nav` | 1: `config.json` gains `"albumNav"` |
| `passwords-uganda` | 89: Uganda HMAC'd, no `cover.jpg`, `albums.json` differs |
| `passwords-all` | 278: all three albums HMAC'd, `albums.enc.json`, no covers |

Every WebP, MP4 and `index.json` is identical in the first three, and `passwords-keyonly`
had **zero** tests unique to it. The three fields are orthogonal, so one run with all three
set replaces the three runs. `bin/run-tests.sh` already composed the flags, so this needed
no new plumbing. Six variants became four.

What it gives up: "css alone" and "album-nav alone" are no longer exercised. Plain covers
neither-configured and `config-extras` covers both-configured, so only the exactly-one
combinations go untested.

## `--skip-video`

`video.spec.ts` was 92.4s of the 250s of test time, running six times against MP4s the site
diff proves identical in five of them. A transcoded MP4 depends only on its source and the
encode settings: encryption changes the output *filename*, never the bytes.

`bin/run-tests.sh --skip-video` sets `PLAYWRIGHT_SKIP_VIDEO`, following the existing
`PLAYWRIGHT_PASSWORDS_FILE` / `PLAYWRIGHT_CUSTOM_CSS` pattern. `bin/test-all.sh` sets it on
`config-extras` and `passwords-uganda`; `passwords-all` already skipped the spec on its own,
since a locked site publishes no discoverable video. Unset by default, so a direct
`npx playwright test` is unaffected. The skip happens in `beforeEach` rather than by leaving
`video` null, so the reported reason says what actually happened.

## `@deploy` tag for the deploy test

There were seven Playwright runs, not six: `bin/deploy-photos.sh` re-ran all 87 tests
post-deploy, with zero unique coverage, and `bin/rsync-test.sh` paid 38s for it.

`deploy-photos.sh` gains `--playwright-smoke`, which narrows both its Playwright runs to
`--grep @deploy`: the tests that fail when the *deployed tree* is wrong rather than when the
app is, covering what `bin/test-photos-server.sh` cannot since it only curls for status
codes. Off by default, because a real deploy should keep verifying the live site in full.
Only `bin/rsync-test.sh` passes it.

## A coverage gap found while choosing that subset

No test in the suite asserted that an image actually loads. `album page renders photos in
the grid` renders from `index.json`, so a tile is visible whether or not its WebP exists,
which means a deploy that shipped album metadata but no media passed all 87 tests.

`album page grid images actually load` polls `naturalWidth` and closes that. Verified by
deleting every Antarctica grid WebP from a served site:

```
✓ album page renders photos in the grid @deploy      <- old test still passed
✘ album page grid images actually load @deploy       <- only this caught it
```

This is a coverage gain for the full suite, not only for the subset.

## Results

| Check | Before | After |
| --- | --- | --- |
| `bin/test-all.sh --mode apache` | 262s | 145s |
| `bin/test-all.sh` (dev + Apache + nginx) | 672s, 18 runs | 367s, 12 runs |
| `make sample-rsync-test` | 51s in CI | 21s local; its Playwright pass 26s to 2.0s |
| `make web-sanity-test` | | 83s, green |
| `make sample-s3-test` | | 23 PASS, 0 FAIL |

Coverage diff, old six variants against new four:

```
union OLD = 87   union NEW = 88
Ran somewhere before, runs NOWHERE now:  0
New coverage: 1  (album page grid images actually load)
```

Every one of the 87 tests still runs somewhere. 12/12 runs green, `make web-lint` clean.

---

# Measured in CI

Baseline is run 33266953029 (before this PR), round 1 is run 33270510082, round 2 is run
33272526011. All three jobs green in each.

| Job | Baseline | Round 1 | Round 2 |
| --- | --- | --- | --- |
| `test` (critical path) | 12m08 | 8m34 | **6m20** |
| `test-nginx-s3` | 10m40 | 6m36 | **5m31** |
| `test-docker` | 4m46 | 4m12 | 4m47 |
| **Run total** | **12m12** | 8m37 | **6m24** |

47% off the wall clock. `test-docker` is untouched by this PR; its movement is variance on
the uncached Docker build, and at 4m47 it is now within striking distance of being the
job that sets the floor.

Step by step inside `test`:

| Step | Baseline | Round 1 | Round 2 |
| --- | --- | --- | --- |
| Apache e2e (all variants) | 431s | 266s | **159s** |
| Go build, test, vet | 102s | 54s | 50s |
| rsync deploy test | 45s | 51s | **21s** |
| Photogen and build | 52s | 51s | 50s |
| Install ffmpeg | 10s | 9s | **0s** (cache hit) |
| Install Playwright Chromium | 11s | 10s | **0s** (cache hit) |

Per variant in the e2e step: no passwords 28.3s, `passwords-all` 16.9s, `config-extras`
14.2s, `passwords-uganda` 14.4s. Six variants at 266s became four at 159s.

Mechanisms confirmed firing in the round 2 run rather than assumed:

- ffmpeg transcodes: exactly 2 (`albums/sample` and `albums/sample-pw-all`), down from 6.
- `--skip-video`: skip counts rise to 39 on `config-extras` and 34 on `passwords-uganda`,
  against 25 on the no-passwords variant that still runs the spec.
- `@deploy`: the deploy step logs `Running Playwright e2e tests (@deploy subset)` and runs
  5 tests in 2.1s in place of 87.

Two caveats on reading the round 2 column:

- The ffmpeg and Playwright caches hit for the first time in that run, but the restore steps
  cost 3s and 4s themselves, so the net saving is about 12s rather than the 19s the two
  zeroed rows imply.
- `Install system dependencies` took 37s in round 2 against 21s in round 1. That is the
  Azure apt mirror `bin/ci-apt-install.sh` exists to survive, and it added ~16s of noise, so
  the round 2 improvement is slightly better than the totals show.
